### PR TITLE
fix(docs): update path to allow direct loading of the tags doc page

### DIFF
--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -23,7 +23,7 @@ var paths = [
   '/components/popovers/',
   '/components/tooltips/',
   '/components/modals/',
-  '/components/labels/',
+  '/components/tags/',
   '/components/card/',
   '/components/tables/',
   '/404.html'


### PR DESCRIPTION
When running localhost / dev webpack, the tags route cannot be navigated to directly (or reloaded). This is because I missed a reference when updating labels to tags. This PR fixes that.