### PR TITLE
feat(inputGroup): add InputGroup

### DIFF
--- a/docs/lib/Components/InputGroupPage.jsx
+++ b/docs/lib/Components/InputGroupPage.jsx
@@ -1,0 +1,126 @@
+/* eslint react/no-multi-comp: 0, react/prop-types: 0 */
+import React from 'react';
+import { PrismCode } from 'react-prism';
+import Helmet from 'react-helmet';
+import OverviewExample from '../examples/InputGroupOverview';
+const OverviewExampleSource = require('!!raw!../examples/InputGroupOverview.jsx');
+import AddonExample from '../examples/InputGroupAddon';
+const AddonExampleSource = require('!!raw!../examples/InputGroupAddon.jsx');
+import AddonSizingExample from '../examples/InputGroupSizing';
+const AddonSizingExampleSource = require('!!raw!../examples/InputGroupSizing.jsx');
+import ButtonExample from '../examples/InputGroupButton';
+const ButtonExampleSource = require('!!raw!../examples/InputGroupButton.jsx');
+import ButtonShorthandExample from '../examples/InputGroupButtonShorthand';
+const ButtonShorthandExampleSource = require('!!raw!../examples/InputGroupButtonShorthand.jsx');
+
+export default class InputGroupPage extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.toggle = this.toggle.bind(this);
+    this.state = {
+      dropdownOpen: false
+    };
+  }
+
+  toggle() {
+    this.setState({
+      dropdownOpen: !this.state.dropdownOpen
+    });
+  }
+
+  render() {
+    return (
+      <div>
+        <Helmet title="Input Group" />
+        <h3>Input Group</h3>
+        <div className="docs-example">
+          <OverviewExample />
+        </div>
+        <pre>
+          <PrismCode className="language-jsx">
+            {OverviewExampleSource}
+          </PrismCode>
+        </pre>
+        <h4>Properties</h4>
+        <pre>
+          <PrismCode className="language-jsx">
+{`InputGroup.propTypes = {
+  tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  size: PropTypes.string,
+  className: PropTypes.any
+};
+
+InputGroupAddOn.propTypes = {
+  tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  className: PropTypes.any
+};
+
+InputGroupButton.propTypes = {
+  tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  children: PropTypes.node,
+  groupClassName: PropTypes.any, // only used in shorthand
+  groupAttributes: PropTypes.object, // only used in shorthand
+  className: PropTypes.any
+};`}
+          </PrismCode>
+        </pre>
+        <h3>Addons</h3>
+        <div className="docs-example">
+          <div>
+            <AddonExample />
+          </div>
+        </div>
+        <pre>
+          <PrismCode className="language-jsx">
+            {AddonExampleSource}
+          </PrismCode>
+        </pre>
+
+        <h3>Addon Sizing</h3>
+        <div className="docs-example">
+          <div>
+            <AddonSizingExample />
+          </div>
+        </div>
+        <pre>
+          <PrismCode className="language-jsx">
+            {AddonSizingExampleSource}
+          </PrismCode>
+        </pre>
+
+        <h3>Buttons / Dropdowns</h3>
+        <div className="docs-example">
+          <div>
+            <ButtonExample />
+          </div>
+        </div>
+        <pre>
+          <PrismCode className="language-jsx">
+            {ButtonExampleSource}
+          </PrismCode>
+        </pre>
+
+        <h3>Button Shorthand</h3>
+        <p>
+          Button shorthand is a convenience method for adding just a button. It is triggered when only a single string
+          is the child. A Button will be created and all of the props will be passed to it with the exception of
+          <code>groupClassName</code> and <code>groupAttributes</code>, which are used to added classes and attributes
+          to the wrapping container. This means you can add your <code>onClick</code> and other handlers directly to
+          <code>InputGroupButton</code>. If you want your string to not be wrapped in a button, then you really want to
+          use <code>InputGroupAddon</code> (see Addons above for that).
+        </p>
+        <div className="docs-example">
+          <div>
+            <ButtonShorthandExample />
+          </div>
+        </div>
+        <pre>
+          <PrismCode className="language-jsx">
+            {ButtonShorthandExampleSource}
+          </PrismCode>
+        </pre>
+      </div>
+    );
+  }
+}

--- a/docs/lib/Components/index.jsx
+++ b/docs/lib/Components/index.jsx
@@ -40,6 +40,10 @@ class Components extends React.Component {
           to: '/components/form/'
         },
         {
+          name: 'Input Group',
+          to: '/components/input-group/'
+        },
+        {
           name: 'Breadscrumbs',
           to: '/components/breadcrumbs/'
         },

--- a/docs/lib/examples/InputGroupAddon.jsx
+++ b/docs/lib/examples/InputGroupAddon.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { InputGroup, InputGroupAddon, Input } from 'reactstrap';
+
+const Example = (props) => {
+  return (
+    <div>
+      <InputGroup>
+        <InputGroupAddon>To the Left!</InputGroupAddon>
+        <Input />
+      </InputGroup>
+      <br />
+      <InputGroup>
+        <Input />
+        <InputGroupAddon>To the Right!</InputGroupAddon>
+      </InputGroup>
+      <br />
+      <InputGroup>
+        <InputGroupAddon>To the Left!</InputGroupAddon>
+        <Input placeholder="and..." />
+        <InputGroupAddon>To the Right!</InputGroupAddon>
+      </InputGroup>
+    </div>
+  );
+};
+
+export default Example;

--- a/docs/lib/examples/InputGroupButton.jsx
+++ b/docs/lib/examples/InputGroupButton.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { InputGroup, InputGroupButton, Input, Button } from 'reactstrap';
+import ButtonDropdownExample from './ButtonDropdown';
+
+const Example = (props) => {
+  return (
+    <div>
+      <InputGroup>
+        <InputGroupButton><Button>I'm a button</Button></InputGroupButton>
+        <Input />
+      </InputGroup>
+      <br />
+      <InputGroup>
+        <Input />
+        <InputGroupButton><ButtonDropdownExample /></InputGroupButton>
+      </InputGroup>
+      <br />
+      <InputGroup>
+        <InputGroupButton><ButtonDropdownExample /></InputGroupButton>
+        <Input placeholder="and..." />
+        <InputGroupButton><Button color="secondary">I'm a button</Button></InputGroupButton>
+      </InputGroup>
+    </div>
+  );
+};
+
+export default Example;

--- a/docs/lib/examples/InputGroupButtonShorthand.jsx
+++ b/docs/lib/examples/InputGroupButtonShorthand.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { InputGroup, InputGroupButton, Input } from 'reactstrap';
+
+const Example = (props) => {
+  return (
+    <div>
+      <InputGroup>
+        <InputGroupButton>To the Left!</InputGroupButton>
+        <Input />
+      </InputGroup>
+      <br />
+      <InputGroup>
+        <Input />
+        <InputGroupButton color="secondary">To the Right!</InputGroupButton>
+      </InputGroup>
+      <br />
+      <InputGroup>
+        <InputGroupButton color="danger">To the Left!</InputGroupButton>
+        <Input placeholder="and..." />
+        <InputGroupButton color="success">To the Right!</InputGroupButton>
+      </InputGroup>
+    </div>
+  );
+};
+
+export default Example;

--- a/docs/lib/examples/InputGroupOverview.jsx
+++ b/docs/lib/examples/InputGroupOverview.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { InputGroup, InputGroupAddon, Input } from 'reactstrap';
+
+const Example = (props) => {
+  return (
+    <div>
+      <InputGroup>
+        <InputGroupAddon>@</InputGroupAddon>
+        <Input placeholder="username" />
+      </InputGroup>
+      <br />
+      <InputGroup>
+        <InputGroupAddon>
+          <Input addon type="checkbox" aria-label="Checkbox for following text input" />
+        </InputGroupAddon>
+        <Input placeholder="Check it out" />
+      </InputGroup>
+      <br />
+      <InputGroup>
+        <Input placeholder="username" />
+        <InputGroupAddon>@example.com</InputGroupAddon>
+      </InputGroup>
+      <br />
+      <InputGroup>
+        <InputGroupAddon>$</InputGroupAddon>
+        <InputGroupAddon>$</InputGroupAddon>
+        <Input placeholder="Dolla dolla billz yo!" />
+        <InputGroupAddon>$</InputGroupAddon>
+        <InputGroupAddon>$</InputGroupAddon>
+      </InputGroup>
+      <br />
+      <InputGroup>
+        <InputGroupAddon>$</InputGroupAddon>
+        <Input placeholder="Amount" type="number" step="1" />
+        <InputGroupAddon>.00</InputGroupAddon>
+      </InputGroup>
+    </div>
+  );
+};
+
+export default Example;

--- a/docs/lib/examples/InputGroupSizing.jsx
+++ b/docs/lib/examples/InputGroupSizing.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { InputGroup, InputGroupAddon, Input } from 'reactstrap';
+
+const Example = (props) => {
+  return (
+    <div>
+      <InputGroup size="lg">
+        <InputGroupAddon>@lg</InputGroupAddon>
+        <Input />
+      </InputGroup>
+      <br />
+      <InputGroup>
+        <InputGroupAddon>@normal</InputGroupAddon>
+        <Input />
+      </InputGroup>
+      <br />
+      <InputGroup size="sm">
+        <InputGroupAddon>@sm</InputGroupAddon>
+        <Input />
+      </InputGroup>
+    </div>
+  );
+};
+
+export default Example;

--- a/docs/lib/routes.jsx
+++ b/docs/lib/routes.jsx
@@ -10,6 +10,7 @@ import ButtonGroupPage from './Components/ButtonGroupPage';
 import ButtonDropdownPage from './Components/ButtonDropdownPage';
 import DropdownsPage from './Components/DropdownsPage';
 import FormPage from './Components/FormPage';
+import InputGroupPage from './Components/InputGroupPage';
 import PopoversPage from './Components/PopoversPage';
 import TooltipsPage from './Components/TooltipsPage';
 import TagsPage from './Components/TagsPage';
@@ -31,6 +32,7 @@ const routes = (
       <Route path="button-dropdown/" component={ButtonDropdownPage} />
       <Route path="dropdowns/" component={DropdownsPage} />
       <Route path="form/" component={FormPage} />
+      <Route path="input-group/" component={InputGroupPage} />
       <Route path="popovers/" component={PopoversPage} />
       <Route path="tooltips/" component={TooltipsPage} />
       <Route path="tags/" component={TagsPage} />

--- a/src/Input.jsx
+++ b/src/Input.jsx
@@ -8,6 +8,7 @@ const propTypes = {
   state: PropTypes.string,
   tag: PropTypes.string,
   static: PropTypes.bool,
+  addon: PropTypes.bool,
   className: PropTypes.string,
 };
 
@@ -23,6 +24,7 @@ const Input = (props) => {
     size,
     state,
     tag,
+    addon,
     static: staticInput,
     ...attributes,
   } = props;
@@ -42,7 +44,11 @@ const Input = (props) => {
   } else if (fileInput) {
     formControlClass = `${formControlClass}-file`;
   } else if (checkInput) {
-    formControlClass = 'form-check-input';
+    if (addon) {
+      formControlClass = null;
+    } else {
+      formControlClass = 'form-check-input';
+    }
   }
 
   const classes = classNames(

--- a/src/InputGroup.jsx
+++ b/src/InputGroup.jsx
@@ -1,0 +1,35 @@
+import React, { PropTypes } from 'react';
+import classNames from 'classnames';
+
+const propTypes = {
+  tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  size: PropTypes.string,
+  className: PropTypes.any
+};
+
+const defaultProps = {
+  tag: 'div'
+};
+
+const InputGroup = (props) => {
+  const {
+    className,
+    tag: Tag,
+    size,
+    ...attributes
+  } = props;
+  const classes = classNames(
+    className,
+    'input-group',
+    size ? `input-group-${size}` : null
+  );
+
+  return (
+    <Tag {...attributes} className={classes} />
+  );
+};
+
+InputGroup.propTypes = propTypes;
+InputGroup.defaultProps = defaultProps;
+
+export default InputGroup;

--- a/src/InputGroupAddon.jsx
+++ b/src/InputGroupAddon.jsx
@@ -1,0 +1,32 @@
+import React, { PropTypes } from 'react';
+import classNames from 'classnames';
+
+const propTypes = {
+  tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  className: PropTypes.any
+};
+
+const defaultProps = {
+  tag: 'div'
+};
+
+const InputGroupAddon = (props) => {
+  const {
+    className,
+    tag: Tag,
+    ...attributes
+  } = props;
+  const classes = classNames(
+    className,
+    'input-group-addon'
+  );
+
+  return (
+    <Tag {...attributes} className={classes} />
+  );
+};
+
+InputGroupAddon.propTypes = propTypes;
+InputGroupAddon.defaultProps = defaultProps;
+
+export default InputGroupAddon;

--- a/src/InputGroupButton.jsx
+++ b/src/InputGroupButton.jsx
@@ -1,0 +1,53 @@
+import React, { PropTypes } from 'react';
+import classNames from 'classnames';
+import Button from './Button';
+
+const propTypes = {
+  tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  children: PropTypes.node,
+  groupClassName: PropTypes.any,
+  groupAttributes: PropTypes.object,
+  className: PropTypes.any
+};
+
+const defaultProps = {
+  tag: 'div'
+};
+
+const InputGroupButton = (props) => {
+  let {
+    className,
+    tag: Tag,
+    children,
+    groupClassName,
+    groupAttributes,
+    ...attributes
+  } = props;
+
+  if (typeof children === 'string') {
+    const groupClasses = classNames(
+      groupClassName,
+      'input-group-btn'
+    );
+
+    return (
+      <Tag {...groupAttributes} className={groupClasses}>
+        <Button {...attributes} className={className} children={children} />
+      </Tag>
+    );
+  }
+
+  const classes = classNames(
+    className,
+    'input-group-btn'
+  );
+
+  return (
+    <Tag {...attributes} className={classes} children={children} />
+  );
+};
+
+InputGroupButton.propTypes = propTypes;
+InputGroupButton.defaultProps = defaultProps;
+
+export default InputGroupButton;

--- a/src/index.js
+++ b/src/index.js
@@ -49,6 +49,9 @@ import FormFeedback from './FormFeedback';
 import FormGroup from './FormGroup';
 import FormText from './FormText';
 import Input from './Input';
+import InputGroup from './InputGroup';
+import InputGroupAddon from './InputGroupAddon';
+import InputGroupButton from './InputGroupButton';
 import Label from './Label';
 
 export {
@@ -103,5 +106,8 @@ export {
   FormGroup,
   FormText,
   Input,
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
   Label,
 };

--- a/test/Input.spec.js
+++ b/test/Input.spec.js
@@ -133,6 +133,20 @@ describe('Input', () => {
     expect(wrapper.hasClass('form-check-input')).toBe(true);
   });
 
+  it('should not render with "form-check-input" nor "form-control" class when type is checkbox and addon is truthy', () => {
+    const wrapper = shallow(<Input addon type="checkbox" />);
+
+    expect(wrapper.hasClass('form-check-input')).toBe(false);
+    expect(wrapper.hasClass('form-control')).toBe(false);
+  });
+
+  it('should not render with "form-check-input" nor "form-control" class when type is radio and addon is truthy', () => {
+    const wrapper = shallow(<Input addon type="radio" />);
+
+    expect(wrapper.hasClass('form-check-input')).toBe(false);
+    expect(wrapper.hasClass('form-control')).toBe(false);
+  });
+
   it('should render with "form-control-file" class when type is file', () => {
     const wrapper = shallow(<Input type="file" />);
 

--- a/test/InputGroup.spec.js
+++ b/test/InputGroup.spec.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { InputGroup } from 'reactstrap';
+
+describe('InputGroup', () => {
+  it('should render with "div" tag', () => {
+    const wrapper = shallow(<InputGroup>Yo!</InputGroup>);
+
+    expect(wrapper.type()).toBe('div');
+  });
+
+  it('should render children', () => {
+    const wrapper = shallow(<InputGroup>Yo!</InputGroup>);
+
+    expect(wrapper.text()).toBe('Yo!');
+  });
+
+  it('should render with "input-group" class', () => {
+    const wrapper = shallow(<InputGroup>Yo!</InputGroup>);
+
+    expect(wrapper.hasClass('input-group')).toBe(true);
+  });
+
+  it('should render with "input-group-${size}" class when size is passed', () => {
+    const wrapper = shallow(<InputGroup size="whatever">Yo!</InputGroup>);
+
+    expect(wrapper.hasClass('input-group-whatever')).toBe(true);
+  });
+
+  it('should render additional classes', () => {
+    const wrapper = shallow(<InputGroup className="other">Yo!</InputGroup>);
+
+    expect(wrapper.hasClass('other')).toBe(true);
+    expect(wrapper.hasClass('input-group')).toBe(true);
+  });
+
+  it('should render custom tag', () => {
+    const wrapper = shallow(<InputGroup tag="main">Yo!</InputGroup>);
+
+    expect(wrapper.type()).toBe('main');
+  });
+});

--- a/test/InputGroupAddon.spec.js
+++ b/test/InputGroupAddon.spec.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { InputGroupAddon } from 'reactstrap';
+
+describe('InputGroupAddon', () => {
+  it('should render with "div" tag', () => {
+    const wrapper = shallow(<InputGroupAddon>Yo!</InputGroupAddon>);
+
+    expect(wrapper.type()).toBe('div');
+  });
+
+  it('should render children', () => {
+    const wrapper = shallow(<InputGroupAddon>Yo!</InputGroupAddon>);
+
+    expect(wrapper.text()).toBe('Yo!');
+  });
+
+  it('should render with "input-group-addon" class', () => {
+    const wrapper = shallow(<InputGroupAddon>Yo!</InputGroupAddon>);
+
+    expect(wrapper.hasClass('input-group-addon')).toBe(true);
+  });
+
+  it('should render additional classes', () => {
+    const wrapper = shallow(<InputGroupAddon className="other">Yo!</InputGroupAddon>);
+
+    expect(wrapper.hasClass('other')).toBe(true);
+    expect(wrapper.hasClass('input-group-addon')).toBe(true);
+  });
+
+  it('should render custom tag', () => {
+    const wrapper = shallow(<InputGroupAddon tag="main">Yo!</InputGroupAddon>);
+
+    expect(wrapper.type()).toBe('main');
+  });
+});

--- a/test/InputGroupButton.spec.js
+++ b/test/InputGroupButton.spec.js
@@ -1,0 +1,77 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { InputGroupButton, Button } from 'reactstrap';
+
+describe('InputGroupButton', () => {
+  it('should render with "div" tag', () => {
+    const wrapper = shallow(<InputGroupButton>Yo!</InputGroupButton>);
+
+    expect(wrapper.type()).toBe('div');
+  });
+
+  it('should render with "input-group-btn" class', () => {
+    const wrapper = shallow(<InputGroupButton>Yo!</InputGroupButton>);
+
+    expect(wrapper.hasClass('input-group-btn')).toBe(true);
+  });
+
+  it('should render custom tag', () => {
+    const wrapper = shallow(<InputGroupButton tag="main">Yo!</InputGroupButton>);
+
+    expect(wrapper.type()).toBe('main');
+  });
+
+  describe('Standard usage', () => {
+    it('should render children provided', () => {
+      const wrapper = shallow(<InputGroupButton><span>Yo!</span></InputGroupButton>);
+
+      expect(wrapper.childAt(0).type()).toBe('span');
+    });
+
+    it('should render additional classes', () => {
+      const wrapper = shallow(<InputGroupButton className="other"><span>Yo!</span></InputGroupButton>);
+
+      expect(wrapper.hasClass('other')).toBe(true);
+      expect(wrapper.hasClass('input-group-btn')).toBe(true);
+    });
+  });
+
+  describe('Shorthand usage', () => {
+    it('should render a child Button', () => {
+      const wrapper = shallow(<InputGroupButton>Yo!</InputGroupButton>);
+
+      expect(wrapper.childAt(0).type()).toBe(Button);
+    });
+
+    it('should render the string provided in the child Button', () => {
+      const wrapper = shallow(<InputGroupButton>Yo!</InputGroupButton>);
+
+      expect(wrapper.childAt(0).prop('children')).toBe('Yo!');
+    });
+
+    it('should render additional props on the child Button', () => {
+      const wrapper = shallow(<InputGroupButton color="rad">Yo!</InputGroupButton>);
+
+      expect(wrapper.childAt(0).prop('color')).toBe('rad');
+    });
+
+    it('should render additional classes on the child Button', () => {
+      const wrapper = shallow(<InputGroupButton className="yo">Yo!</InputGroupButton>);
+
+      expect(wrapper.childAt(0).hasClass('yo')).toBe(true);
+    });
+
+    it('should render groupClassName as additional classes on the input-group-btn wrapper', () => {
+      const wrapper = shallow(<InputGroupButton groupClassName="other">Yo!</InputGroupButton>);
+
+      expect(wrapper.hasClass('other')).toBe(true);
+      expect(wrapper.hasClass('input-group-btn')).toBe(true);
+    });
+
+    it('should render groupAttributes as additional attributes on the input-group-btn wrapper', () => {
+      const wrapper = shallow(<InputGroupButton groupAttributes={{ style: { textAlign: 'left' } }}>Yo!</InputGroupButton>);
+
+      expect(wrapper.prop('style').textAlign).toBe('left');
+    });
+  });
+});

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -22,6 +22,7 @@ var paths = [
   '/components/button-dropdown/',
   '/components/dropdowns/',
   '/components/form/',
+  '/components/input-group/',
   '/components/popovers/',
   '/components/tooltips/',
   '/components/modals/',


### PR DESCRIPTION
Resolves #74
Add `InputGroup` with `size` prop
Add `InputGroupAddon`
Change Input to add `addon` prop for radio/checkbox to not add `form-check-input` class
Add `InputGroupButton` with convinence shorthand when only a single string is passed
Add tests for all of the above
Add documention