### PR TITLE
feat(outline): Make outline a separate prop

### DIFF
--- a/docs/lib/Home/index.jsx
+++ b/docs/lib/Home/index.jsx
@@ -21,7 +21,7 @@ export default () => {
                 Easy to use React Bootstrap 4 components
               </p>
               <p>
-                <Button color="danger-outline" href="https://github.com/reactstrap/reactstrap">View on Github</Button>
+                <Button outline color="danger" href="https://github.com/reactstrap/reactstrap">View on Github</Button>
                 <Button color="danger" tag={Link} to="/components/">View Components</Button>
               </p>
             </Col>

--- a/docs/lib/NotFound/index.jsx
+++ b/docs/lib/NotFound/index.jsx
@@ -19,7 +19,7 @@ export default () => {
                 Can't find what you're looking for? <a href="https://github.com/reactstrap/reactstrap/issues/new">Open</a> up an issue.
               </p>
               <p>
-                <Button color="danger-outline" className="m-r-1" tag={Link} to="/">Get Started</Button>
+                <Button outline color="danger" className="m-r-1" tag={Link} to="/">Get Started</Button>
                 <Button color="danger" tag={Link} to="/components">View Components</Button>
               </p>
             </Col>

--- a/docs/lib/examples/ButtonOutline.jsx
+++ b/docs/lib/examples/ButtonOutline.jsx
@@ -5,12 +5,12 @@ export default class Example extends React.Component {
   render() {
     return (
       <div>
-        <Button color="outline-primary">primary</Button>
-        <Button color="outline-secondary">secondary</Button>
-        <Button color="outline-success">success</Button>
-        <Button color="outline-info">info</Button>
-        <Button color="outline-warning">warning</Button>
-        <Button color="outline-danger">danger</Button>
+        <Button outline color="primary">primary</Button>
+        <Button outline color="secondary">secondary</Button>
+        <Button outline color="success">success</Button>
+        <Button outline color="info">info</Button>
+        <Button outline color="warning">warning</Button>
+        <Button outline color="danger">danger</Button>
       </div>
     );
   }

--- a/docs/lib/examples/CardOutline.jsx
+++ b/docs/lib/examples/CardOutline.jsx
@@ -4,32 +4,32 @@ import { Card, Button, CardTitle, CardText } from 'reactstrap';
 const Example = (props) => {
   return (
     <div>
-      <Card block color="outline-secondary">
+      <Card block outline color="secondary">
         <CardTitle>Special Title Treatment</CardTitle>
         <CardText>With supporting text below as a natural lead-in to additional content.</CardText>
         <Button>Button</Button>
       </Card>
-      <Card block color="outline-primary">
+      <Card block outline color="primary">
         <CardTitle>Special Title Treatment</CardTitle>
         <CardText>With supporting text below as a natural lead-in to additional content.</CardText>
         <Button color="secondary">Button</Button>
       </Card>
-      <Card block color="outline-success">
+      <Card block outline color="success">
         <CardTitle>Special Title Treatment</CardTitle>
         <CardText>With supporting text below as a natural lead-in to additional content.</CardText>
         <Button color="secondary">Button</Button>
       </Card>
-      <Card block color="outline-info">
+      <Card block outline color="info">
         <CardTitle>Special Title Treatment</CardTitle>
         <CardText>With supporting text below as a natural lead-in to additional content.</CardText>
         <Button color="secondary">Button</Button>
       </Card>
-      <Card block color="outline-warning">
+      <Card block outline color="warning">
         <CardTitle>Special Title Treatment</CardTitle>
         <CardText>With supporting text below as a natural lead-in to additional content.</CardText>
         <Button color="secondary">Button</Button>
       </Card>
-      <Card block color="outline-danger">
+      <Card block outline color="danger">
         <CardTitle>Special Title Treatment</CardTitle>
         <CardText>With supporting text below as a natural lead-in to additional content.</CardText>
         <Button color="secondary">Button</Button>

--- a/src/Button.jsx
+++ b/src/Button.jsx
@@ -6,6 +6,7 @@ const propTypes = {
   block: PropTypes.bool,
   color: PropTypes.string,
   disabled: PropTypes.bool,
+  outline: PropTypes.bool,
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   onClick: PropTypes.func,
   size: PropTypes.string
@@ -39,6 +40,7 @@ class Button extends React.Component {
       block,
       className,
       color,
+      outline,
       size,
       tag: Tag,
       ...attributes
@@ -47,8 +49,8 @@ class Button extends React.Component {
     const classes = classNames(
       className,
       'btn',
-      'btn-' + color,
-      size ? 'btn-' + size : false,
+      `btn${outline ? '-outline' : ''}-${color}`,
+      size ? `btn-${size}` : false,
       block ? 'btn-block' : false,
       { active, disabled: this.props.disabled }
     );

--- a/src/Card.jsx
+++ b/src/Card.jsx
@@ -6,6 +6,7 @@ const propTypes = {
   inverse: PropTypes.bool,
   color: PropTypes.string,
   block: PropTypes.bool,
+  outline: PropTypes.bool,
   className: PropTypes.any
 };
 
@@ -19,6 +20,7 @@ const Card = (props) => {
     color,
     block,
     inverse,
+    outline,
     tag: Tag,
     ...attributes
   } = props;
@@ -27,7 +29,7 @@ const Card = (props) => {
     'card',
     inverse ? 'card-inverse' : false,
     block ? 'card-block' : false,
-    color ? 'card-' + color : false
+    color ? `card${outline ? '-outline' : ''}-${color}` : false
   );
 
   return (

--- a/test/Button.spec.js
+++ b/test/Button.spec.js
@@ -37,6 +37,18 @@ describe('Button', () => {
     expect(wrapper.hasClass('btn-danger')).toBe(true);
   });
 
+  it('should render buttons with outline variant', () => {
+    const wrapper = shallow(<Button outline>Default Button</Button>);
+
+    expect(wrapper.hasClass('btn-outline-primary')).toBe(true);
+  });
+
+  it('should render buttons with outline variant with different colors', () => {
+    const wrapper = shallow(<Button outline color="info">Default Button</Button>);
+
+    expect(wrapper.hasClass('btn-outline-info')).toBe(true);
+  });
+
   it('should render buttons at different sizes', () => {
     const small = shallow(<Button size="sm">Small Button</Button>);
     const large = shallow(<Button size="lg">Large Button</Button>);

--- a/test/Card.spec.js
+++ b/test/Card.spec.js
@@ -20,6 +20,24 @@ describe('Card', () => {
     expect(wrapper.hasClass('card-inverse')).toBe(true);
   });
 
+  it('should render with "outline" class when a color is provided', () => {
+    const wrapper = shallow(<Card outline block color="primary">Yo!</Card>);
+
+    expect(wrapper.text()).toBe('Yo!');
+    expect(wrapper.hasClass('card')).toBe(true);
+    expect(wrapper.hasClass('card-block')).toBe(true);
+    expect(wrapper.hasClass('card-outline-primary')).toBe(true);
+  });
+
+  it('should not render with "outline" class when a color is not provided (no default)', () => {
+    const wrapper = shallow(<Card outline block>Yo!</Card>);
+
+    expect(wrapper.text()).toBe('Yo!');
+    expect(wrapper.hasClass('card')).toBe(true);
+    expect(wrapper.hasClass('card-block')).toBe(true);
+    expect(wrapper.html()).not.toContain('card-outline');
+  });
+
   it('should render additional classes', () => {
     const wrapper = shallow(<Card className="other">Yo!</Card>);
 


### PR DESCRIPTION
The outline for buttons and cards is now it's own props separate from the color value.
Based on https://github.com/reactstrap/reactstrap/issues/33#issuecomment-214025488

This also adds additional tests around this new props.

Also:
Cards, unlike buttons, do not have a default color. Thus adding outline prop to a card without a color will do nothing.
Is this acceptable? Should it produce a warning/error? Should it default to 'card-outline-secondary' when outline is provided but no color is provided?