### PR TITLE
Create Paginate component

### DIFF
--- a/docs/lib/Components/PaginationPage.jsx
+++ b/docs/lib/Components/PaginationPage.jsx
@@ -3,6 +3,9 @@ import React from 'react';
 import { PrismCode } from 'react-prism';
 import Helmet from 'react-helmet';
 
+import PagenateExample from '../examples/Paginate';
+const PagenateExampleSource = require('!!raw!../examples/Paginate.jsx');
+
 import PaginationExample from '../examples/Pagination';
 const PaginationExampleSource = require('!!raw!../examples/Pagination.jsx');
 
@@ -64,6 +67,22 @@ export default class PaginationPage extends React.Component {
         <pre>
           <PrismCode className="language-jsx">
             {PaginationSizingSmallExampleSource}
+          </PrismCode>
+        </pre>
+        <div className="docs-example">
+          <PagenateExample />
+            <hr/>
+            Middle is off
+            <hr/>
+          <PagenateExample middle={false} />
+            <hr/>
+            Customize navigators
+            <hr/>
+          <PagenateExample custom={true} />
+        </div>
+        <pre>
+          <PrismCode className="language-jsx">
+            {PagenateExampleSource}
           </PrismCode>
         </pre>
       </div>

--- a/docs/lib/examples/Paginate.jsx
+++ b/docs/lib/examples/Paginate.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import {Paginate, Button} from 'reactstrap';
+
+export default class Example extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {page: 8, pages: 20, showPages: 10};
+    }
+
+    render() {
+        let {showPages, page, pages} = this.state,
+            attrs                    = {
+                showPages, page, pages,
+                onClick: (page)=>this.setState({page}), middle: this.props.middle
+            };
+        if (this.props.custom) {
+            attrs = {
+                ...attrs,
+                first: 'First',
+                prev:  'Prev',
+                next:  'Next',
+                last:  'Last',
+            }
+        }
+        return (
+            <Paginate {...attrs} />
+        );
+    }
+}

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0",
-    "react-addons-transition-group": "^0.14.0 || ^15.0.0",
+    "react-addons-transition-group": "^0.14.0 || ^15.3.1",
     "react-dom": "^0.14.0 || ^15.0.0"
   },
   "devDependencies": {

--- a/src/Paginate.jsx
+++ b/src/Paginate.jsx
@@ -2,7 +2,6 @@ import React, { PropTypes } from 'react';
 import { Pagination, PaginationItem, PaginationLink } from './index';
 
 const propTypes = {
-  className: PropTypes.string,
   page: PropTypes.number.isRequired,
   pages: PropTypes.number.isRequired,
   showPages: PropTypes.number,
@@ -10,7 +9,7 @@ const propTypes = {
   prev: PropTypes.string,
   first: PropTypes.string,
   last: PropTypes.string,
-  middle:PropTypes.bool,
+  middle: PropTypes.bool,
   onClick: PropTypes.func
 };
 
@@ -21,12 +20,12 @@ const defaultProps = {
   prev: '<',
   first: '<<',
   last: '>>',
-  middle:true,
+  middle: true,
   onClick: () => null
 };
 
 const Paginate = (props) => {
-  const { showPages, onClick, pages, page, next, prev, first, last,middle, ...resetOfProps } = props;
+  const { showPages, onClick, pages, page, next, prev, first, last, middle, ...resetOfProps } = props;
   const createLink = (_page, title, key, attributes = {}) => {
     return (<PaginationItem {...attributes} key={key}>
       <PaginationLink tag="button" type="button" onClick={() => onClick(_page)}>
@@ -41,15 +40,15 @@ const Paginate = (props) => {
     let isMaxSized = !isNaN(showPages) && showPages < pages;
 
     if (isMaxSized) {
-      if (middle){
+      if (middle) {
         // Current page is displayed in the middle of the visible ones
         startPage = Math.max(page - Math.floor(showPages / 2), 1);
-        endPage = startPage + showPages - 1;
+        endPage = (startPage + showPages) - 1;
 
         // Adjust if limit is exceeded
         if (endPage > pages) {
           endPage = pages;
-          startPage = endPage - showPages + 1;
+          startPage = (endPage - showPages) + 1;
         }
       } else {
         startPage = ((Math.ceil(page / showPages) - 1) * showPages) + 1;

--- a/src/Paginate.jsx
+++ b/src/Paginate.jsx
@@ -1,0 +1,94 @@
+import React, { PropTypes } from 'react';
+import { Pagination, PaginationItem, PaginationLink } from './index';
+
+const propTypes = {
+  className: PropTypes.string,
+  page: PropTypes.number.isRequired,
+  pages: PropTypes.number.isRequired,
+  showPages: PropTypes.number,
+  next: PropTypes.string,
+  prev: PropTypes.string,
+  first: PropTypes.string,
+  last: PropTypes.string,
+  middle:PropTypes.bool,
+  onClick: PropTypes.func
+};
+
+const defaultProps = {
+  page: 1,
+  showPages: 10,
+  next: '>',
+  prev: '<',
+  first: '<<',
+  last: '>>',
+  middle:true,
+  onClick: () => null
+};
+
+const Paginate = (props) => {
+  const { showPages, onClick, pages, page, next, prev, first, last,middle, ...resetOfProps } = props;
+  const createLink = (_page, title, key, attributes = {}) => {
+    return (<PaginationItem {...attributes} key={key}>
+      <PaginationLink tag="button" type="button" onClick={() => onClick(_page)}>
+        {title}
+      </PaginationLink>
+    </PaginationItem>);
+  };
+  const getPages = () => {
+    let links = [];
+    let startPage = 1;
+    let endPage = pages;
+    let isMaxSized = !isNaN(showPages) && showPages < pages;
+
+    if (isMaxSized) {
+      if (middle){
+        // Current page is displayed in the middle of the visible ones
+        startPage = Math.max(page - Math.floor(showPages / 2), 1);
+        endPage = startPage + showPages - 1;
+
+        // Adjust if limit is exceeded
+        if (endPage > pages) {
+          endPage = pages;
+          startPage = endPage - showPages + 1;
+        }
+      } else {
+        startPage = ((Math.ceil(page / showPages) - 1) * showPages) + 1;
+        // Adjust last page if limit is exceeded
+        endPage = Math.min(startPage + (showPages - 1), pages);
+      }
+    }
+
+  // Create links
+    for (let number = startPage; number <= endPage; number++) {
+      let attrs = {};
+      if (number === page) {
+        attrs.active = true;
+      }
+      if (onClick) {
+        attrs.onClick = () => onClick(number);
+      }
+      links.push(createLink(number, number, number, attrs));
+    }
+    if (page > 1) {
+      links.unshift(createLink(page - 1, prev, 'prev'));
+    }
+    if (startPage > 1) {
+      links.unshift(createLink(1, first, 'first'));
+    }
+
+    if (page < pages) {
+      links.push(createLink(page + 1, next, 'next'));
+    }
+    if (endPage < pages) {
+      links.push(createLink(pages, last, 'last'));
+    }
+
+    return links;
+  };
+  return <Pagination {...resetOfProps}>{getPages()}</Pagination>;
+};
+
+Paginate.propTypes = propTypes;
+Paginate.defaultProps = defaultProps;
+
+export default Paginate;

--- a/src/index.js
+++ b/src/index.js
@@ -58,6 +58,7 @@ import Media from './Media';
 import Pagination from './Pagination';
 import PaginationItem from './PaginationItem';
 import PaginationLink from './PaginationLink';
+import Paginate from './Paginate';
 
 export {
   Container,
@@ -120,4 +121,5 @@ export {
   Pagination,
   PaginationItem,
   PaginationLink,
+  Paginate
 };

--- a/test/Paginate.spec.js
+++ b/test/Paginate.spec.js
@@ -1,0 +1,197 @@
+/* eslint react/no-multi-comp: 0, react/prop-types: 0 */
+import React from 'react';
+import {shallow, mount} from 'enzyme';
+import {Paginate} from 'reactstrap';
+
+describe('Paginate', () => {
+    it('should not render prev and first on first page', () => {
+        const wrapper = mount(<Paginate page={1} pages={50}/>);
+        expect(wrapper.find('button').at(0).text()).toEqual('1');
+        expect(wrapper.find('button').at(1).text()).toEqual('2');
+    });
+    it('should not render next and last on last page', () => {
+        const wrapper = mount(<Paginate page={50} pages={50}/>);
+        expect(wrapper.find('button').at(11).text()).toEqual('50');
+        expect(wrapper.find('button').at(10).text()).toEqual('49');
+    });
+    it('should customize `first` `prev` `next` `last` titles', () => {
+
+        const first   = 'FIRST',
+              prev    = 'PREV',
+              next    = 'NEXT',
+              last    = 'LAST',
+              wrapper = mount(<Paginate {...{first, prev, next, last, pages: 50, page: 30}}/>);
+        expect(wrapper.find('button').at(0).text()).toEqual(first);
+        expect(wrapper.find('button').at(1).text()).toEqual(prev);
+        expect(wrapper.find('button').at(12).text()).toEqual(next);
+        expect(wrapper.find('button').at(13).text()).toEqual(last);
+    });
+    it('should render 14 links', () => {
+        const wrapper = mount(<Paginate page={20} pages={50}/>);
+        expect(wrapper.find('button').length).toBe(14); // the number of links is 14 because of first, prev, next and last buttons
+    });
+    it('should render number of links based on showPages links', () => {
+        const wrapper = mount(<Paginate page={1} pages={15} showPages={15}/>);
+        expect(wrapper.find('button').length).toBe(16); // the number of links is 16 because next button
+    });
+    it('no error on when no callback is given', ()=> {
+        const wrapper = mount(<Paginate page={1} pages={50}/>),
+              link    = wrapper.find('button').at(5);
+        expect(link.simulate.bind(link, 'click')).not.toThrow();
+    });
+    const pageClicker = (page, pages, index, shouldBe)=> {
+        let currentPage = page,
+            callback    = (_page)=> {
+                currentPage = _page;
+            };
+        const wrapper   = mount(<Paginate page={currentPage} onClick={callback} pages={pages}/>);
+        wrapper.find('button').at(index).simulate('click');
+        expect(currentPage).toBe(shouldBe);
+    };
+    it('should callback the when a link is clicked', ()=> {
+        pageClicker(1, 10, 6, 7)
+    });
+    it('should go to first page', ()=> {
+        pageClicker(14, 100, 0, 1)
+    });
+    it('should go to prev page', ()=> {
+        pageClicker(14, 100, 1, 13)
+    });
+    it('should go to next page', ()=> {
+        pageClicker(14, 100, 12, 15)
+    });
+    it('should go to last page', ()=> {
+        pageClicker(14, 100, 13, 100)
+    });
+    it('should set active on current page link', () => {
+        let wrapper = mount(<Paginate page={1} pages={15} showPages={15}/>);
+        expect(wrapper.find('.active button').text()).toBe('1');
+        wrapper.setProps({page: 5});
+        expect(wrapper.find('.active button').text()).toBe('5');
+    });
+    it('rotate pages to let current page in the middle', () => {
+        const wrapper = mount(<Paginate page={1} pages={20} showPages={10} middle={true} />);
+        //f: first, c: current,l: last
+        /*
+INDEX          0,   1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13
+SELECT: 1   |  1,   2,  3,  4,  5,  6,  7,  8,  9,  10, >,  >>
+SELECT: 2   |  <,   1,  2,  3,  4,  5,  6,  7,  8,  9,  10, >,  >>
+SELECT: 3   |  <,   1,  2,  3,  4,  5,  6,  7,  8,  9,  10, >,  >>
+SELECT: 4   |  <,   1,  2,  3,  4,  5,  6,  7,  8,  9,  10, >,  >>
+SELECT: 5   |  <,   1,  2,  3,  4,  5,  6,  7,  8,  9,  10, >,  >>
+SELECT: 6   |  <,   1,  2,  3,  4,  5,  6,  7,  8,  9,  10, >,  >>
+SELECT: 7   |  <<,  <,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, >,  >>
+SELECT: 8   |  <<,  <,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, >,  >>
+SELECT: 9   |  <<,  <,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, >,  >>
+SELECT: 10  |  <<,  <,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, >,  >>
+SELECT: 11  |  <<,  <,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, >,  >>
+SELECT: 12  |  <<,  <,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16, >,  >>
+SELECT: 13  |  <<,  <,  8,  9,  10, 11, 12, 13, 14, 15, 16, 17, >,  >>
+SELECT: 14  |  <<,  <,  9,  10, 11, 12, 13, 14, 15, 16, 17, 18, >,  >>
+SELECT: 15  |  <<,  <,  10, 11, 12, 13, 14, 15, 16, 17, 18, 19, >,  >>
+SELECT: 16  |  <<,  <,  11, 12, 13, 14, 15, 16, 17, 18, 19, 20, >
+SELECT: 17  |  <<,  <,  11, 12, 13, 14, 15, 16, 17, 18, 19, 20, >
+SELECT: 18  |  <<,  <,  11, 12, 13, 14, 15, 16, 17, 18, 19, 20, >
+SELECT: 19  |  <<,  <,  11, 12, 13, 14, 15, 16, 17, 18, 19, 20, >
+SELECT: 20  |  <<,  <,  11, 12, 13, 14, 15, 16, 17, 18, 19, 20
+*/
+        [
+            {f: 1, c: 1, l: 10},
+            {f: 1, c: 2, l: 10},
+            {f: 1, c: 3, l: 10},
+            {f: 1, c: 4, l: 10},
+            {f: 1, c: 5, l: 10},
+            {f: 1, c: 6, l: 10},
+            {f: 2, c: 7, l: 11},
+            {f: 3, c: 8, l: 12},
+            {f: 4, c: 9, l: 13},
+            {f: 5, c: 10, l: 14},
+            {f: 6, c: 11, l: 15},
+            {f: 7, c: 12, l: 16},
+            {f: 8, c: 13, l: 17},
+            {f: 9, c: 14, l: 18},
+            {f: 10, c: 15, l: 19},
+            {f: 11, c: 16, l: 20},
+            {f: 11, c: 17, l: 20},
+            {f: 11, c: 18, l: 20},
+            {f: 11, c: 19, l: 20},
+            {f: 11, c: 20, l: 20},
+        ].forEach((target)=> {
+            let firstIndex = target.c > 1 ? target.c > 6 ? 2 : 1 : 0, // this is for prev(after first page) and first(after half of the show pages. In case of the showPages is even will add one to middle in this case 10/2 = 5 but will use 6)
+                lastIndex  = firstIndex + 9;
+            wrapper.setProps({page: target.c});
+            let current = {
+                cf: wrapper.find('button').at(firstIndex).text(),
+                cl: wrapper.find('button').at(lastIndex).text(),
+                    firstIndex,
+                    lastIndex,
+                ...target
+            };
+            expect(current.cf).toBe(`${current.f}`);
+            expect(current.cl).toBe(`${current.l}`);
+        });
+    });
+    it('display pages in batches based if middle is false', () => {
+        const wrapper = mount(<Paginate page={1} pages={20} showPages={10} middle={false} />);
+        //f: first, c: current,l: last
+        /*
+INDEX          0,   1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13
+SELECT: 1   |  1,   2,  3,  4,  5,  6,  7,  8,  9,  10, >,  >>
+SELECT: 2   |  <,   1,  2,  3,  4,  5,  6,  7,  8,  9,  10, >,  >>
+SELECT: 3   |  <,   1,  2,  3,  4,  5,  6,  7,  8,  9,  10, >,  >>
+SELECT: 4   |  <,   1,  2,  3,  4,  5,  6,  7,  8,  9,  10, >,  >>
+SELECT: 5   |  <,   1,  2,  3,  4,  5,  6,  7,  8,  9,  10, >,  >>
+SELECT: 6   |  <,   1,  2,  3,  4,  5,  6,  7,  8,  9,  10, >,  >>
+SELECT: 7   |  <,   1,  2,  3,  4,  5,  6,  7,  8,  9,  10, >,  >>
+SELECT: 8   |  <,   1,  2,  3,  4,  5,  6,  7,  8,  9,  10, >,  >>
+SELECT: 9   |  <,   1,  2,  3,  4,  5,  6,  7,  8,  9,  10, >,  >>
+SELECT: 10  |  <,   1,  2,  3,  4,  5,  6,  7,  8,  9,  10, >,  >>
+SELECT: 11  |  <<,  <,  11, 12, 13, 14, 15, 16, 17, 18, 19, 20, >
+SELECT: 12  |  <<,  <,  11, 12, 13, 14, 15, 16, 17, 18, 19, 20, >
+SELECT: 13  |  <<,  <,  11, 12, 13, 14, 15, 16, 17, 18, 19, 20, >
+SELECT: 14  |  <<,  <,  11, 12, 13, 14, 15, 16, 17, 18, 19, 20, >
+SELECT: 15  |  <<,  <,  11, 12, 13, 14, 15, 16, 17, 18, 19, 20, >
+SELECT: 16  |  <<,  <,  11, 12, 13, 14, 15, 16, 17, 18, 19, 20, >
+SELECT: 17  |  <<,  <,  11, 12, 13, 14, 15, 16, 17, 18, 19, 20, >
+SELECT: 18  |  <<,  <,  11, 12, 13, 14, 15, 16, 17, 18, 19, 20, >
+SELECT: 19  |  <<,  <,  11, 12, 13, 14, 15, 16, 17, 18, 19, 20, >
+SELECT: 20  |  <<,  <,  11, 12, 13, 14, 15, 16, 17, 18, 19, 20
+*/
+        [
+            {f: 1, c: 1, l: 10},
+            {f: 1, c: 2, l: 10},
+            {f: 1, c: 3, l: 10},
+            {f: 1, c: 4, l: 10},
+            {f: 1, c: 5, l: 10},
+            {f: 1, c: 6, l: 10},
+            {f: 1, c: 7, l: 10},
+            {f: 1, c: 8, l: 10},
+            {f: 1, c: 9, l: 10},
+            {f: 1, c: 10, l: 10},
+            {f: 11, c: 11, l: 20},
+            {f: 11, c: 12, l: 20},
+            {f: 11, c: 13, l: 20},
+            {f: 11, c: 14, l: 20},
+            {f: 11, c: 15, l: 20},
+            {f: 11, c: 16, l: 20},
+            {f: 11, c: 17, l: 20},
+            {f: 11, c: 18, l: 20},
+            {f: 11, c: 19, l: 20},
+            {f: 11, c: 20, l: 20},
+        ].forEach((target)=> {
+            let firstIndex = target.c > 1 ? target.c > 10 ? 2 : 1 : 0, // this is for prev(after first page) and first(after first batch)
+                lastIndex  = firstIndex + 9;
+            wrapper.setProps({page: target.c});
+            let current = {
+                cf: wrapper.find('button').at(firstIndex).text(),
+                cl: wrapper.find('button').at(lastIndex).text(),
+                    firstIndex,
+                    lastIndex,
+                ...target
+            };
+            expect(current.cf).toBe(`${current.f}`);
+            expect(current.cl).toBe(`${current.l}`);
+            // console.log(wrapper.find('button').reduce((a,v)=>`${a ? `${a},   ` : ``}${v.text()}`,null));
+        });
+    });
+});


### PR DESCRIPTION
Add reusable pagination component where the component will handle the numbering and positioning of the active page while the parent will handle the changing event  **the current page** and it is based on the **Pagination** **PaginationItem** **PaginationLink**  components.

The PropTypes for this component is 
` const propTypes = {
  page: PropTypes.number.isRequired,
  pages: PropTypes.number.isRequired,
  showPages: PropTypes.number,
  next: PropTypes.string,
  prev: PropTypes.string,
  first: PropTypes.string,
  last: PropTypes.string,
  middle:PropTypes.bool,
  onClick: PropTypes.func
};

const defaultProps = {
  page: 1,
  showPages: 10,
  next: '>',
  prev: '<',
  first: '<<',
  last: '>>',
  middle:true,
  onClick: () => null
}; `