### PR TITLE
feat(Media): add component

### DIFF
--- a/docs/lib/Components/MediaPage.jsx
+++ b/docs/lib/Components/MediaPage.jsx
@@ -1,0 +1,81 @@
+/* eslint react/no-multi-comp: 0, react/prop-types: 0 */
+import React from 'react';
+import { PrismCode } from 'react-prism';
+import Helmet from 'react-helmet';
+
+import MediaExample from '../examples/Media';
+const MediaExampleSource = require('!!raw!../examples/Media.jsx');
+
+import MediaNestedExample from '../examples/MediaNested';
+const MediaNestedExampleSource = require('!!raw!../examples/MediaNested.jsx');
+
+import MediaAlignmentExample from '../examples/MediaAlignment';
+const MediaAlignmentExampleSource = require('!!raw!../examples/MediaAlignment.jsx');
+
+import MediaListExample from '../examples/MediaList';
+const MediaListExampleSource = require('!!raw!../examples/MediaList.jsx');
+
+export default class MediaPage extends React.Component {
+  render() {
+    return (
+      <div>
+        <Helmet title="Media object" />
+        <h3>Media object</h3>
+        <div className="docs-example">
+          <MediaExample />
+        </div>
+        <pre>
+          <PrismCode className="language-jsx">
+            {MediaExampleSource}
+          </PrismCode>
+        </pre>
+        <h4>Properties</h4>
+        <pre>
+          <PrismCode className="language-jsx">
+{`Media.propTypes = {
+  body: PropTypes.bool,
+  bottom: PropTypes.bool,
+  children: PropTypes.node,
+  className: PropTypes.string,
+  heading: PropTypes.bool,
+  left: PropTypes.bool,
+  list: PropTypes.bool,
+  middle: PropTypes.bool,
+  object: PropTypes.bool,
+  right: PropTypes.bool,
+  tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  top: PropTypes.bool,
+};`}
+          </PrismCode>
+        </pre>
+        <h4>Nesting</h4>
+        <div className="docs-example">
+          <MediaNestedExample />
+        </div>
+        <pre>
+          <PrismCode className="language-jsx">
+            {MediaNestedExampleSource}
+          </PrismCode>
+        </pre>
+        <h4>Alignment</h4>
+        <div className="docs-example">
+          <MediaAlignmentExample />
+        </div>
+        <pre>
+          <PrismCode className="language-jsx">
+            {MediaAlignmentExampleSource}
+          </PrismCode>
+        </pre>
+        <h4>Media list</h4>
+        <div className="docs-example">
+          <MediaListExample />
+        </div>
+        <pre>
+          <PrismCode className="language-jsx">
+            {MediaListExampleSource}
+          </PrismCode>
+        </pre>
+      </div>
+    );
+  }
+}

--- a/docs/lib/Components/index.jsx
+++ b/docs/lib/Components/index.jsx
@@ -83,6 +83,10 @@ class Components extends React.Component {
           name: 'Tables',
           to: '/components/tables/'
         },
+        {
+          name: 'Media',
+          to: '/components/media/'
+        },
       ]
     };
   }

--- a/docs/lib/app.jsx
+++ b/docs/lib/app.jsx
@@ -14,7 +14,26 @@ if (typeof document !== 'undefined') {
     window.ga('set', 'page', location.pathname);
     window.ga('send', 'pageview');
   });
-  ReactDOM.render(<Router onUpdate={() => window.scrollTo(0, 0)} history={browserHistory} routes={routes} />, outlet);
+
+  let Holder;
+  window.addEventListener('DOMContentLoaded', () => {
+    Holder = require('holderjs');
+  });
+
+  ReactDOM.render(
+    <Router
+      onUpdate={() => {
+        window.scrollTo(0, 0);
+
+        if (Holder) {
+          Holder.run();
+        }
+      }}
+      history={browserHistory}
+      routes={routes}
+    />,
+    outlet
+  );
 }
 
 // Exported static site renderer:

--- a/docs/lib/examples/Media.jsx
+++ b/docs/lib/examples/Media.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Media } from 'reactstrap';
+
+const Example = () => {
+  return (
+    <Media>
+      <Media left href="#">
+        <Media object data-src="holder.js/64x64" alt="Generic placeholder image" />
+      </Media>
+      <Media body>
+        <Media heading>
+          Media heading
+        </Media>
+        Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin commodo. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis. Fusce condimentum nunc ac nisi vulputate fringilla. Donec lacinia congue felis in faucibus.
+      </Media>
+    </Media>
+  );
+};
+
+export default Example;

--- a/docs/lib/examples/MediaAlignment.jsx
+++ b/docs/lib/examples/MediaAlignment.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Media } from 'reactstrap';
+
+const Example = () => {
+  return (
+    <div>
+      <Media>
+        <Media left top href="#">
+          <Media object data-src="holder.js/64x64" alt="Generic placeholder image" />
+        </Media>
+        <Media body>
+          <Media heading>
+            Top aligned media
+          </Media>
+          Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin commodo. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis. Fusce condimentum nunc ac nisi vulputate fringilla. Donec lacinia congue felis in faucibus.
+        </Media>
+      </Media>
+      <Media className="m-t-1">
+        <Media left middle href="#">
+          <Media object data-src="holder.js/64x64" alt="Generic placeholder image" />
+        </Media>
+        <Media body>
+          <Media heading>
+            Middle aligned media
+          </Media>
+          Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin commodo. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis. Fusce condimentum nunc ac nisi vulputate fringilla. Donec lacinia congue felis in faucibus.
+        </Media>
+      </Media>
+      <Media className="m-t-1">
+        <Media left bottom href="#">
+          <Media object data-src="holder.js/64x64" alt="Generic placeholder image" />
+        </Media>
+        <Media body>
+          <Media heading>
+            Bottom aligned media
+          </Media>
+          Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin commodo. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis. Fusce condimentum nunc ac nisi vulputate fringilla. Donec lacinia congue felis in faucibus.
+        </Media>
+      </Media>
+    </div>
+  );
+};
+
+export default Example;

--- a/docs/lib/examples/MediaList.jsx
+++ b/docs/lib/examples/MediaList.jsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { Media } from 'reactstrap';
+
+const Example = () => {
+  return (
+    <Media list>
+      <Media tag="li">
+        <Media left href="#">
+          <Media object data-src="holder.js/64x64" alt="Generic placeholder image" />
+        </Media>
+        <Media body>
+          <Media heading>
+            Media heading
+          </Media>
+          Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin commodo. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis. Fusce condimentum nunc ac nisi vulputate fringilla. Donec lacinia congue felis in faucibus.
+          <Media>
+            <Media left href="#">
+              <Media object data-src="holder.js/64x64" alt="Generic placeholder image" />
+            </Media>
+            <Media body>
+              <Media heading>
+                Nested media heading
+              </Media>
+              Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin commodo. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis. Fusce condimentum nunc ac nisi vulputate fringilla. Donec lacinia congue felis in faucibus.
+              <Media>
+                <Media left href="#">
+                  <Media object data-src="holder.js/64x64" alt="Generic placeholder image" />
+                </Media>
+                <Media body>
+                  <Media heading>
+                    Nested media heading
+                  </Media>
+                  Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin commodo. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis. Fusce condimentum nunc ac nisi vulputate fringilla. Donec lacinia congue felis in faucibus.
+                </Media>
+              </Media>
+            </Media>
+          </Media>
+          <Media>
+            <Media left href="#">
+              <Media object data-src="holder.js/64x64" alt="Generic placeholder image" />
+            </Media>
+            <Media body>
+              <Media heading>
+                Nested media heading
+              </Media>
+              Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin commodo. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis. Fusce condimentum nunc ac nisi vulputate fringilla. Donec lacinia congue felis in faucibus.
+            </Media>
+          </Media>
+        </Media>
+      </Media>
+      <Media tag="li">
+        <Media body>
+          <Media heading>
+            Media heading
+          </Media>
+          Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin commodo. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis. Fusce condimentum nunc ac nisi vulputate fringilla. Donec lacinia congue felis in faucibus.
+        </Media>
+        <Media right href="#">
+          <Media object data-src="holder.js/64x64" alt="Generic placeholder image" />
+        </Media>
+      </Media>
+    </Media>
+  );
+};
+
+export default Example;

--- a/docs/lib/examples/MediaNested.jsx
+++ b/docs/lib/examples/MediaNested.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Media } from 'reactstrap';
+
+const Example = () => {
+  return (
+    <Media>
+      <Media left href="#">
+        <Media object data-src="holder.js/64x64" alt="Generic placeholder image" />
+      </Media>
+      <Media body>
+        <Media heading>
+          Media heading
+        </Media>
+        Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin commodo. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis. Fusce condimentum nunc ac nisi vulputate fringilla. Donec lacinia congue felis in faucibus.
+        <Media>
+          <Media left href="#">
+            <Media object data-src="holder.js/64x64" alt="Generic placeholder image" />
+          </Media>
+          <Media body>
+            <Media heading>
+              Nested media heading
+            </Media>
+            Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin commodo. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis. Fusce condimentum nunc ac nisi vulputate fringilla. Donec lacinia congue felis in faucibus.
+          </Media>
+        </Media>
+      </Media>
+    </Media>
+  );
+};
+
+export default Example;

--- a/docs/lib/routes.jsx
+++ b/docs/lib/routes.jsx
@@ -14,6 +14,7 @@ import InputGroupPage from './Components/InputGroupPage';
 import PopoversPage from './Components/PopoversPage';
 import TooltipsPage from './Components/TooltipsPage';
 import TagsPage from './Components/TagsPage';
+import MediaPage from './Components/MediaPage';
 import ModalsPage from './Components/ModalsPage';
 import CardPage from './Components/CardPage';
 import TablesPage from './Components/TablesPage';
@@ -42,6 +43,7 @@ const routes = (
       <Route path="layout/" component={LayoutPage} />
       <Route path="navs/" component={NavsPage} />
       <Route path="navbar/" component={NavbarPage} />
+      <Route path="media/" component={MediaPage} />
     </Route>
     <Route path="*" component={NotFound} />
   </Route>

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "eslint-plugin-standard": "^2.0.0",
     "extract-text-webpack-plugin": "^1.0.1",
     "history": "^3.0.0",
+    "holderjs": "^2.9.3",
     "jasmine-core": "^2.4.1",
     "json-loader": "^0.5.4",
     "karma": "^1.1.2",

--- a/src/Media.jsx
+++ b/src/Media.jsx
@@ -1,0 +1,72 @@
+import React, { PropTypes } from 'react';
+import classNames from 'classnames';
+
+const propTypes = {
+  body: PropTypes.bool,
+  bottom: PropTypes.bool,
+  children: PropTypes.node,
+  className: PropTypes.string,
+  heading: PropTypes.bool,
+  left: PropTypes.bool,
+  list: PropTypes.bool,
+  middle: PropTypes.bool,
+  object: PropTypes.bool,
+  right: PropTypes.bool,
+  tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  top: PropTypes.bool,
+};
+
+const Media = (props) => {
+  const {
+    body,
+    bottom,
+    className,
+    heading,
+    left,
+    list,
+    middle,
+    object,
+    right,
+    tag,
+    top,
+    ...attributes,
+  } = props;
+
+  let defaultTag;
+  if (heading) {
+    defaultTag = 'h4';
+  } else if (left || right) {
+    defaultTag = 'a';
+  } else if (object) {
+    defaultTag = 'img';
+  } else if (list) {
+    defaultTag = 'ul';
+  } else {
+    defaultTag = 'div';
+  }
+  const Tag = tag || defaultTag;
+
+  const classes = classNames(
+    className,
+    {
+      'media-body': body,
+      'media-heading': heading,
+      'media-left': left,
+      'media-right': right,
+      'media-top': top,
+      'media-bottom': bottom,
+      'media-middle': middle,
+      'media-object': object,
+      'media-list': list,
+      media: !body && !heading && !left && !right && !top && !bottom && !middle && !object && !list,
+    }
+  );
+
+  return (
+    <Tag {...attributes} className={classes} />
+  );
+};
+
+Media.propTypes = propTypes;
+
+export default Media;

--- a/src/index.js
+++ b/src/index.js
@@ -53,6 +53,7 @@ import InputGroup from './InputGroup';
 import InputGroupAddon from './InputGroupAddon';
 import InputGroupButton from './InputGroupButton';
 import Label from './Label';
+import Media from './Media';
 
 export {
   Container,
@@ -110,4 +111,5 @@ export {
   InputGroupAddon,
   InputGroupButton,
   Label,
+  Media,
 };

--- a/test/Media.spec.js
+++ b/test/Media.spec.js
@@ -1,0 +1,131 @@
+/* eslint react/no-multi-comp: 0, react/prop-types: 0 */
+import React from 'react';
+import { shallow } from 'enzyme';
+import { Media } from 'reactstrap';
+
+describe('Media', () => {
+  it('should render a div tag by default', () => {
+    const wrapper = shallow(<Media />);
+
+    expect(wrapper.type()).toBe('div');
+  });
+
+  it('should render an h4 tag by default for heading', () => {
+    const wrapper = shallow(<Media heading />);
+
+    expect(wrapper.type()).toBe('h4');
+  });
+
+  it('should render an a tag by default for left', () => {
+    const wrapper = shallow(<Media left />);
+
+    expect(wrapper.type()).toBe('a');
+  });
+
+  it('should render an a tag by default for right', () => {
+    const wrapper = shallow(<Media right />);
+
+    expect(wrapper.type()).toBe('a');
+  });
+
+  it('should render an img tag by default for object', () => {
+    const wrapper = shallow(<Media object />);
+
+    expect(wrapper.type()).toBe('img');
+  });
+
+  it('should render a ul tag by default for list', () => {
+    const wrapper = shallow(<Media list />);
+
+    expect(wrapper.type()).toBe('ul');
+  });
+
+  it('should pass additional classNames', () => {
+    const wrapper = shallow(<Media className="extra" />);
+
+    expect(wrapper.hasClass('extra')).toBe(true);
+  });
+
+  it('should render custom tag', () => {
+    const wrapper = shallow(<Media tag="main" />);
+
+    expect(wrapper.type()).toBe('main');
+  });
+
+  it('should render body', () => {
+    const wrapper = shallow(<Media body />);
+
+    expect(wrapper.hasClass('media-body')).toBe(true);
+  });
+
+  it('should render heading', () => {
+    const wrapper = shallow(<Media heading />);
+
+    expect(wrapper.hasClass('media-heading')).toBe(true);
+  });
+
+  it('should render left', () => {
+    const wrapper = shallow(<Media left />);
+
+    expect(wrapper.hasClass('media-left')).toBe(true);
+  });
+
+  it('should render right', () => {
+    const wrapper = shallow(<Media right />);
+
+    expect(wrapper.hasClass('media-right')).toBe(true);
+  });
+
+  it('should render top', () => {
+    const wrapper = shallow(<Media top />);
+
+    expect(wrapper.hasClass('media-top')).toBe(true);
+  });
+
+  it('should render bottom', () => {
+    const wrapper = shallow(<Media bottom />);
+
+    expect(wrapper.hasClass('media-bottom')).toBe(true);
+  });
+
+  it('should render middle', () => {
+    const wrapper = shallow(<Media middle />);
+
+    expect(wrapper.hasClass('media-middle')).toBe(true);
+  });
+
+  it('should render object', () => {
+    const wrapper = shallow(<Media object />);
+
+    expect(wrapper.hasClass('media-object')).toBe(true);
+  });
+
+  it('should render media', () => {
+    const wrapper = shallow(<Media />);
+
+    expect(wrapper.hasClass('media')).toBe(true);
+  });
+
+  it('should render list', () => {
+    const wrapper = shallow(
+      <Media list>
+        <Media tag="li" />
+        <Media tag="li" />
+        <Media tag="li" />
+      </Media>
+    );
+
+    expect(wrapper.hasClass('media-list')).toBe(true);
+    expect(wrapper.find({ tag: 'li' }).length).toBe(3);
+  });
+
+  it('should render children', () => {
+    const wrapper = shallow(
+      <Media>
+        <Media body />
+      </Media>
+    );
+
+    expect(wrapper.find({ body: true }).length).toBe(1);
+  });
+});

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -29,6 +29,7 @@ var paths = [
   '/components/tags/',
   '/components/card/',
   '/components/tables/',
+  '/components/media/',
   '/404.html'
 ];
 
@@ -66,7 +67,7 @@ var config = [{
   module: {
     loaders: [
       {
-        test: /\.(json)$/,
+        test: /\.json$/,
         loaders: [
           'json-loader?cacheDirectory'
         ]


### PR DESCRIPTION
References #75

Notes
- The media components are fairly lightweight (almost single class). This is particularly true for `MediaHeading` and `MediaObject`.
- I'm using `MediaMarginal` for shared code between `MediaLeft` and `MediaRight`. It's not intended for direct use by users, but is exposed so we can test it.
- In `MediaList`, I'm applying `tag="li"` to the children. This way, the user of `MediaList` doesn't have to specify `li` on each `Media` item.
- I'm using [Holder](http://holderjs.com) to populate placeholder images, similar to the Bootstrap docs. Also, I had to rerun Holder on route update. Without this, if the user goes to `/components/media`, then `/components/buttons`, then hits back, the placeholder image isn't populated.
