### PR TITLE
chore(package.json): update eslint version to match airbnb peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "css-loader": "^0.23.1",
     "ejs": "^2.4.1",
     "enzyme": "^2.4.1",
-    "eslint": "^3.0.1",
+    "eslint": "^2.13.1",
     "eslint-config-airbnb": "^9.0.0",
     "eslint-plugin-import": "^1.7.0",
     "eslint-plugin-jsx-a11y": "^1.2.0",


### PR DESCRIPTION
Tiny fix to remove the following warning:

```
npm WARN eslint-config-airbnb@9.0.1 requires a peer of eslint@^2.9.0 but none was installed.
npm WARN eslint-config-airbnb-base@3.0.1 requires a peer of eslint@^2.9.0 but none was installed.
```
