### PR TITLE
feat(Progress): add Progress component

### DIFF
--- a/docs/lib/Components/ProgressPage.jsx
+++ b/docs/lib/Components/ProgressPage.jsx
@@ -1,0 +1,118 @@
+/* eslint react/no-multi-comp: 0, react/prop-types: 0 */
+import React from 'react';
+import { PrismCode } from 'react-prism';
+import Helmet from 'react-helmet';
+import { Card, CardText } from 'reactstrap';
+import ProgressExample from '../examples/Progress';
+const ProgressExampleSource = require('!!raw!../examples/Progress.jsx');
+import ProgressColorExample from '../examples/ProgressColor';
+const ProgressColorExampleSource = require('!!raw!../examples/ProgressColor.jsx');
+import ProgressAnimatedExample from '../examples/ProgressAnimated';
+const ProgressAnimatedExampleSource = require('!!raw!../examples/ProgressAnimated.jsx');
+import ProgressStripedExample from '../examples/ProgressStriped';
+const ProgressStripedExampleSource = require('!!raw!../examples/ProgressStriped.jsx');
+import ProgressMaxExample from '../examples/ProgressMax';
+const ProgressMaxExampleSource = require('!!raw!../examples/ProgressMax.jsx');
+
+export default class ProgressPage extends React.Component {
+  render() {
+    return (
+      <div>
+        <Helmet title="Progress" />
+        <h3>Progress</h3>
+        <div className="docs-example">
+          <ProgressExample />
+        </div>
+        <pre>
+          <PrismCode className="language-jsx">
+            {ProgressExampleSource}
+          </PrismCode>
+        </pre>
+        <h4>Properties</h4>
+        <pre>
+          <PrismCode className="language-jsx">
+{`Progress.propTypes = {
+  tag: PropTypes.string,
+  value: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+  ]),
+  max: PropTypes.oneOf([
+    PropTypes.string,
+    PropTypes.number,
+  ]),
+  animated: PropTypes.bool,
+  stripped: PropTypes.bool,
+  color: PropTypes.string,
+  className: PropTypes.any
+};
+
+Progress.defaultProps = {
+  tag: 'progress',
+  value: 0,
+  max: 100,
+};`}
+          </PrismCode>
+        </pre>
+
+        <h3>Color Variants</h3>
+        <div className="docs-example">
+          <div>
+            <ProgressColorExample />
+          </div>
+        </div>
+        <pre>
+          <PrismCode className="language-jsx">
+            {ProgressColorExampleSource}
+          </PrismCode>
+        </pre>
+
+        <h3>Striped</h3>
+        <div className="docs-example">
+          <div>
+            <ProgressStripedExample />
+          </div>
+        </div>
+        <pre>
+          <PrismCode className="language-jsx">
+            {ProgressStripedExampleSource}
+          </PrismCode>
+        </pre>
+
+        <h3>Animated</h3>
+        <p>
+          The <code>animated</code> prop also adds the <code>striped</code> prop; there is no need to pass both.
+        </p>
+        <Card block outline color="danger">
+          <CardText>
+            Currently, animated progress does not work in bootstrap v4 (alpha 3). This is an issue bootstrap has to
+            resolve.
+          </CardText>
+        </Card>
+        <div className="docs-example">
+          <div>
+            <ProgressAnimatedExample />
+          </div>
+        </div>
+        <pre>
+          <PrismCode className="language-jsx">
+            {ProgressAnimatedExampleSource}
+          </PrismCode>
+        </pre>
+
+        <h3>Max value</h3>
+        <div className="docs-example">
+          <div>
+            <ProgressMaxExample />
+          </div>
+        </div>
+        <pre>
+          <PrismCode className="language-jsx">
+            {ProgressMaxExampleSource}
+          </PrismCode>
+        </pre>
+
+      </div>
+    );
+  }
+}

--- a/docs/lib/Components/index.jsx
+++ b/docs/lib/Components/index.jsx
@@ -72,6 +72,10 @@ class Components extends React.Component {
           to: '/components/popovers/'
         },
         {
+          name: 'Progress',
+          to: '/components/progress/'
+        },
+        {
           name: 'Modals',
           to: '/components/modals/'
         },

--- a/docs/lib/examples/Progress.jsx
+++ b/docs/lib/examples/Progress.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Progress } from 'reactstrap';
+
+const Example = (props) => {
+  return (
+    <div>
+      <div className="text-xs-center">0%</div>
+      <Progress />
+      <div className="text-xs-center">25%</div>
+      <Progress value="25" />
+      <div className="text-xs-center">50%</div>
+      <Progress value={50} />
+      <div className="text-xs-center">75%</div>
+      <Progress value={75} />
+      <div className="text-xs-center">100%</div>
+      <Progress value="100" />
+    </div>
+  );
+};
+
+export default Example;

--- a/docs/lib/examples/ProgressAnimated.jsx
+++ b/docs/lib/examples/ProgressAnimated.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Progress } from 'reactstrap';
+
+const Example = (props) => {
+  return (
+    <div>
+      <Progress animated value={2 * 5} />
+      <Progress animated color="success" value="25" />
+      <Progress animated color="info" value={50} />
+      <Progress animated color="warning" value={75} />
+      <Progress animated color="danger" value="100" />
+    </div>
+  );
+};
+
+export default Example;

--- a/docs/lib/examples/ProgressColor.jsx
+++ b/docs/lib/examples/ProgressColor.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Progress } from 'reactstrap';
+
+const Example = (props) => {
+  return (
+    <div>
+      <Progress value={2 * 5} />
+      <Progress color="success" value="25" />
+      <Progress color="info" value={50} />
+      <Progress color="warning" value={75} />
+      <Progress color="danger" value="100" />
+    </div>
+  );
+};
+
+export default Example;

--- a/docs/lib/examples/ProgressMax.jsx
+++ b/docs/lib/examples/ProgressMax.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Progress } from 'reactstrap';
+
+const Example = (props) => {
+  return (
+    <div>
+      <div className="text-xs-center">1 of 5</div>
+      <Progress value="1" max="5" />
+      <div className="text-xs-center">50 of 135</div>
+      <Progress value={50} max="135" />
+      <div className="text-xs-center">75 of 111</div>
+      <Progress value={75} max={111} />
+      <div className="text-xs-center">463 of 500</div>
+      <Progress value="463" max={500} />
+    </div>
+  );
+};
+
+export default Example;

--- a/docs/lib/examples/ProgressStriped.jsx
+++ b/docs/lib/examples/ProgressStriped.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Progress } from 'reactstrap';
+
+const Example = (props) => {
+  return (
+    <div>
+      <Progress striped value={2 * 5} />
+      <Progress striped color="success" value="25" />
+      <Progress striped color="info" value={50} />
+      <Progress striped color="warning" value={75} />
+      <Progress striped color="danger" value="100" />
+    </div>
+  );
+};
+
+export default Example;

--- a/docs/lib/routes.jsx
+++ b/docs/lib/routes.jsx
@@ -12,6 +12,7 @@ import DropdownsPage from './Components/DropdownsPage';
 import FormPage from './Components/FormPage';
 import InputGroupPage from './Components/InputGroupPage';
 import PopoversPage from './Components/PopoversPage';
+import ProgressPage from './Components/ProgressPage';
 import TooltipsPage from './Components/TooltipsPage';
 import TagsPage from './Components/TagsPage';
 import MediaPage from './Components/MediaPage';
@@ -35,6 +36,7 @@ const routes = (
       <Route path="form/" component={FormPage} />
       <Route path="input-group/" component={InputGroupPage} />
       <Route path="popovers/" component={PopoversPage} />
+      <Route path="progress/" component={ProgressPage} />
       <Route path="tooltips/" component={TooltipsPage} />
       <Route path="tags/" component={TagsPage} />
       <Route path="card/" component={CardPage} />

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "classnames": "^2.2.3",
     "lodash.isfunction": "^3.0.8",
     "lodash.omit": "^4.4.1",
+    "lodash.tonumber": "^4.0.3",
     "tether": "^1.3.4"
   },
   "peerDependencies": {

--- a/src/Progress.jsx
+++ b/src/Progress.jsx
@@ -1,0 +1,86 @@
+import React, { PropTypes } from 'react';
+import classNames from 'classnames';
+import toNumber from 'lodash.tonumber';
+
+const propTypes = {
+  tag: PropTypes.string,
+  value: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+  ]),
+  max: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+  ]),
+  animated: PropTypes.bool,
+  striped: PropTypes.bool,
+  color: PropTypes.string,
+  className: PropTypes.any
+};
+
+const defaultProps = {
+  tag: 'progress',
+  value: 0,
+  max: 100,
+};
+
+const Progress = (props) => {
+  const {
+    className,
+    value,
+    max,
+    animated,
+    striped,
+    color,
+    tag: Tag,
+    ...attributes
+  } = props;
+
+  const percent = ((toNumber(value) / toNumber(max)) * 100);
+
+  const nonProgressClasses = classNames(
+    className,
+    'progress',
+    animated ? 'progress-animated' : null
+  );
+
+  const progressClasses = classNames(
+    nonProgressClasses,
+    color ? `progress-${color}` : null,
+    striped || animated ? 'progress-striped' : null
+  );
+
+  const fallbackClasses = classNames(
+    'progress-bar',
+    color ? `progress-${color}` : null,
+    striped || animated ? 'progress-bar-striped' : null
+  );
+
+  const fallbackFill = (
+    <span
+      className={fallbackClasses}
+      style={{ width: `${percent}%` }}
+      role="progressbar"
+      aria-valuenow={value}
+      aria-valuemin="0"
+      aria-valuemax={max}
+    />
+  );
+
+  if (Tag === 'progress') {
+    return (
+      <Tag {...attributes} className={progressClasses} value={value} max={max}>
+        <div className={nonProgressClasses} children={fallbackFill} />
+      </Tag>
+    );
+  }
+
+  return (
+    <Tag {...attributes} className={nonProgressClasses} children={fallbackFill} />
+  );
+};
+
+Progress.propTypes = propTypes;
+Progress.defaultProps = defaultProps;
+
+export default Progress;

--- a/src/index.js
+++ b/src/index.js
@@ -36,6 +36,7 @@ import CardTitle from './CardTitle';
 import Popover from './Popover';
 import PopoverTitle from './PopoverTitle';
 import PopoverContent from './PopoverContent';
+import Progress from './Progress';
 import Modal from './Modal';
 import ModalHeader from './ModalHeader';
 import ModalBody from './ModalBody';
@@ -94,6 +95,7 @@ export {
   Popover,
   PopoverContent,
   PopoverTitle,
+  Progress,
   Modal,
   ModalHeader,
   ModalBody,

--- a/test/Progress.spec.js
+++ b/test/Progress.spec.js
@@ -1,0 +1,190 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { Progress } from 'reactstrap';
+
+describe('Progress', () => {
+  it('should render with "progress" tag by default', () => {
+    const wrapper = shallow(<Progress />);
+
+    expect(wrapper.type()).toBe('progress');
+  });
+
+  it('should render with "progress" class', () => {
+    const wrapper = shallow(<Progress />);
+
+    expect(wrapper.hasClass('progress')).toBe(true);
+  });
+
+  it('should render with "value" 0 by default', () => {
+    const wrapper = shallow(<Progress />);
+
+    expect(wrapper.prop('value')).toBe(0);
+  });
+
+  it('should render with "max" 100 by default', () => {
+    const wrapper = shallow(<Progress />);
+
+    expect(wrapper.prop('max')).toBe(100);
+  });
+
+  it('should render with the given "value" when passed as string prop', () => {
+    const wrapper = shallow(<Progress value="10" />);
+
+    expect(wrapper.prop('value')).toBe('10');
+  });
+
+  it('should render with the given "value" when passed as number prop', () => {
+    const wrapper = shallow(<Progress value={10} />);
+
+    expect(wrapper.prop('value')).toBe(10);
+  });
+
+  it('should render with the given "max" when passed as string prop', () => {
+    const wrapper = shallow(<Progress max="10" />);
+
+    expect(wrapper.prop('max')).toBe('10');
+  });
+
+  it('should render with the given "max" when passed as number prop', () => {
+    const wrapper = shallow(<Progress max={10} />);
+
+    expect(wrapper.prop('max')).toBe(10);
+  });
+
+  it('should render with "progress-striped" class when striped prop is truthy', () => {
+    const wrapper = shallow(<Progress striped />);
+
+    expect(wrapper.hasClass('progress-striped')).toBe(true);
+  });
+
+  it('should render with "progress-striped" and "progress-animated" classes when animated prop is truthy', () => {
+    const wrapper = shallow(<Progress animated />);
+
+    expect(wrapper.hasClass('progress-striped')).toBe(true);
+    expect(wrapper.hasClass('progress-animated')).toBe(true);
+  });
+
+  it('should render with "progress-${color}" class when color prop is defined', () => {
+    const wrapper = shallow(<Progress color="yo" />);
+
+    expect(wrapper.hasClass('progress-yo')).toBe(true);
+  });
+
+  it('should render additional classes', () => {
+    const wrapper = shallow(<Progress className="other" />);
+
+    expect(wrapper.hasClass('other')).toBe(true);
+    expect(wrapper.hasClass('progress')).toBe(true);
+  });
+
+  it('should have div fallback for IE9', () => {
+    const wrapper = shallow(<Progress />);
+
+    expect(wrapper.childAt(0).type()).toBe('div');
+  });
+
+  describe('div fallback', () => {
+    it('should render with "progress" class', () => {
+      const div = shallow(<Progress />).childAt(0);
+
+      expect(div.hasClass('progress')).toBe(true);
+    });
+
+    it('should render with "progress-animated" class when animated is truthy', () => {
+      const div = shallow(<Progress animated />).childAt(0);
+
+      expect(div.hasClass('progress-animated')).toBe(true);
+    });
+
+    it('should render additional classes', () => {
+      const div = shallow(<Progress className="other" />).childAt(0);
+
+      expect(div.hasClass('other')).toBe(true);
+      expect(div.hasClass('progress')).toBe(true);
+    });
+
+    it('should have a span', () => {
+      const div = shallow(<Progress />).childAt(0);
+
+      expect(div.childAt(0).type()).toBe('span');
+    });
+
+    describe('the span', () => {
+      it('should render with "progress-bar" class', () => {
+        const span = shallow(<Progress />).childAt(0).childAt(0);
+
+        expect(span.hasClass('progress-bar')).toBe(true);
+      });
+
+      it('should render with "progress-bar-striped" class when striped is truthy', () => {
+        const span = shallow(<Progress striped />).childAt(0).childAt(0);
+
+        expect(span.hasClass('progress-bar-striped')).toBe(true);
+      });
+
+      it('should render with "progress-bar-striped" class when animated is truthy', () => {
+        const span = shallow(<Progress animated />).childAt(0).childAt(0);
+
+        expect(span.hasClass('progress-bar-striped')).toBe(true);
+      });
+
+      it('should render with a style width matching the percent of the fill', () => {
+        const span = shallow(<Progress value="25" />).childAt(0).childAt(0);
+
+        expect(span.prop('style').width).toBe('25%');
+      });
+
+      it('should render with a style width matching the percent of the fill (with max)', () => {
+        const span = shallow(<Progress value="25" max="50" />).childAt(0).childAt(0);
+
+        expect(span.prop('style').width).toBe('50%');
+      });
+    });
+  });
+
+  describe('with a custom tag', () => {
+    it('should render custom tag', () => {
+      const wrapper = shallow(<Progress tag="main" />);
+
+      expect(wrapper.type()).toBe('main');
+    });
+
+    it('should have a span', () => {
+      const span = shallow(<Progress tag="main" />).childAt(0);
+
+      expect(span.type()).toBe('span');
+    });
+
+    describe('the span', () => {
+      it('should render with "progress-bar" class', () => {
+        const span = shallow(<Progress tag="main" />).childAt(0);
+
+        expect(span.hasClass('progress-bar')).toBe(true);
+      });
+
+      it('should render with "progress-bar-striped" class when striped is truthy', () => {
+        const span = shallow(<Progress tag="main" striped />).childAt(0);
+
+        expect(span.hasClass('progress-bar-striped')).toBe(true);
+      });
+
+      it('should render with "progress-bar-striped" class when animated is truthy', () => {
+        const span = shallow(<Progress tag="main" animated />).childAt(0);
+
+        expect(span.hasClass('progress-bar-striped')).toBe(true);
+      });
+
+      it('should render with a style width matching the percent of the fill', () => {
+        const span = shallow(<Progress tag="main" value="25" />).childAt(0);
+
+        expect(span.prop('style').width).toBe('25%');
+      });
+
+      it('should render with a style width matching the percent of the fill (with max)', () => {
+        const span = shallow(<Progress tag="main" value="25" max="50" />).childAt(0);
+
+        expect(span.prop('style').width).toBe('50%');
+      });
+    });
+  });
+});

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -24,6 +24,7 @@ var paths = [
   '/components/form/',
   '/components/input-group/',
   '/components/popovers/',
+  '/components/progress/',
   '/components/tooltips/',
   '/components/modals/',
   '/components/tags/',


### PR DESCRIPTION
Add Progress component which will output bootstrap's progress component
Progress has `striped`, `animated`, and `color` props.
It will default to `<progress>` with a `<div>` fallback for IE9
Overriding the tag will produce the fallback inside the custom tag.
Add docs and tests as well.

Closes #78