### PR TITLE
set modal focus state before showing

### DIFF
--- a/src/Modal.jsx
+++ b/src/Modal.jsx
@@ -78,8 +78,8 @@ class Modal extends React.Component {
 
   togglePortal() {
     if (this.props.isOpen) {
-      this.show();
       this._focus = true;
+      this.show();
     } else {
       this.hide();
     }


### PR DESCRIPTION
Hello,

I was having some issues with controlled inputs inside modals. When I would update the Modal after an input value changed, the input would suddenly lose focus. I managed to track this issue down to the Modal's focus state being set after the call to `renderIntoSubtree()`. This meant that the Modal wasn't be focused until the next render, when the input changed values.

Here is some React code to show what I mean:

```jsx
import React from "react";
import {Modal,ModalBody} from "reactstrap";

class ModalWithInput extends React.Component {
  state = {};

  render() {
    return <Modal {...this.props}>
      <ModalBody>
        <input
          type="text"
          value={this.state.inputValue}
          onChange={(e) => this.setState({ inputValue: e.target.value })} />
      </ModalBody>
    </Modal>;
  }
}
```