### PR TITLE
chore(coverage): Update instrumenter

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,8 @@
 {
-  "presets": ["es2015", "stage-0", "react"]
+  "presets": ["es2015", "stage-0", "react"],
+  "env": {
+    "test": {
+      "plugins": [ "istanbul" ]
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -44,9 +44,7 @@
   },
   "homepage": "https://github.com/reactstrap/reactstrap#readme",
   "dependencies": {
-    "babel-cli": "^6.11.4",
     "classnames": "^2.2.3",
-    "cross-env": "^2.0.0",
     "lodash.isfunction": "^3.0.8",
     "lodash.omit": "^4.4.1",
     "tether": "^1.3.4"
@@ -57,6 +55,7 @@
     "react-dom": "^0.14.0 || ^15.0.0"
   },
   "devDependencies": {
+    "babel-cli": "^6.11.4",
     "babel-core": "^6.13.2",
     "babel-loader": "^6.2.2",
     "babel-plugin-istanbul": "^2.0.0",
@@ -71,6 +70,7 @@
     "conventional-recommended-bump": "^0.2.0",
     "copy-webpack-plugin": "^3.0.1",
     "coveralls": "^2.11.12",
+    "cross-env": "^2.0.0",
     "css-loader": "^0.23.1",
     "ejs": "^2.5.1",
     "enzyme": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -5,11 +5,11 @@
   "main": "lib/index.js",
   "scripts": {
     "coverage": "coveralls < ./test/coverage/lcov/lcov.info",
-    "test": "npm run lint && karma start --single-run --reporters spec,coverage",
+    "test": "npm run lint && cross-env BABEL_ENV=test karma start --single-run --reporters spec,coverage",
     "test-watch": "karma start --reporters dots,coverage",
     "start": "webpack-dev-server --config ./webpack.dev.config.js --watch",
-    "build-docs": "WEBPACK_BUILD=production webpack --config ./webpack.dev.config.js --progress --colors",
-    "build": "WEBPACK_BUILD=production webpack --progress --colors && webpack --progress --colors",
+    "build-docs": "cross-env WEBPACK_BUILD=production webpack --config ./webpack.dev.config.js --progress --colors",
+    "build": "cross-env WEBPACK_BUILD=production webpack --progress --colors && webpack --progress --colors",
     "prebuild": "babel src --out-dir lib",
     "create-release": "npm test && sh ./scripts/release",
     "publish-release": "npm test && sh ./scripts/publish",
@@ -46,6 +46,7 @@
   "dependencies": {
     "babel-cli": "^6.11.4",
     "classnames": "^2.2.3",
+    "cross-env": "^2.0.0",
     "lodash.isfunction": "^3.0.8",
     "lodash.omit": "^4.4.1",
     "tether": "^1.3.4"
@@ -58,6 +59,7 @@
   "devDependencies": {
     "babel-core": "^6.13.2",
     "babel-loader": "^6.2.2",
+    "babel-plugin-istanbul": "^2.0.0",
     "babel-polyfill": "^6.13.0",
     "babel-preset-es2015": "^6.13.2",
     "babel-preset-react": "^6.5.0",
@@ -80,7 +82,6 @@
     "eslint-plugin-standard": "^2.0.0",
     "extract-text-webpack-plugin": "^1.0.1",
     "history": "^3.0.0",
-    "isparta-loader": "^2.0.0",
     "jasmine-core": "^2.4.1",
     "json-loader": "^0.5.4",
     "karma": "^1.1.2",

--- a/webpack.test.config.js
+++ b/webpack.test.config.js
@@ -38,12 +38,6 @@ var webpackConfig = {
   },
 };
 
-webpackConfig.module.preLoaders = webpackConfig.module.preLoaders || [];
-webpackConfig.module.preLoaders.push({
-  test: /\.jsx?$/,
-  exclude: /(test|node_modules)\//,
-  loader: 'isparta'
-});
 webpackConfig.webpackServer = {
   noInfo: true
 };


### PR DESCRIPTION
Replace isparta with istambul since isparta is no longer maintained
See: https://github.com/douglasduteil/isparta
Istambul now support es2015/6.
(Also added cross-env to allow it to work on windows)

This PR is not a big deal, just some maintenance, though I did notice the coverage output was _slightly_ more detailed with the babel istambul plugin this PR adds than the isparta loader it replaces.