### PR TITLE
feat(Card): fix image class

### DIFF
--- a/docs/lib/examples/CardContentTypes.jsx
+++ b/docs/lib/examples/CardContentTypes.jsx
@@ -10,7 +10,7 @@ const Example = (props) => {
           <CardTitle>Card title</CardTitle>
           <CardSubtitle>Card subtitle</CardSubtitle>
         </CardBlock>
-        <CardImg top width="100%" src="https://placeholdit.imgix.net/~text?txtsize=33&txt=318%C3%97180&w=318&h=180" alt="Card image cap" />
+        <img width="100%" src="https://placeholdit.imgix.net/~text?txtsize=33&txt=318%C3%97180&w=318&h=180" alt="Card image cap" />
         <CardBlock>
           <CardText>Some quick example text to build on the card title and make up the bulk of the card's content.</CardText>
           <CardLink href="#">Card Link</CardLink>

--- a/src/CardImg.jsx
+++ b/src/CardImg.jsx
@@ -20,11 +20,18 @@ const CardImg = (props) => {
     tag: Tag,
     ...attributes
   } = props;
+
+  let cardImgClassName = 'card-img';
+  if (top) {
+    cardImgClassName = 'card-img-top';
+  }
+  if (bottom) {
+    cardImgClassName = 'card-img-bottom';
+  }
+
   const classes = classNames(
     className,
-    'card-img',
-    top ? 'card-img-top' : false,
-    bottom ? 'card-img-bottom' : false
+    cardImgClassName
   );
 
   return (


### PR DESCRIPTION
Minor fix for card image border radius.

Note that a card image should have one of `card-img`, `card-img-top`, or `card-img-bottom` (this is a Bootstrap inconsistency).

Also, when a card image is in the middle of a card, a plain image is used in the Bootstrap example. We may still want to use CardImg here, but ensure no classes are applied.