### PR TITLE
Modal Component

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: node_js
 
 node_js:
-  - 4
-  - 5
+  - stable
+
+cache:
+  directories:
+    - node_modules
 
 addons:
   firefox: "latest"

--- a/example/js/Layout.jsx
+++ b/example/js/Layout.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ButtonsExample from './ButtonsExample';
 import DropdownsExample from './DropdownsExample';
+import ModalExample from './ModalExample';
 import TetherExample from './TetherExample';
 import TooltipExample from './TooltipExample';
 import LabelsExample from './LabelsExample';
@@ -19,6 +20,7 @@ class Layout extends React.Component {
             <DropdownsExample/>
             <TetherExample/>
             <TooltipExample/>
+            <ModalExample/>
             <PopoverExample/>
             <LabelsExample/>
           </div>

--- a/example/js/ModalExample.jsx
+++ b/example/js/ModalExample.jsx
@@ -1,0 +1,45 @@
+/* eslint react/no-multi-comp: 0, react/prop-types: 0 */
+
+import React from 'react';
+import { Button, Modal, ModalHeader, ModalBody, ModalFooter } from 'lib/index';
+
+class ModalExample extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      modal: false
+    };
+
+    this.toggle = this.toggle.bind(this);
+  }
+
+  toggle() {
+    this.setState({
+      modal: !this.state.modal
+    });
+  }
+
+  render() {
+    return (
+      <div>
+        <h3>Modals</h3>
+        <hr/>
+        <p>
+          <Button color="danger" onClick={this.toggle}>Launch Modal</Button>
+        </p>
+        <Modal isOpen={this.state.modal} toggle={this.toggle}>
+          <ModalHeader toggle={this.toggle}>Modal title</ModalHeader>
+          <ModalBody>
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+          </ModalBody>
+          <ModalFooter>
+            <Button color="primary" onClick={this.toggle}>Do Something</Button>
+            <Button color="secondary" onClick={this.toggle}>Cancel</Button>
+          </ModalFooter>
+        </Modal>
+      </div>
+    );
+  }
+}
+
+export default ModalExample;

--- a/lib/Fade.jsx
+++ b/lib/Fade.jsx
@@ -1,0 +1,59 @@
+import React, { PropTypes } from 'react';
+import classNames from 'classnames';
+
+const propTypes = {
+  className: PropTypes.string
+};
+
+const defaultProps = {};
+
+class Fade extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      fadeIn: false
+    };
+
+    this.fade = this.fade.bind(this);
+    this.fadeIn = this.fadeIn.bind(this);
+    this.fadeOut = this.fadeOut.bind(this);
+  }
+
+  fade(fade, cb, delay) {
+    this.setState({
+      fadeIn: fade
+    });
+
+    if (cb) {
+      setTimeout(cb, delay);
+    }
+  }
+
+  fadeIn(cb, delay) {
+    this.fade(true, cb, delay);
+  }
+
+  fadeOut(cb, delay) {
+    this.fade(false, cb, delay);
+  }
+
+  render() {
+    const classes = classNames(
+      this.props.className,
+      'fade',
+      {
+        in: this.state.fadeIn
+      }
+    );
+
+    return (
+      <div {...this.props} className={classes} />
+    );
+  }
+}
+
+Fade.propTypes = propTypes;
+Fade.defaultProps = defaultProps;
+
+export default Fade;

--- a/lib/Modal.jsx
+++ b/lib/Modal.jsx
@@ -1,0 +1,158 @@
+import React, { PropTypes } from 'react';
+import ReactDOM from 'react-dom';
+import classNames from 'classnames';
+import Fade from './Fade';
+
+const propTypes = {
+  isOpen: PropTypes.bool,
+  size: PropTypes.string,
+  toggle: PropTypes.func.isRequired,
+  onEnter: PropTypes.func,
+  onExit: PropTypes.func
+};
+
+const defaultProps = {
+  isOpen: false
+};
+
+class Modal extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.handleProps = this.handleProps.bind(this);
+    this.handleBackdropClick = this.handleBackdropClick.bind(this);
+    this.handleEscape = this.handleEscape.bind(this);
+    this.destroy = this.destroy.bind(this);
+    this.onEnter = this.onEnter.bind(this);
+    this.onExit = this.onExit.bind(this);
+  }
+
+  componentDidMount() {
+    if (this.props.isOpen) {
+      this.show();
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    if (this.props.isOpen !== prevProps.isOpen) {
+      this.handleProps();
+    }
+  }
+
+  componentWillUnmount() {
+    this.hide();
+  }
+
+  onEnter() {
+    this._modal.fadeIn();
+    if (this.props.onEnter) {
+      this.props.onEnter();
+    }
+  }
+
+  onExit() {
+    this.destroy();
+    if (this.props.onExit) {
+      this.props.onExit();
+    }
+  }
+
+  handleEscape(e) {
+    if (e.keyCode === 27) {
+      this.props.toggle();
+    }
+  }
+
+  handleBackdropClick(e) {
+    const container = ReactDOM.findDOMNode(this._dialog);
+
+    if (e.target && !container.contains(e.target)) {
+      this.props.toggle();
+    }
+  }
+
+  handleProps() {
+    if (this.props.isOpen) {
+      this.show();
+    } else {
+      this.hide();
+    }
+  }
+
+  destroy() {
+    let classes = document.body.className.replace('modal-open', '');
+    this.removeEvents();
+
+    if (this._element) {
+      ReactDOM.unmountComponentAtNode(this._element);
+      document.body.removeChild(this._element);
+      this._element = null;
+    }
+
+    document.body.className = classNames(classes).trim();
+  }
+
+  removeEvents() {
+    document.removeEventListener('click', this.handleBackdropClick, false);
+    document.removeEventListener('keyup', this.handleEscape, false);
+  }
+
+  hide() {
+    this.removeEvents();
+
+    if (this._modal) {
+      this._modal.fadeOut();
+    }
+    if (this._backdrop) {
+      this._backdrop.fadeOut(this.onExit, 250);
+    }
+  }
+
+  show() {
+    const classes = document.body.className;
+    this._element = document.createElement('div');
+    this._element.setAttribute('tabindex', '-1');
+
+    document.body.appendChild(this._element);
+    document.addEventListener('click', this.handleBackdropClick, false);
+    document.addEventListener('keyup', this.handleEscape, false);
+
+    document.body.className = classNames(
+      classes,
+      'modal-open'
+    );
+
+    ReactDOM.unstable_renderSubtreeIntoContainer(
+      this,
+      this.renderChildren(),
+      this._element
+    );
+
+    this._element.focus();
+    this._backdrop.fadeIn(this.onEnter, 100);
+  }
+
+  renderChildren() {
+    return (
+      <div>
+        <Fade className="modal" style={{ display: 'block' }} tabIndex="-1" ref={(c) => this._modal = c }>
+          <div className="modal-dialog" role="document" ref={(c) => this._dialog = c }>
+            <div className="modal-content">
+              { this.props.children }
+            </div>
+          </div>
+        </Fade>
+        <Fade className="modal-backdrop" ref={(c) => this._backdrop = c }/>
+      </div>
+    );
+  }
+
+  render() {
+    return null;
+  }
+}
+
+Modal.propTypes = propTypes;
+Modal.defaultProps = defaultProps;
+
+export default Modal;

--- a/lib/ModalBody.jsx
+++ b/lib/ModalBody.jsx
@@ -1,0 +1,21 @@
+import React, { PropTypes } from 'react';
+import classNames from 'classnames';
+
+const propTypes = {
+  className: PropTypes.string
+};
+
+const ModalBody = (props) => {
+  const classes = classNames(
+    props.className,
+    'modal-body'
+  );
+
+  return (
+    <div {...props} className={classes} />
+  );
+};
+
+ModalBody.propTypes = propTypes;
+
+export default ModalBody;

--- a/lib/ModalFooter.jsx
+++ b/lib/ModalFooter.jsx
@@ -1,0 +1,21 @@
+import React, { PropTypes } from 'react';
+import classNames from 'classnames';
+
+const propTypes = {
+  className: PropTypes.string
+};
+
+const ModalFooter = (props) => {
+  const classes = classNames(
+    props.className,
+    'modal-footer'
+  );
+
+  return (
+    <div {...props} className={classes} />
+  );
+};
+
+ModalFooter.propTypes = propTypes;
+
+export default ModalFooter;

--- a/lib/ModalHeader.jsx
+++ b/lib/ModalHeader.jsx
@@ -1,0 +1,46 @@
+import React, { PropTypes } from 'react';
+import classNames from 'classnames';
+
+const propTypes = {
+  toggle: PropTypes.func
+};
+
+const defaultProps = {};
+
+class ModalHeader extends React.Component {
+  render() {
+    let closeButton;
+    const {
+      className,
+      children,
+      toggle,
+      ...props } = this.props;
+
+    const classes = classNames(
+      className,
+      'modal-header'
+    );
+
+    if (toggle) {
+      closeButton = (
+        <button type="button" onClick={toggle} className="close" dataDismiss="modal" ariaLabel="Close">
+          <span ariaHidden="true">&times;</span>
+        </button>
+      );
+    }
+
+    return (
+      <div {...props} className={classes}>
+        { closeButton }
+        <h4 className="modal-title">
+          { children }
+        </h4>
+      </div>
+    );
+  }
+}
+
+ModalHeader.propTypes = propTypes;
+ModalHeader.defaultProps = defaultProps;
+
+export default ModalHeader;

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,6 +11,10 @@ import Label from './Label';
 import Popover from './Popover';
 import PopoverTitle from './PopoverTitle';
 import PopoverContent from './PopoverContent';
+import Modal from './Modal';
+import ModalHeader from './ModalHeader';
+import ModalBody from './ModalBody';
+import ModalFooter from './ModalFooter';
 import TetherContent from './TetherContent';
 import Tooltip from './Tooltip';
 
@@ -28,6 +32,10 @@ export {
   Popover,
   PopoverContent,
   PopoverTitle,
+  Modal,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
   TetherContent,
   Tooltip
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,7 @@ import Dropdown from './Dropdown';
 import DropdownItem from './DropdownItem';
 import DropdownMenu from './DropdownMenu';
 import DropdownToggle from './DropdownToggle';
+import Fade from './Fade';
 import Label from './Label';
 import Popover from './Popover';
 import PopoverTitle from './PopoverTitle';
@@ -22,6 +23,7 @@ export {
   DropdownItem,
   DropdownMenu,
   DropdownToggle,
+  Fade,
   Label,
   Popover,
   PopoverContent,

--- a/test/Fade.spec.js
+++ b/test/Fade.spec.js
@@ -1,0 +1,64 @@
+/* eslint react/no-multi-comp: 0, react/prop-types: 0 */
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { shallow, mount } from 'enzyme';
+import { Fade } from '../lib';
+
+describe('Fade', () => {
+  it('should render with "fade" class', () => {
+    const wrapper = shallow(<Fade>Yo!</Fade>);
+
+    expect(wrapper.hasClass('fade')).toBe(true);
+    expect(wrapper.hasClass('in')).toBe(false);
+    expect(wrapper.text()).toBe('Yo!');
+  });
+
+  it('should render additional classes', () => {
+    const wrapper = shallow(<Fade className="other">Yo!</Fade>);
+
+    expect(wrapper.hasClass('other')).toBe(true);
+    expect(wrapper.hasClass('fade')).toBe(true);
+    expect(wrapper.hasClass('in')).toBe(false);
+  });
+
+  it('should toggle "in" class with fadeIn & fadeOut', () => {
+    const wrapper = mount(<Fade>Yo!</Fade>);
+    const instance = wrapper.instance();
+
+    expect(wrapper.hasClass('in')).toBe(false);
+
+    instance.fadeIn();
+    // hasClass does not pick up updates
+    // maybe related https://github.com/airbnb/enzyme/issues/134
+    expect(ReactDOM.findDOMNode(instance).className).toBe('fade in');
+
+    instance.fadeOut();
+
+    expect(ReactDOM.findDOMNode(instance).className).toBe('fade');
+  });
+
+  it('should call fadeIn & fadeOut with delayed callbacks', () => {
+    jasmine.clock().install();
+
+    const fadeInCallback = jasmine.createSpy('spy');
+    const fadeOutCallback = jasmine.createSpy('spy');
+    const wrapper = mount(<Fade>Yo!</Fade>);
+    const instance = wrapper.instance();
+
+    expect(wrapper.hasClass('in')).toBe(false);
+
+    instance.fadeIn(fadeInCallback, 250);
+    expect(fadeInCallback).not.toHaveBeenCalled();
+
+    jasmine.clock().tick(250);
+    expect(fadeInCallback).toHaveBeenCalled();
+
+    instance.fadeOut(fadeOutCallback, 250);
+    expect(fadeOutCallback).not.toHaveBeenCalled();
+
+    jasmine.clock().tick(250);
+    expect(fadeOutCallback).toHaveBeenCalled();
+
+    jasmine.clock().uninstall();
+  });
+});

--- a/test/Modal.spec.js
+++ b/test/Modal.spec.js
@@ -1,0 +1,225 @@
+/* eslint react/no-multi-comp: 0, react/prop-types: 0 */
+import React from 'react';
+import { mount } from 'enzyme';
+import { Modal } from '../lib';
+
+describe('Modal', () => {
+  let isOpen;
+  let toggle;
+
+  beforeEach(() => {
+    isOpen = false;
+    toggle = () => { isOpen = !isOpen; };
+    jasmine.clock().install();
+  });
+
+  afterEach(() => {
+    // fast forward time for modal to fade out
+    jasmine.clock().tick(300);
+    jasmine.clock().uninstall();
+  });
+
+
+  it('should render modal when isOpen is true', () => {
+    isOpen = true;
+    const wrapper = mount(
+      <Modal isOpen={isOpen} toggle={toggle}>
+        Yo!
+      </Modal>
+    );
+
+    jasmine.clock().tick(300);
+    expect(wrapper.children().length).toBe(0);
+    expect(document.getElementsByClassName('modal').length).toBe(1);
+    expect(document.getElementsByClassName('modal-backdrop').length).toBe(1);
+    wrapper.unmount();
+  });
+
+  it('should not render modal when isOpen is false', () => {
+    const wrapper = mount(
+      <Modal isOpen={isOpen} toggle={toggle}>
+        Yo!
+      </Modal>
+    );
+
+    jasmine.clock().tick(300);
+    expect(wrapper.children().length).toBe(0);
+    expect(document.getElementsByClassName('modal').length).toBe(0);
+    expect(document.getElementsByClassName('modal-backdrop').length).toBe(0);
+    wrapper.unmount();
+  });
+
+  it('should toggle modal', () => {
+    const wrapper = mount(
+      <Modal isOpen={isOpen} toggle={toggle}>
+        Yo!
+      </Modal>
+    );
+
+    jasmine.clock().tick(300);
+    expect(isOpen).toBe(false);
+    expect(document.getElementsByClassName('modal').length).toBe(0);
+    expect(document.getElementsByClassName('modal-backdrop').length).toBe(0);
+
+    toggle();
+    wrapper.setProps({
+      isOpen: isOpen
+    });
+
+    jasmine.clock().tick(300);
+    expect(isOpen).toBe(true);
+    expect(document.getElementsByClassName('modal').length).toBe(1);
+    expect(document.getElementsByClassName('modal-backdrop').length).toBe(1);
+    wrapper.unmount();
+  });
+
+  it('should call onExit & onEnter', () => {
+    spyOn(Modal.prototype, 'onEnter').and.callThrough();
+    spyOn(Modal.prototype, 'onExit').and.callThrough();
+    const onEnter = jasmine.createSpy('spy');
+    const onExit = jasmine.createSpy('spy');
+    const wrapper = mount(
+      <Modal isOpen={isOpen} onEnter={onEnter} onExit={onExit} toggle={toggle}>
+        Yo!
+      </Modal>
+    );
+
+    jasmine.clock().tick(300);
+    expect(isOpen).toBe(false);
+    expect(onEnter).not.toHaveBeenCalled();
+    expect(Modal.prototype.onEnter).not.toHaveBeenCalled();
+    expect(onExit).not.toHaveBeenCalled();
+    expect(Modal.prototype.onExit).not.toHaveBeenCalled();
+
+    toggle();
+    wrapper.setProps({
+      isOpen: isOpen
+    });
+    jasmine.clock().tick(300);
+
+    expect(isOpen).toBe(true);
+    expect(onEnter).toHaveBeenCalled();
+    expect(Modal.prototype.onEnter).toHaveBeenCalled();
+    expect(onExit).not.toHaveBeenCalled();
+    expect(Modal.prototype.onExit).not.toHaveBeenCalled();
+
+    toggle();
+    wrapper.setProps({
+      isOpen: isOpen
+    });
+    jasmine.clock().tick(300);
+
+    expect(isOpen).toBe(false);
+    expect(onExit).toHaveBeenCalled();
+    expect(Modal.prototype.onExit).toHaveBeenCalled();
+
+    wrapper.unmount();
+  });
+
+  it('should not call handleProps when isOpen does not change', () => {
+    spyOn(Modal.prototype, 'handleProps').and.callThrough();
+    spyOn(Modal.prototype, 'componentDidUpdate').and.callThrough();
+    const wrapper = mount(
+      <Modal isOpen={isOpen} toggle={toggle}>
+        Yo!
+      </Modal>
+    );
+
+    jasmine.clock().tick(300);
+    expect(isOpen).toBe(false);
+    expect(Modal.prototype.handleProps).not.toHaveBeenCalled();
+    expect(Modal.prototype.componentDidUpdate).not.toHaveBeenCalled();
+
+    wrapper.setProps({
+      isOpen: isOpen
+    });
+    jasmine.clock().tick(300);
+
+    expect(isOpen).toBe(false);
+    expect(Modal.prototype.handleProps).not.toHaveBeenCalled();
+    expect(Modal.prototype.componentDidUpdate).toHaveBeenCalled();
+
+    wrapper.unmount();
+  });
+
+  it('should close modal when escape key pressed', () => {
+    isOpen = true;
+    const wrapper = mount(
+      <Modal isOpen={isOpen} toggle={toggle}>
+        Yo!
+      </Modal>
+    );
+    const instance = wrapper.instance();
+
+    jasmine.clock().tick(300);
+
+    expect(isOpen).toBe(true);
+    expect(document.getElementsByClassName('modal').length).toBe(1);
+
+    instance.handleEscape({keyCode: 13});
+    jasmine.clock().tick(300);
+
+    expect(isOpen).toBe(true);
+    expect(document.getElementsByClassName('modal').length).toBe(1);
+
+    instance.handleEscape({keyCode: 27});
+    jasmine.clock().tick(300);
+
+    expect(isOpen).toBe(false);
+
+    wrapper.setProps({
+      isOpen: isOpen
+    });
+    jasmine.clock().tick(300);
+
+    expect(document.getElementsByClassName('modal').length).toBe(0);
+
+    wrapper.unmount();
+  });
+
+  it('should close modal when clicking backdrop', () => {
+    isOpen = true;
+    const wrapper = mount(
+      <Modal isOpen={isOpen} toggle={toggle}>
+        <button id="clicker">Does Nothing</button>
+      </Modal>
+    );
+
+    jasmine.clock().tick(300);
+
+    expect(isOpen).toBe(true);
+    expect(document.getElementsByClassName('modal').length).toBe(1);
+    //
+    document.getElementById('clicker').click();
+    jasmine.clock().tick(300);
+
+    expect(isOpen).toBe(true);
+
+    document.getElementsByClassName('modal-backdrop')[0].click();
+    jasmine.clock().tick(300);
+
+    expect(isOpen).toBe(false);
+
+    wrapper.unmount();
+  });
+
+  it('should destroy this._element', () => {
+    isOpen = true;
+    const wrapper = mount(
+      <Modal isOpen={isOpen} toggle={toggle}>
+        <button id="clicker">Does Nothing</button>
+      </Modal>
+    );
+    const instance = wrapper.instance();
+
+    jasmine.clock().tick(300);
+    expect(instance._element).toBeTruthy()
+
+    instance.destroy();
+
+    expect(instance._element).toBe(null)
+
+    instance.destroy();
+    wrapper.unmount();
+  });
+});

--- a/test/ModalBody.spec.js
+++ b/test/ModalBody.spec.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { ModalBody } from '../lib';
+
+describe('ModalBody', () => {
+  it('should render with "modal-body" class', () => {
+    const wrapper = shallow(<ModalBody>Yo!</ModalBody>);
+
+    expect(wrapper.text()).toBe('Yo!');
+    expect(wrapper.hasClass('modal-body')).toBe(true);
+  });
+
+  it('should render additional classes', () => {
+    const wrapper = shallow(<ModalBody className="other">Yo!</ModalBody>);
+
+    expect(wrapper.hasClass('other')).toBe(true);
+    expect(wrapper.hasClass('modal-body')).toBe(true);
+  });
+});

--- a/test/ModalFooter.spec.js
+++ b/test/ModalFooter.spec.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { ModalFooter } from '../lib';
+
+describe('ModalFooter', () => {
+  it('should render with "modal-footer" class', () => {
+    const wrapper = shallow(<ModalFooter>Yo!</ModalFooter>);
+
+    expect(wrapper.text()).toBe('Yo!');
+    expect(wrapper.hasClass('modal-footer')).toBe(true);
+  });
+
+  it('should render additional classes', () => {
+    const wrapper = shallow(<ModalFooter className="other">Yo!</ModalFooter>);
+
+    expect(wrapper.hasClass('modal-footer')).toBe(true);
+    expect(wrapper.hasClass('other')).toBe(true);
+  });
+});

--- a/test/ModalHeader.spec.js
+++ b/test/ModalHeader.spec.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { ModalHeader } from '../lib';
+
+describe('ModalHeader', () => {
+  it('should render with "modal-header" class', () => {
+    const wrapper = shallow(<ModalHeader>Yo!</ModalHeader>);
+
+    expect(wrapper.text()).toBe('Yo!');
+    expect(wrapper.hasClass('modal-header')).toBe(true);
+  });
+
+  it('should render additional classes', () => {
+    const wrapper = shallow(<ModalHeader className="other">Yo!</ModalHeader>);
+
+    expect(wrapper.hasClass('other')).toBe(true);
+    expect(wrapper.hasClass('modal-header')).toBe(true);
+  });
+
+  it('should render close button', () => {
+    const wrapper = shallow(<ModalHeader toggle={() => {}} className="other">Yo!</ModalHeader>);
+
+    expect(wrapper.hasClass('other')).toBe(true);
+    expect(wrapper.hasClass('modal-header')).toBe(true);
+    expect(wrapper.find('button.close').length).toBe(1);
+  });
+});


### PR DESCRIPTION
First run at applying fade classes to a component. Modal has a fade in for backdrop and modal content. Added a Fade component to help with toggling classes from `.fade` to `.fade.in` via state.

Modal Props

- isOpen
- toggle
- onExit - called after exit
- onEnter - called after enter

Modal Header Props

- toggle - adding this enables close button