### PR TITLE
feat(form): add forms and form element components

### DIFF
--- a/docs/lib/Components/FormPage.jsx
+++ b/docs/lib/Components/FormPage.jsx
@@ -1,0 +1,117 @@
+/* eslint react/no-multi-comp: 0, react/prop-types: 0 */
+import React from 'react';
+import { PrismCode } from 'react-prism';
+import Helmet from 'react-helmet';
+
+import FormExample from '../examples/Form';
+const FormExampleSource = require('!!raw!../examples/Form.jsx');
+
+import FormGridExample from '../examples/FormGrid';
+const FormGridExampleSource = require('!!raw!../examples/FormGrid.jsx');
+
+import FormInlineExample from '../examples/FormInline';
+const FormInlineExampleSource = require('!!raw!../examples/FormInline.jsx');
+
+import FormFeedbackExample from '../examples/FormFeedback';
+const FormFeedbackExampleSource = require('!!raw!../examples/FormFeedback.jsx');
+
+import InputTypeExample from '../examples/InputType';
+const InputTypeExampleSource = require('!!raw!../examples/InputType.jsx');
+
+import InputSizingExample from '../examples/InputSizing';
+const InputSizingExampleSource = require('!!raw!../examples/InputSizing.jsx');
+
+import InputGridSizingExample from '../examples/InputGridSizing';
+const InputGridSizingExampleSource = require('!!raw!../examples/InputGridSizing.jsx');
+
+import LabelHiddenExample from '../examples/LabelHidden';
+const LabelHiddenExampleSource = require('!!raw!../examples/LabelHidden.jsx');
+
+export default class FormPage extends React.Component {
+  render() {
+    return (
+      <div>
+        <Helmet title="Form" />
+        <h3>Form</h3>
+        <div className="docs-example">
+          <FormExample />
+        </div>
+        <pre>
+          <PrismCode className="language-jsx">
+            {FormExampleSource}
+          </PrismCode>
+        </pre>
+
+        <h3>Form Grid</h3>
+        <div className="docs-example">
+          <FormGridExample />
+        </div>
+        <pre>
+          <PrismCode className="language-jsx">
+            {FormGridExampleSource}
+          </PrismCode>
+        </pre>
+
+        <h3>Inline Form</h3>
+        <div className="docs-example">
+          <FormInlineExample />
+        </div>
+        <pre>
+          <PrismCode className="language-jsx">
+            {FormInlineExampleSource}
+          </PrismCode>
+        </pre>
+
+        <h3>Form Feedback</h3>
+        <div className="docs-example">
+          <FormFeedbackExample />
+        </div>
+        <pre>
+          <PrismCode className="language-jsx">
+            {FormFeedbackExampleSource}
+          </PrismCode>
+        </pre>
+
+        <h3>Input Types</h3>
+        <div className="docs-example">
+          <InputTypeExample />
+        </div>
+        <pre>
+          <PrismCode className="language-jsx">
+            {InputTypeExampleSource}
+          </PrismCode>
+        </pre>
+
+        <h3>Input Sizing</h3>
+        <div className="docs-example">
+          <InputSizingExample />
+        </div>
+        <pre>
+          <PrismCode className="language-jsx">
+            {InputSizingExampleSource}
+          </PrismCode>
+        </pre>
+
+        <h3>Input Grid Sizing</h3>
+        <div className="docs-example">
+          <InputGridSizingExample />
+        </div>
+        <pre>
+          <PrismCode className="language-jsx">
+            {InputGridSizingExampleSource}
+          </PrismCode>
+        </pre>
+
+        <h3>Hidden Labels</h3>
+        <div className="docs-example">
+          <LabelHiddenExample />
+        </div>
+        <pre>
+          <PrismCode className="language-jsx">
+            {LabelHiddenExampleSource}
+          </PrismCode>
+        </pre>
+      </div>
+    );
+  }
+}

--- a/docs/lib/Components/index.jsx
+++ b/docs/lib/Components/index.jsx
@@ -36,6 +36,10 @@ class Components extends React.Component {
           to: '/components/dropdowns/'
         },
         {
+          name: 'Form',
+          to: '/components/form/'
+        },
+        {
           name: 'Tags',
           to: '/components/tags/'
         },

--- a/docs/lib/examples/Form.jsx
+++ b/docs/lib/examples/Form.jsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { Button, Form, FormGroup, Label, Input, FormText } from 'reactstrap';
+
+export default class Example extends React.Component {
+  render() {
+    return (
+      <Form>
+        <FormGroup>
+          <Label for="exampleEmail">Email</Label>
+          <Input type="email" name="email" id="exampleEmail" placeholder="with a placeholder" />
+        </FormGroup>
+        <FormGroup>
+          <Label for="examplePassword">Password</Label>
+          <Input type="password" name="password" id="examplePassword" placeholder="password placeholder" />
+        </FormGroup>
+        <FormGroup>
+          <Label for="exampleSelect">Select</Label>
+          <Input type="select" name="select" id="exampleSelect">
+            <option>1</option>
+            <option>2</option>
+            <option>3</option>
+            <option>4</option>
+            <option>5</option>
+          </Input>
+        </FormGroup>
+        <FormGroup>
+          <Label for="exampleSelectMulti">Select Multiple</Label>
+          <Input type="select" name="selectMulti" id="exampleSelectMulti" multiple>
+            <option>1</option>
+            <option>2</option>
+            <option>3</option>
+            <option>4</option>
+            <option>5</option>
+          </Input>
+        </FormGroup>
+        <FormGroup>
+          <Label for="exampleText">Text Area</Label>
+          <Input type="textarea" name="text" id="exampleText" />
+        </FormGroup>
+        <FormGroup>
+          <Label for="exampleFile">File</Label>
+          <Input type="file" name="file" id="exampleFile" />
+          <FormText color="muted">
+            This is some placeholder block-level help text for the above input.
+            It's a bit lighter and easily wraps to a new line.
+          </FormText>
+        </FormGroup>
+        <FormGroup tag="fieldset">
+          <legend>Radio Buttons</legend>
+          <FormGroup check>
+            <Label check>
+              <Input type="radio" name="radio1" />{' '}
+              Option one is this and that—be sure to include why it's great
+            </Label>
+          </FormGroup>
+          <FormGroup check>
+            <Label check>
+              <Input type="radio" name="radio1" />{' '}
+              Option two can be something else and selecting it will deselect option one
+            </Label>
+          </FormGroup>
+          <FormGroup check disabled>
+            <Label check>
+              <Input type="radio" name="radio1" disabled />{' '}
+              Option three is disabled
+            </Label>
+          </FormGroup>
+        </FormGroup>
+        <FormGroup check>
+          <Label check>
+            <Input type="checkbox" />{' '}
+            Check me out
+          </Label>
+        </FormGroup>
+        <Button>Submit</Button>
+      </Form>
+    );
+  }
+}

--- a/docs/lib/examples/FormFeedback.jsx
+++ b/docs/lib/examples/FormFeedback.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Form, FormGroup, Label, Input, FormFeedback, FormText } from 'reactstrap';
+
+export default class Example extends React.Component {
+  render() {
+    return (
+      <Form>
+        <FormGroup color="success">
+          <Label for="exampleEmail">Input with success</Label>
+          <Input state="success" />
+          <FormFeedback>Success! You did it!</FormFeedback>
+          <FormText color="muted">Example help text that remains unchanged.</FormText>
+        </FormGroup>
+        <FormGroup color="warning">
+          <Label for="examplePassword">Input with warning</Label>
+          <Input state="warning" />
+          <FormFeedback>Whoops, check your formatting and try again.</FormFeedback>
+          <FormText color="muted">Example help text that remains unchanged.</FormText>
+        </FormGroup>
+        <FormGroup color="danger">
+          <Label for="examplePassword">Input with danger</Label>
+          <Input state="danger" />
+          <FormFeedback>Oh noes! that name is already taken</FormFeedback>
+          <FormText color="muted">Example help text that remains unchanged.</FormText>
+        </FormGroup>
+      </Form>
+    );
+  }
+}

--- a/docs/lib/examples/FormGrid.jsx
+++ b/docs/lib/examples/FormGrid.jsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { Col, Button, Form, FormGroup, Label, Input, FormText } from 'reactstrap';
+
+export default class Example extends React.Component {
+  render() {
+    return (
+      <Form>
+        <FormGroup row>
+          <Label for="exampleEmail" sm={2}>Email</Label>
+          <Col sm={10}>
+            <Input type="email" name="email" id="exampleEmail" placeholder="with a placeholder" />
+          </Col>
+        </FormGroup>
+        <FormGroup row>
+          <Label for="examplePassword" sm={2}>Password</Label>
+          <Col sm={10}>
+            <Input type="password" name="password" id="examplePassword" placeholder="password placeholder" />
+          </Col>
+        </FormGroup>
+        <FormGroup row>
+          <Label for="exampleSelect" sm={2}>Select</Label>
+          <Col sm={10}>
+            <Input type="select" name="select" id="exampleSelect" />
+          </Col>
+        </FormGroup>
+        <FormGroup row>
+          <Label for="exampleSelectMulti" sm={2}>Select Multiple</Label>
+          <Col sm={10}>
+            <Input type="select" name="selectMulti" id="exampleSelectMulti" multiple />
+          </Col>
+        </FormGroup>
+        <FormGroup row>
+          <Label for="exampleText" sm={2}>Text Area</Label>
+          <Col sm={10}>
+            <Input type="textarea" name="text" id="exampleText" />
+          </Col>
+        </FormGroup>
+        <FormGroup row>
+          <Label for="exampleFile" sm={2}>File</Label>
+          <Col sm={10}>
+            <Input type="file" name="file" id="exampleFile" />
+            <FormText color="muted">
+              This is some placeholder block-level help text for the above input.
+              It's a bit lighter and easily wraps to a new line.
+            </FormText>
+          </Col>
+        </FormGroup>
+        <FormGroup tag="fieldset" row>
+          <legend className="col-form-legend col-sm-2">Radio Buttons</legend>
+          <Col sm={10}>
+            <FormGroup check>
+              <Label check>
+                <Input type="radio" name="radio2" />{' '}
+                Option one is this and that—be sure to include why it's great
+              </Label>
+            </FormGroup>
+            <FormGroup check>
+              <Label check>
+                <Input type="radio" name="radio2" />{' '}
+                Option two can be something else and selecting it will deselect option one
+              </Label>
+            </FormGroup>
+            <FormGroup check disabled>
+              <Label check>
+                <Input type="radio" name="radio2" disabled />{' '}
+                Option three is disabled
+              </Label>
+            </FormGroup>
+          </Col>
+        </FormGroup>
+        <FormGroup row>
+          <Label for="checkbox2" sm={2}>Checkbox</Label>
+          <Col sm={{ size: 10 }}>
+            <FormGroup check>
+              <Label check>
+                <Input type="checkbox" id="checkbox2" />{' '}
+                Check me out
+              </Label>
+            </FormGroup>
+          </Col>
+        </FormGroup>
+        <FormGroup check row>
+          <Col sm={{ size: 10, offset: 2 }}>
+            <Button>Submit</Button>
+          </Col>
+        </FormGroup>
+      </Form>
+    );
+  }
+}

--- a/docs/lib/examples/FormInline.jsx
+++ b/docs/lib/examples/FormInline.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Button, Form, FormGroup, Label, Input } from 'reactstrap';
+
+export default class Example extends React.Component {
+  render() {
+    return (
+      <Form inline>
+        <FormGroup>
+          <Label for="exampleEmail">Email</Label>{' '}
+          <Input type="email" name="email" id="exampleEmail" placeholder="something@idk.cool" />
+        </FormGroup>
+        {' '}
+        <FormGroup>
+          <Label for="examplePassword">Password</Label>{' '}
+          <Input type="password" name="password" id="examplePassword" placeholder="don't tell!" />
+        </FormGroup>
+        {' '}
+        <Button>Submit</Button>
+      </Form>
+    );
+  }
+}

--- a/docs/lib/examples/InputGridSizing.jsx
+++ b/docs/lib/examples/InputGridSizing.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Col, Form, FormGroup, Label, Input } from 'reactstrap';
+
+export default class Example extends React.Component {
+  render() {
+    return (
+      <Form>
+        <FormGroup row>
+          <Label for="exampleEmail" sm={2} size="lg">Email</Label>
+          <Col sm={10}>
+            <Input type="email" name="email" id="exampleEmail" placeholder="lg" size="lg" />
+          </Col>
+        </FormGroup>
+        <FormGroup row>
+          <Label for="exampleEmail2" sm={2}>Email</Label>
+          <Col sm={10}>
+            <Input type="email" name="email" id="exampleEmail2" placeholder="default" />
+          </Col>
+        </FormGroup>
+      </Form>
+    );
+  }
+}

--- a/docs/lib/examples/InputSizing.jsx
+++ b/docs/lib/examples/InputSizing.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Form, Input } from 'reactstrap';
+
+export default class Example extends React.Component {
+  render() {
+    return (
+      <Form>
+        <Input placeholder="lg" size="lg" />
+        <Input placeholder="default" />
+        <Input placeholder="sm" size="sm" />
+        <Input type="select" size="lg">
+          <option>Large Select</option>
+        </Input>
+        <Input type="select">
+          <option>Default Select</option>
+        </Input>
+        <Input type="select" size="sm">
+          <option>Small Select</option>
+        </Input>
+      </Form>
+    );
+  }
+}

--- a/docs/lib/examples/InputType.jsx
+++ b/docs/lib/examples/InputType.jsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { Button, Form, FormGroup, Label, Input, FormText } from 'reactstrap';
+
+export default class Example extends React.Component {
+  render() {
+    return (
+      <Form>
+        <FormGroup>
+          <Label for="exampleEmail">Static</Label>
+          <Input static>Some static value</Input>
+        </FormGroup>
+        <FormGroup>
+          <Label for="exampleEmail">Email</Label>
+          <Input type="email" name="email" id="exampleEmail" placeholder="with a placeholder" />
+        </FormGroup>
+        <FormGroup>
+          <Label for="examplePassword">Password</Label>
+          <Input type="password" name="password" id="examplePassword" placeholder="password placeholder" />
+        </FormGroup>
+        <FormGroup>
+          <Label for="exampleUrl">Url</Label>
+          <Input type="url" name="url" id="exampleUrl" placeholder="url placeholder" />
+        </FormGroup>
+        <FormGroup>
+          <Label for="exampleNumber">Number</Label>
+          <Input type="number" name="number" id="exampleNumber" placeholder="number placeholder" />
+        </FormGroup>
+        <FormGroup>
+          <Label for="exampleDatetime">Datetime</Label>
+          <Input type="datetime" name="datetime" id="exampleDatetime" placeholder="datetime placeholder" />
+        </FormGroup>
+        <FormGroup>
+          <Label for="exampleDate">Date</Label>
+          <Input type="date" name="date" id="exampleDate" placeholder="date placeholder" />
+        </FormGroup>
+        <FormGroup>
+          <Label for="exampleTime">Time</Label>
+          <Input type="time" name="time" id="exampleTime" placeholder="time placeholder" />
+        </FormGroup>
+        <FormGroup>
+          <Label for="exampleColor">Color</Label>
+          <Input type="color" name="color" id="exampleColor" placeholder="color placeholder" />
+        </FormGroup>
+        <FormGroup>
+          <Label for="exampleSearch">Search</Label>
+          <Input type="search" name="search" id="exampleSearch" placeholder="search placeholder" />
+        </FormGroup>
+        <FormGroup>
+          <Label for="exampleSelect">Select</Label>
+          <Input type="select" name="select" id="exampleSelect">
+            <option>1</option>
+            <option>2</option>
+            <option>3</option>
+            <option>4</option>
+            <option>5</option>
+          </Input>
+        </FormGroup>
+        <FormGroup>
+          <Label for="exampleSelectMulti">Select Multiple</Label>
+          <Input type="select" name="selectMulti" id="exampleSelectMulti" multiple>
+            <option>1</option>
+            <option>2</option>
+            <option>3</option>
+            <option>4</option>
+            <option>5</option>
+          </Input>
+        </FormGroup>
+        <FormGroup>
+          <Label for="exampleText">Text Area</Label>
+          <Input type="textarea" name="text" id="exampleText" />
+        </FormGroup>
+        <FormGroup>
+          <Label for="exampleFile">File</Label>
+          <Input type="file" name="file" id="exampleFile" />
+          <FormText color="muted">
+            This is some placeholder block-level help text for the above input.
+            It's a bit lighter and easily wraps to a new line.
+          </FormText>
+        </FormGroup>
+        <FormGroup check>
+          <Label check>
+            <Input type="radio" />{' '}
+            Option one is this and that—be sure to include why it's great
+          </Label>
+        </FormGroup>
+        <FormGroup check>
+          <Label check>
+            <Input type="checkbox" />{' '}
+            Check me out
+          </Label>
+        </FormGroup>
+      </Form>
+    );
+  }
+}

--- a/docs/lib/examples/LabelHidden.jsx
+++ b/docs/lib/examples/LabelHidden.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Button, Form, FormGroup, Label, Input } from 'reactstrap';
+
+export default class Example extends React.Component {
+  render() {
+    return (
+      <Form inline>
+        <FormGroup>
+          <Label for="exampleEmail" hidden>Email</Label>
+          <Input type="email" name="email" id="exampleEmail" placeholder="Email" />
+        </FormGroup>
+        {' '}
+        <FormGroup>
+          <Label for="examplePassword" hidden>Password</Label>
+          <Input type="password" name="password" id="examplePassword" placeholder="Password" />
+        </FormGroup>
+        {' '}
+        <Button>Submit</Button>
+      </Form>
+    );
+  }
+}

--- a/docs/lib/routes.jsx
+++ b/docs/lib/routes.jsx
@@ -8,6 +8,7 @@ import ButtonsPage from './Components/ButtonsPage';
 import ButtonGroupPage from './Components/ButtonGroupPage';
 import ButtonDropdownPage from './Components/ButtonDropdownPage';
 import DropdownsPage from './Components/DropdownsPage';
+import FormPage from './Components/FormPage';
 import PopoversPage from './Components/PopoversPage';
 import TooltipsPage from './Components/TooltipsPage';
 import TagsPage from './Components/TagsPage';
@@ -27,6 +28,7 @@ const routes = (
       <Route path="button-group/" component={ ButtonGroupPage } />
       <Route path="button-dropdown/" component={ ButtonDropdownPage } />
       <Route path="dropdowns/" component={ DropdownsPage } />
+      <Route path="form/" component={ FormPage } />
       <Route path="popovers/" component={ PopoversPage } />
       <Route path="tooltips/" component={ TooltipsPage } />
       <Route path="tags/" component={ TagsPage } />

--- a/docs/static/docs.css
+++ b/docs/static/docs.css
@@ -187,6 +187,10 @@ pre, code {
   color: #5F5F5F;
 }
 
+.docs-example .form-control + .form-control {
+    margin-top: .5rem;
+}
+
 
 /* http://prismjs.com/download.html?themes=prism-okaidia&languages=markup+css+clike+javascript+bash+jsx */
 /**

--- a/src/Form.jsx
+++ b/src/Form.jsx
@@ -1,0 +1,36 @@
+import React, { PropTypes } from 'react';
+import classNames from 'classnames';
+
+const propTypes = {
+  children: PropTypes.node,
+  inline: PropTypes.bool,
+  tag: PropTypes.string,
+  className: PropTypes.string,
+};
+
+const defaultProps = {
+  tag: 'form',
+};
+
+const Form = (props) => {
+  const {
+    className,
+    inline,
+    tag: Tag,
+    ...attributes,
+  } = props;
+
+  const classes = classNames(
+    className,
+    inline ? 'form-inline' : false
+  );
+
+  return (
+    <Tag {...attributes} className={classes} />
+  );
+};
+
+Form.propTypes = propTypes;
+Form.defaultProps = defaultProps;
+
+export default Form;

--- a/src/FormFeedback.jsx
+++ b/src/FormFeedback.jsx
@@ -1,0 +1,34 @@
+import React, { PropTypes } from 'react';
+import classNames from 'classnames';
+
+const propTypes = {
+  children: PropTypes.node,
+  tag: PropTypes.string,
+  className: PropTypes.string,
+};
+
+const defaultProps = {
+  tag: 'div',
+};
+
+const Form = (props) => {
+  const {
+    className,
+    tag: Tag,
+    ...attributes,
+  } = props;
+
+  const classes = classNames(
+    className,
+    'form-control-feedback'
+  );
+
+  return (
+    <Tag {...attributes} className={classes} />
+  );
+};
+
+Form.propTypes = propTypes;
+Form.defaultProps = defaultProps;
+
+export default Form;

--- a/src/FormFeedback.jsx
+++ b/src/FormFeedback.jsx
@@ -11,7 +11,7 @@ const defaultProps = {
   tag: 'div',
 };
 
-const Form = (props) => {
+const FormFeedback = (props) => {
   const {
     className,
     tag: Tag,
@@ -28,7 +28,7 @@ const Form = (props) => {
   );
 };
 
-Form.propTypes = propTypes;
-Form.defaultProps = defaultProps;
+FormFeedback.propTypes = propTypes;
+FormFeedback.defaultProps = defaultProps;
 
-export default Form;
+export default FormFeedback;

--- a/src/FormGroup.jsx
+++ b/src/FormGroup.jsx
@@ -15,7 +15,7 @@ const defaultProps = {
   tag: 'div',
 };
 
-const Form = (props) => {
+const FormGroup = (props) => {
   const {
     className,
     row,
@@ -39,7 +39,7 @@ const Form = (props) => {
   );
 };
 
-Form.propTypes = propTypes;
-Form.defaultProps = defaultProps;
+FormGroup.propTypes = propTypes;
+FormGroup.defaultProps = defaultProps;
 
-export default Form;
+export default FormGroup;

--- a/src/FormGroup.jsx
+++ b/src/FormGroup.jsx
@@ -1,0 +1,45 @@
+import React, { PropTypes } from 'react';
+import classNames from 'classnames';
+
+const propTypes = {
+  children: PropTypes.node,
+  row: PropTypes.bool,
+  check: PropTypes.bool,
+  disabled: PropTypes.bool,
+  tag: PropTypes.string,
+  color: PropTypes.string,
+  className: PropTypes.string,
+};
+
+const defaultProps = {
+  tag: 'div',
+};
+
+const Form = (props) => {
+  const {
+    className,
+    row,
+    disabled,
+    color,
+    check,
+    tag: Tag,
+    ...attributes,
+  } = props;
+
+  const classes = classNames(
+    className,
+    color ? `has-${color}` : false,
+    row ? 'row' : false,
+    check ? 'form-check' : 'form-group',
+    check && disabled ? 'disabled' : false
+  );
+
+  return (
+    <Tag {...attributes} className={classes} />
+  );
+};
+
+Form.propTypes = propTypes;
+Form.defaultProps = defaultProps;
+
+export default Form;

--- a/src/FormText.jsx
+++ b/src/FormText.jsx
@@ -13,7 +13,7 @@ const defaultProps = {
   tag: 'small',
 };
 
-const Form = (props) => {
+const FormText = (props) => {
   const {
     className,
     inline,
@@ -33,7 +33,7 @@ const Form = (props) => {
   );
 };
 
-Form.propTypes = propTypes;
-Form.defaultProps = defaultProps;
+FormText.propTypes = propTypes;
+FormText.defaultProps = defaultProps;
 
-export default Form;
+export default FormText;

--- a/src/FormText.jsx
+++ b/src/FormText.jsx
@@ -1,0 +1,39 @@
+import React, { PropTypes } from 'react';
+import classNames from 'classnames';
+
+const propTypes = {
+  children: PropTypes.node,
+  inline: PropTypes.bool,
+  tag: PropTypes.string,
+  color: PropTypes.string,
+  className: PropTypes.string,
+};
+
+const defaultProps = {
+  tag: 'small',
+};
+
+const Form = (props) => {
+  const {
+    className,
+    inline,
+    color,
+    tag: Tag,
+    ...attributes,
+  } = props;
+
+  const classes = classNames(
+    className,
+    !inline ? 'form-text' : false,
+    color ? `text-${color}` : false
+  );
+
+  return (
+    <Tag {...attributes} className={classes} />
+  );
+};
+
+Form.propTypes = propTypes;
+Form.defaultProps = defaultProps;
+
+export default Form;

--- a/src/Input.jsx
+++ b/src/Input.jsx
@@ -16,7 +16,7 @@ const defaultProps = {
   type: 'text',
 };
 
-const Form = (props) => {
+const Input = (props) => {
   const {
     className,
     type,
@@ -52,7 +52,7 @@ const Form = (props) => {
     formControlClass
   );
 
-  if (!staticInput && !selectInput) {
+  if (Tag === 'input') {
     attributes.type = type;
   }
 
@@ -61,7 +61,7 @@ const Form = (props) => {
   );
 };
 
-Form.propTypes = propTypes;
-Form.defaultProps = defaultProps;
+Input.propTypes = propTypes;
+Input.defaultProps = defaultProps;
 
-export default Form;
+export default Input;

--- a/src/Input.jsx
+++ b/src/Input.jsx
@@ -1,0 +1,67 @@
+import React, { PropTypes } from 'react';
+import classNames from 'classnames';
+
+const propTypes = {
+  children: PropTypes.node,
+  type: PropTypes.string,
+  size: PropTypes.string,
+  state: PropTypes.string,
+  tag: PropTypes.string,
+  'static': PropTypes.bool,
+  className: PropTypes.string,
+};
+
+const defaultProps = {
+  tag: 'p',
+  type: 'text',
+};
+
+const Form = (props) => {
+  const {
+    className,
+    type,
+    size,
+    state,
+    tag,
+    'static': staticInput,
+    ...attributes,
+  } = props;
+
+  const checkInput = ['radio', 'checkbox'].indexOf(type) > -1;
+
+  const fileInput = type === 'file';
+  const textareaInput = type === 'textarea';
+  const selectInput = type === 'select';
+  let Tag = selectInput || textareaInput ? type : 'input';
+
+  let formControlClass = 'form-control';
+
+  if (staticInput) {
+    formControlClass = `${formControlClass}-static`;
+    Tag = tag;
+  } else if (fileInput) {
+    formControlClass = `${formControlClass}-file`;
+  } else if (checkInput) {
+    formControlClass = 'form-check-input';
+  }
+
+  const classes = classNames(
+    className,
+    state ? `form-control-${state}` : false,
+    size ? `form-control-${size}` : false,
+    formControlClass
+  );
+
+  if (!staticInput && !selectInput) {
+    attributes.type = type;
+  }
+
+  return (
+    <Tag {...attributes} className={classes} />
+  );
+};
+
+Form.propTypes = propTypes;
+Form.defaultProps = defaultProps;
+
+export default Form;

--- a/src/Label.jsx
+++ b/src/Label.jsx
@@ -1,0 +1,86 @@
+import React, { PropTypes } from 'react';
+import classNames from 'classnames';
+
+const colSizes = ['xs', 'sm', 'md', 'lg', 'xl'];
+
+const stringOrNumberProp = PropTypes.oneOfType([PropTypes.number, PropTypes.string]);
+
+const columnProps = PropTypes.oneOfType([
+  PropTypes.string,
+  PropTypes.number,
+  PropTypes.shape({
+    size: stringOrNumberProp,
+    push: stringOrNumberProp,
+    pull: stringOrNumberProp,
+    offset: stringOrNumberProp,
+  }),
+]);
+
+const propTypes = {
+  children: PropTypes.node,
+  hidden: PropTypes.bool,
+  check: PropTypes.bool,
+  inline: PropTypes.bool,
+  size: PropTypes.string,
+  'for': PropTypes.string,
+  tag: PropTypes.string,
+  className: PropTypes.string,
+  xs: columnProps,
+  sm: columnProps,
+  md: columnProps,
+  lg: columnProps,
+  xl: columnProps,
+};
+
+const defaultProps = {
+  tag: 'label',
+};
+
+const Form = (props) => {
+  const {
+    className,
+    hidden,
+    tag: Tag,
+    check,
+    inline,
+    size,
+    'for': htmlFor,
+    ...attributes,
+  } = props;
+
+  const colClasses = [];
+
+  colSizes.forEach(colSize => {
+    const columnProp = props[colSize];
+    delete attributes[colSize];
+
+    if (columnProp && columnProp.size) {
+      colClasses.push(classNames({
+        [`col-${colSize}-${columnProp.size}`]: columnProp.size,
+        [`push-${colSize}-${columnProp.push}`]: columnProp.push,
+        [`pull-${colSize}-${columnProp.pull}`]: columnProp.pull,
+        [`offset-${colSize}-${columnProp.offset}`]: columnProp.offset,
+      }));
+    } else if (columnProp) {
+      colClasses.push(`col-${colSize}-${columnProp}`);
+    }
+  });
+
+  const classes = classNames(
+    className,
+    hidden ? 'sr-only' : false,
+    check ? `form-check-${inline ? 'inline' : 'label'}` : false,
+    size ? `col-form-label-${size}` : false,
+    colClasses,
+    colClasses.length ? 'col-form-label' : false
+  );
+
+  return (
+    <Tag {...attributes} className={classes} htmlFor={htmlFor} />
+  );
+};
+
+Form.propTypes = propTypes;
+Form.defaultProps = defaultProps;
+
+export default Form;

--- a/src/Label.jsx
+++ b/src/Label.jsx
@@ -36,7 +36,7 @@ const defaultProps = {
   tag: 'label',
 };
 
-const Form = (props) => {
+const Label = (props) => {
   const {
     className,
     hidden,
@@ -76,11 +76,11 @@ const Form = (props) => {
   );
 
   return (
-    <Tag {...attributes} className={classes} htmlFor={htmlFor} />
+    <Tag htmlFor={htmlFor} {...attributes} className={classes} />
   );
 };
 
-Form.propTypes = propTypes;
-Form.defaultProps = defaultProps;
+Label.propTypes = propTypes;
+Label.defaultProps = defaultProps;
 
-export default Form;
+export default Label;

--- a/src/index.js
+++ b/src/index.js
@@ -42,6 +42,12 @@ import TetherContent from './TetherContent';
 import Tooltip from './Tooltip';
 import Table from './Table';
 import ListGroup from './ListGroup';
+import Form from './Form';
+import FormFeedback from './FormFeedback';
+import FormGroup from './FormGroup';
+import FormText from './FormText';
+import Input from './Input';
+import Label from './Label';
 
 export {
   Container,
@@ -87,5 +93,11 @@ export {
   TetherContent,
   Tooltip,
   Table,
-  ListGroup
+  ListGroup,
+  Form,
+  FormFeedback,
+  FormGroup,
+  FormText,
+  Input,
+  Label,
 };

--- a/test/Form.spec.js
+++ b/test/Form.spec.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { Form } from 'reactstrap';
+
+describe('Form', () => {
+  it('should render with "form" tag', () => {
+    const wrapper = shallow(<Form>Yo!</Form>);
+
+    expect(wrapper.type()).toBe('form');
+  });
+
+  it('should render children', () => {
+    const wrapper = shallow(<Form>Yo!</Form>);
+
+    expect(wrapper.text()).toBe('Yo!');
+  });
+
+  it('should render with "form-inline" class', () => {
+    const wrapper = shallow(<Form inline>Yo!</Form>);
+
+    expect(wrapper.hasClass('form-inline')).toBe(true);
+  });
+
+  it('should render additional classes', () => {
+    const wrapper = shallow(<Form className="other">Yo!</Form>);
+
+    expect(wrapper.hasClass('other')).toBe(true);
+  });
+
+  it('should render custom tag', () => {
+    const wrapper = shallow(<Form tag="main">Yo!</Form>);
+    
+    expect(wrapper.type()).toBe('main');
+  });
+});

--- a/test/FormFeedback.spec.js
+++ b/test/FormFeedback.spec.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { FormFeedback } from 'reactstrap';
+
+describe('FormFeedback', () => {
+  it('should render with "form" tag by default', () => {
+    const wrapper = shallow(<FormFeedback>Yo!</FormFeedback>);
+
+    expect(wrapper.type()).toBe('div');
+  });
+
+  it('should render children', () => {
+    const wrapper = shallow(<FormFeedback>Yo!</FormFeedback>);
+
+    expect(wrapper.text()).toBe('Yo!');
+  });
+
+  it('should render with "form-control-feedback" class', () => {
+    const wrapper = shallow(<FormFeedback inline>Yo!</FormFeedback>);
+
+    expect(wrapper.hasClass('form-control-feedback')).toBe(true);
+  });
+
+  it('should render additional classes', () => {
+    const wrapper = shallow(<FormFeedback className="other">Yo!</FormFeedback>);
+
+    expect(wrapper.hasClass('other')).toBe(true);
+  });
+
+  it('should render custom tag', () => {
+    const wrapper = shallow(<FormFeedback tag="main">Yo!</FormFeedback>);
+
+    expect(wrapper.type()).toBe('main');
+  });
+});

--- a/test/FormFeedback.spec.js
+++ b/test/FormFeedback.spec.js
@@ -16,7 +16,7 @@ describe('FormFeedback', () => {
   });
 
   it('should render with "form-control-feedback" class', () => {
-    const wrapper = shallow(<FormFeedback inline>Yo!</FormFeedback>);
+    const wrapper = shallow(<FormFeedback>Yo!</FormFeedback>);
 
     expect(wrapper.hasClass('form-control-feedback')).toBe(true);
   });

--- a/test/FormGroup.spec.js
+++ b/test/FormGroup.spec.js
@@ -1,0 +1,84 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { FormGroup } from 'reactstrap';
+
+describe('FormGroup', () => {
+  it('should render with "form" tag by default', () => {
+    const wrapper = shallow(<FormGroup>Yo!</FormGroup>);
+
+    expect(wrapper.type()).toBe('div');
+  });
+
+  it('should render children', () => {
+    const wrapper = shallow(<FormGroup>Yo!</FormGroup>);
+
+    expect(wrapper.text()).toBe('Yo!');
+  });
+
+  it('should render with "form-group" class by default', () => {
+    const wrapper = shallow(<FormGroup>Yo!</FormGroup>);
+
+    expect(wrapper.hasClass('form-group')).toBe(true);
+  });
+  
+  it('should not render with "form-check" class by default', () => {
+    const wrapper = shallow(<FormGroup>Yo!</FormGroup>);
+
+    expect(wrapper.hasClass('form-check')).toBe(false);
+  });
+
+  it('should render with "form-check" class when check prop is truthy', () => {
+    const wrapper = shallow(<FormGroup check>Yo!</FormGroup>);
+
+    expect(wrapper.hasClass('form-check')).toBe(true);
+  });
+
+  it('should not render with "form-group" class when check prop is truthy', () => {
+    const wrapper = shallow(<FormGroup check>Yo!</FormGroup>);
+
+    expect(wrapper.hasClass('form-group')).toBe(false);
+  });
+
+  it('should not render with "disabled" class when disabled prop is truthy but check is not', () => {
+    const wrapper = shallow(<FormGroup disabled>Yo!</FormGroup>);
+
+    expect(wrapper.hasClass('disabled')).toBe(false);
+  });
+
+  it('should render with "disabled" class when both check disabled props are truthy', () => {
+    const wrapper = shallow(<FormGroup check disabled>Yo!</FormGroup>);
+
+    expect(wrapper.hasClass('disabled')).toBe(true);
+    expect(wrapper.hasClass('form-check')).toBe(true);
+  });
+
+  it('should render with "row" class when row prop is truthy', () => {
+    const wrapper = shallow(<FormGroup row>Yo!</FormGroup>);
+
+    expect(wrapper.hasClass('row')).toBe(true);
+  });
+
+  it('should not render with "row" class when row prop is not truthy', () => {
+    const wrapper = shallow(<FormGroup>Yo!</FormGroup>);
+
+    expect(wrapper.hasClass('row')).toBe(false);
+  });
+
+  it('should render with "has-${color}" class when color prop is provided', () => {
+    const wrapper = shallow(<FormGroup color="yoyo">Yo!</FormGroup>);
+
+    expect(wrapper.hasClass('has-yoyo')).toBe(true);
+  });
+
+  it('should render additional classes', () => {
+    const wrapper = shallow(<FormGroup className="other">Yo!</FormGroup>);
+
+    expect(wrapper.hasClass('other')).toBe(true);
+  });
+
+  it('should render custom tag', () => {
+    const wrapper = shallow(<FormGroup tag="main">Yo!</FormGroup>);
+
+    expect(wrapper.type()).toBe('main');
+  });
+});

--- a/test/FormText.spec.js
+++ b/test/FormText.spec.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { FormText } from 'reactstrap';
+
+describe('FormText', () => {
+  it('should render with "form" tag', () => {
+    const wrapper = shallow(<FormText>Yo!</FormText>);
+
+    expect(wrapper.type()).toBe('small');
+  });
+
+  it('should render children', () => {
+    const wrapper = shallow(<FormText>Yo!</FormText>);
+
+    expect(wrapper.text()).toBe('Yo!');
+  });
+
+  it('should render with "form-text" class when not inline', () => {
+    const wrapper = shallow(<FormText>Yo!</FormText>);
+
+    expect(wrapper.hasClass('form-text')).toBe(true);
+  });
+
+  it('should not render with "form-text" class when inline', () => {
+    const wrapper = shallow(<FormText inline>Yo!</FormText>);
+
+    expect(wrapper.hasClass('form-text')).toBe(false);
+  });
+
+  it('should render with "text-${color}" class when color is provided', () => {
+    const wrapper = shallow(<FormText color="yoyo">Yo!</FormText>);
+
+    expect(wrapper.hasClass('text-yoyo')).toBe(true);
+  });
+
+  it('should render additional classes', () => {
+    const wrapper = shallow(<FormText className="other">Yo!</FormText>);
+
+    expect(wrapper.hasClass('other')).toBe(true);
+  });
+
+  it('should render custom tag', () => {
+    const wrapper = shallow(<FormText tag="main">Yo!</FormText>);
+    
+    expect(wrapper.type()).toBe('main');
+  });
+});

--- a/test/Input.spec.js
+++ b/test/Input.spec.js
@@ -1,0 +1,147 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { Input } from 'reactstrap';
+
+describe('Input', () => {
+  it('should render with "input" tag when no type is provided', () => {
+    const wrapper = shallow(<Input>Yo!</Input>);
+
+    expect(wrapper.type()).toBe('input');
+  });
+
+  it('should render with "select" tag when type is "select"', () => {
+    const wrapper = shallow(<Input type="select">Yo!</Input>);
+
+    expect(wrapper.type()).toBe('select');
+  });
+
+  it('should render with "textarea" tag when type is "textarea"', () => {
+    const wrapper = shallow(<Input type="textarea">Yo!</Input>);
+
+    expect(wrapper.type()).toBe('textarea');
+  });
+
+  it('should render with "p" tag when static prop is truthy', () => {
+    const wrapper = shallow(<Input type="select" static />);
+
+    expect(wrapper.type()).toBe('p');
+  });
+
+  it('should render with "form-control-static" class when static prop is truthy', () => {
+    const wrapper = shallow(<Input type="select" static />);
+
+    expect(wrapper.hasClass('form-control-static')).toBe(true);
+  });
+
+  it('should not render with "form-control" class when static prop is truthy', () => {
+    const wrapper = shallow(<Input type="select" static />);
+
+    expect(wrapper.hasClass('form-control')).toBe(false);
+  });
+
+  it('should render with custom tag when static prop is truthy and tag is provided', () => {
+    const wrapper = shallow(<Input type="select" static tag="div" />);
+
+    expect(wrapper.type()).toBe('div');
+  });
+
+  it('should not render with custom tag when static prop is not truthy and tag is provided', () => {
+    const wrapper = shallow(<Input type="select" tag="div" />);
+
+    expect(wrapper.type()).toBe('select');
+  });
+
+  it('should render with "input" tag when type is not a special case', () => {
+    const wrapper = shallow(<Input type="email" />);
+
+    expect(wrapper.type()).toBe('input');
+  });
+
+  it('should render children', () => {
+    const wrapper = shallow(<Input>Yo!</Input>);
+
+    expect(wrapper.text()).toBe('Yo!');
+  });
+
+  it('should render with "form-control-${state}" class when state is provided', () => {
+    const wrapper = shallow(<Input state="danger" />);
+
+    expect(wrapper.hasClass('form-control-danger')).toBe(true);
+  });
+
+  it('should render with "form-control-${size}" class when size is provided', () => {
+    const wrapper = shallow(<Input size="lg" />);
+
+    expect(wrapper.hasClass('form-control-lg')).toBe(true);
+  });
+
+  it('should render with "form-control" class by default', () => {
+    const wrapper = shallow(<Input />);
+
+    expect(wrapper.hasClass('form-control')).toBe(true);
+  });
+
+  it('should not render with "form-control-file" nor "form-control-static" nor "form-check-input" class by default', () => {
+    const wrapper = shallow(<Input />);
+
+    expect(wrapper.hasClass('form-control-file')).toBe(false);
+    expect(wrapper.hasClass('form-control-static')).toBe(false);
+    expect(wrapper.hasClass('form-check-input')).toBe(false);
+  });
+
+  it('should not render with "form-control" nor "form-control-static" nor "form-check-input" class when type is file', () => {
+    const wrapper = shallow(<Input type="file" />);
+
+    expect(wrapper.hasClass('form-control')).toBe(false);
+    expect(wrapper.hasClass('form-control-static')).toBe(false);
+    expect(wrapper.hasClass('form-check-input')).toBe(false);
+  });
+
+  it('should not render with "form-control-file" nor "form-control" nor "form-check-input" class when static prop is truthy', () => {
+    const wrapper = shallow(<Input type="file" static />);
+
+    expect(wrapper.hasClass('form-control-file')).toBe(false);
+    expect(wrapper.hasClass('form-control')).toBe(false);
+    expect(wrapper.hasClass('form-check-input')).toBe(false);
+  });
+
+  it('should not render with "form-control-file" nor "form-control-static" nor "form-control" class when type is radio', () => {
+    const wrapper = shallow(<Input type="radio" />);
+
+    expect(wrapper.hasClass('form-control-file')).toBe(false);
+    expect(wrapper.hasClass('form-control-static')).toBe(false);
+    expect(wrapper.hasClass('form-control')).toBe(false);
+  });
+
+  it('should not render with "form-control-file" nor "form-control-static" nor "form-control" class when type is checkbox', () => {
+    const wrapper = shallow(<Input type="checkbox" />);
+
+    expect(wrapper.hasClass('form-control-file')).toBe(false);
+    expect(wrapper.hasClass('form-control-static')).toBe(false);
+    expect(wrapper.hasClass('form-control')).toBe(false);
+  });
+
+  it('should render with "form-check-input" class when type is checkbox', () => {
+    const wrapper = shallow(<Input type="checkbox" />);
+
+    expect(wrapper.hasClass('form-check-input')).toBe(true);
+  });
+
+  it('should render with "form-check-input" class when type is radio', () => {
+    const wrapper = shallow(<Input type="radio" />);
+
+    expect(wrapper.hasClass('form-check-input')).toBe(true);
+  });
+
+  it('should render with "form-control-file" class when type is file', () => {
+    const wrapper = shallow(<Input type="file" />);
+
+    expect(wrapper.hasClass('form-control-file')).toBe(true);
+  });
+
+  it('should render additional classes', () => {
+    const wrapper = shallow(<Input className="other">Yo!</Input>);
+
+    expect(wrapper.hasClass('other')).toBe(true);
+  });
+});

--- a/test/Label.spec.js
+++ b/test/Label.spec.js
@@ -1,0 +1,125 @@
+/* eslint react/no-multi-comp: 0, react/prop-types: 0 */
+import React from 'react';
+import { shallow } from 'enzyme';
+import { Label } from 'reactstrap';
+
+describe('Label', () => {
+  it('should render a label tag by default', () => {
+    const wrapper = shallow(<Label />);
+
+    expect(wrapper.type()).toBe('label');
+  });
+
+  it('should render children', () => {
+    const wrapper = shallow(<Label>Yo!</Label>);
+
+    expect(wrapper.text()).toBe('Yo!');
+  });
+
+  it('should pass additional classNames', () => {
+    const wrapper = shallow(<Label className="extra">Yo!</Label>);
+
+    expect(wrapper.hasClass('extra')).toBe(true);
+  });
+
+  it('should render with "col-form-label" class when a col is provided', () => {
+    const wrapper = shallow(<Label sm="6">Yo!</Label>);
+
+    expect(wrapper.hasClass('col-form-label')).toBe(true);
+  });
+
+  it('should not render with "col-form-label" class when a col is not provided', () => {
+    const wrapper = shallow(<Label>Yo!</Label>);
+
+    expect(wrapper.hasClass('col-form-label')).toBe(false);
+  });
+
+  it('should pass col size specific classes as Strings', () => {
+    const wrapper = shallow(<Label sm="6">Yo!</Label>);
+
+    expect(wrapper.hasClass('col-sm-6')).toBe(true);
+  });
+
+  it('should render with "sr-only" class when hidden prop is truthy', () => {
+    const wrapper = shallow(<Label hidden>Yo!</Label>);
+
+    expect(wrapper.hasClass('sr-only')).toBe(true);
+  });
+
+  it('should render with "form-check-label" class when check prop is truthy and inline is not', () => {
+    const wrapper = shallow(<Label check>Yo!</Label>);
+
+    expect(wrapper.hasClass('form-check-label')).toBe(true);
+  });
+
+  it('should not render with "form-check-inline" class when check prop is truthy and inline is not', () => {
+    const wrapper = shallow(<Label check>Yo!</Label>);
+
+    expect(wrapper.hasClass('form-check-inline')).toBe(false);
+  });
+
+  it('should render with "form-check-inline" class when check and inline props are truthy', () => {
+    const wrapper = shallow(<Label check inline>Yo!</Label>);
+
+    expect(wrapper.hasClass('form-check-inline')).toBe(true);
+  });
+
+  it('should not render with "form-check-inline" class when check and inline props are truthy', () => {
+    const wrapper = shallow(<Label check inline>Yo!</Label>);
+
+    expect(wrapper.hasClass('form-check-label')).toBe(false);
+  });
+
+  it('should not render with "form-check-inline" class when inline prop is truthy and check is not', () => {
+    const wrapper = shallow(<Label inline>Yo!</Label>);
+
+    expect(wrapper.hasClass('form-check-inline')).toBe(false);
+  });
+
+  it('should not render with "form-check-inline" nor "form-check-label" by default', () => {
+    const wrapper = shallow(<Label>Yo!</Label>);
+
+    expect(wrapper.hasClass('form-check-inline')).toBe(false);
+    expect(wrapper.hasClass('form-check-label')).toBe(false);
+  });
+
+  it('should render with "col-form-label-${size}" class when size is provided', () => {
+    const wrapper = shallow(<Label size="lg">Yo!</Label>);
+
+    expect(wrapper.hasClass('col-form-label-lg')).toBe(true);
+  });
+
+  it('should pass col size specific classes as Numbers', () => {
+    const wrapper = shallow(<Label sm={6}>Yo!</Label>);
+
+    expect(wrapper.hasClass('col-sm-6')).toBe(true);
+  });
+
+  it('should pass col size specific classes via Objects', () => {
+    const wrapper = shallow(<Label sm={{ size: 6, push: 2, pull: 2, offset: 2 }}>Yo!</Label>);
+
+    expect(wrapper.hasClass('col-sm-6')).toBe(true);
+    expect(wrapper.hasClass('push-sm-2')).toBe(true);
+    expect(wrapper.hasClass('pull-sm-2')).toBe(true);
+    expect(wrapper.hasClass('offset-sm-2')).toBe(true);
+  });
+
+  it('should pass multiple col size specific classes via Objects', () => {
+    const wrapper = shallow(<Label sm={{ size: 6, push: 2, pull: 2, offset: 2 }} md={{ size: 7, push: 1, pull: 1, offset: 1 }}>Yo!</Label>);
+
+    expect(wrapper.hasClass('col-sm-6')).toBe(true);
+    expect(wrapper.hasClass('push-sm-2')).toBe(true);
+    expect(wrapper.hasClass('pull-sm-2')).toBe(true);
+    expect(wrapper.hasClass('offset-sm-2')).toBe(true);
+    expect(wrapper.hasClass('col-md-7')).toBe(true);
+    expect(wrapper.hasClass('push-md-1')).toBe(true);
+    expect(wrapper.hasClass('pull-md-1')).toBe(true);
+    expect(wrapper.hasClass('offset-md-1')).toBe(true);
+  });
+
+  it('should render custom tag', () => {
+    const wrapper = shallow(<Label tag="main">Yo!</Label>);
+
+    expect(wrapper.type()).toBe('main');
+  });
+});

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -20,6 +20,7 @@ var paths = [
   '/components/button-toolbar/',
   '/components/button-dropdown/',
   '/components/dropdowns/',
+  '/components/form/',
   '/components/popovers/',
   '/components/tooltips/',
   '/components/modals/',


### PR DESCRIPTION
#50 
Forms and form element components as well as docs and tests including:

- Form
- FormGroup
- FormFeedback
- FormText
- Input
- Label

What this **doesn't** include for forms:

- [input-group and input-group-addon](http://v4-alpha.getbootstrap.com/components/forms/#hidden-labels)
- something about grouping [radio and checks](http://v4-alpha.getbootstrap.com/components/forms/#checkboxes-and-radios) (this seems like something twbs is changing in v4 (new `.form-check` vs `.radio` and `.check`) half of their docs use or the other)
- [custom forms](http://v4-alpha.getbootstrap.com/components/forms/#custom-forms) (Is this new to bs4, don't think I have seen this before)
- fieldsets (doesn't seem like it would be useful since everything would just pass right though `<Fieldset disabled>` -> `<fieldset disabled>`

Also, these are the basic building block components, there are no helper/wrapping components (like a single component which will build out a form group with a label and an input for you.) The helper/wrapping components can utilize these, if you determine this library should have such components (in which case, let me know and I can add them).

I did the best I could with docs, there are a lot of examples which shows everything, but not everything has a dedicated section.
