### PR TITLE
Button & DropdownToggle updates

### DIFF
--- a/docs/lib/Components/ButtonDropdownPage.js
+++ b/docs/lib/Components/ButtonDropdownPage.js
@@ -68,8 +68,8 @@ DropdownToggle.propTypes = {
         <h3>Single button dropdowns</h3>
         <div className="docs-example">
           <div>
-            <Example color="secondary" text="Default" />
             <Example color="primary" text="Primary" />
+            <Example color="secondary" text="Secondary" />
             <Example color="success" text="Success" />
             <Example color="info" text="Info" />
             <Example color="warning" text="Warning" />
@@ -95,8 +95,8 @@ DropdownToggle.propTypes = {
         <h3>Split button dropdowns</h3>
         <div className="docs-example">
           <div>
-            <ExampleSplit color="secondary" text="Default" />
             <ExampleSplit color="primary" text="Primary" />
+            <ExampleSplit color="secondary" text="Secondary" />
             <ExampleSplit color="success" text="Success" />
             <ExampleSplit color="info" text="Info" />
             <ExampleSplit color="warning" text="Warning" />
@@ -107,9 +107,7 @@ DropdownToggle.propTypes = {
           <PrismCode className="language-jsx">
 {`<ButtonDropdown isOpen={isOpen} toggle={toggle}>
   <Button id="caret" color="primary">{this.props.text}</Button>
-  <DropdownToggle caret>
-    <Button color="primary"><span className="sr-only">Toggle Dropdown</span></Button>
-  </DropdownToggle>
+  <DropdownToggle caret color="primary" />
   <DropdownMenu>
     <DropdownItem header>Header</DropdownItem>
     <DropdownItem disabled>Action</DropdownItem>
@@ -124,8 +122,8 @@ DropdownToggle.propTypes = {
         <div className="docs-example">
           <div>
             <ButtonDropdown isOpen={this.state.btnLg} toggle={() => { this.setState({ btnLg: !this.state.btnLg }); }}>
-              <DropdownToggle caret>
-                <Button size="lg">Large Button</Button>
+              <DropdownToggle caret size="lg">
+                Large Button
               </DropdownToggle>
               <DropdownMenu>
                 <DropdownItem>Another Action</DropdownItem>
@@ -135,8 +133,8 @@ DropdownToggle.propTypes = {
           </div>
           <div className="m-t-1">
             <ButtonDropdown isOpen={this.state.btnSm} toggle={() => { this.setState({ btnSm: !this.state.btnSm }); }}>
-              <DropdownToggle caret>
-                <Button size="sm">Small Button</Button>
+              <DropdownToggle caret size="sm">
+                Small Button
               </DropdownToggle>
               <DropdownMenu>
                 <DropdownItem>Another Action</DropdownItem>
@@ -148,8 +146,8 @@ DropdownToggle.propTypes = {
         <pre>
           <PrismCode className="language-jsx">
 {`<ButtonDropdown isOpen={isOpen} toggle={toggle}>
-  <DropdownToggle caret>
-    <Button size="lg">Large Button</Button>
+  <DropdownToggle caret size="lg">
+    Large Button
   </DropdownToggle>
   <DropdownMenu>
     <DropdownItem>Another Action</DropdownItem>
@@ -158,8 +156,8 @@ DropdownToggle.propTypes = {
 </ButtonDropdown>
 
 <ButtonDropdown isOpen={isOpen} toggle={toggle}>
-  <DropdownToggle caret>
-    <Button size="sm">Small Button</Button>
+  <DropdownToggle caret size="sm">
+    Small Button
   </DropdownToggle>
   <DropdownMenu>
     <DropdownItem>Another Action</DropdownItem>
@@ -172,8 +170,8 @@ DropdownToggle.propTypes = {
         <div className="docs-example">
           <div>
             <ButtonDropdown dropup isOpen={this.state.btnDropup} toggle={() => { this.setState({ btnDropup: !this.state.btnDropup }); }}>
-              <DropdownToggle caret>
-                <Button size="lg">Dropup</Button>
+              <DropdownToggle caret size="lg">
+                Dropup
               </DropdownToggle>
               <DropdownMenu>
                 <DropdownItem>Another Action</DropdownItem>
@@ -185,8 +183,8 @@ DropdownToggle.propTypes = {
         <pre>
           <PrismCode className="language-jsx">
 {`<ButtonDropdown isOpen={isOpen} toggle={toggle} dropup>
-  <DropdownToggle caret>
-    <Button>Dropup</Button>
+  <DropdownToggle caret caret size="lg">
+    Dropup
   </DropdownToggle>
   <DropdownMenu>
     <DropdownItem>Another Action</DropdownItem>

--- a/docs/lib/Components/ButtonGroupPage.js
+++ b/docs/lib/Components/ButtonGroupPage.js
@@ -122,7 +122,7 @@ export default class ButtonGroupPage extends React.Component {
               <Button>2</Button>
               <ButtonDropdown isOpen={this.state.dropdownOpen} toggle={this.toggle}>
                 <DropdownToggle caret>
-                  <Button>Dropdown</Button>
+                  Dropdown
                 </DropdownToggle>
                 <DropdownMenu>
                   <DropdownItem>Dropdown Link</DropdownItem>
@@ -139,7 +139,7 @@ export default class ButtonGroupPage extends React.Component {
   <Button>2</Button>
   <ButtonDropdown isOpen={this.state.dropdownOpen} toggle={this.toggle}>
     <DropdownToggle caret>
-      <Button>Dropdown</Button>
+      Dropdown
     </DropdownToggle>
     <DropdownMenu>
       <DropdownItem>Dropdown Link</DropdownItem>
@@ -156,7 +156,7 @@ export default class ButtonGroupPage extends React.Component {
             <Button>2</Button>
             <ButtonDropdown isOpen={this.state.dropdownOpen} toggle={this.toggle}>
               <DropdownToggle caret>
-                <Button>Dropdown</Button>
+                Dropdown
               </DropdownToggle>
               <DropdownMenu>
                 <DropdownItem>Dropdown Link</DropdownItem>
@@ -172,7 +172,7 @@ export default class ButtonGroupPage extends React.Component {
   <Button>2</Button>
   <ButtonDropdown isOpen={this.state.dropdownOpen} toggle={this.toggle}>
     <DropdownToggle caret>
-      <Button>Dropdown</Button>
+      Dropdown
     </DropdownToggle>
     <DropdownMenu>
       <DropdownItem>Dropdown Link</DropdownItem>

--- a/docs/lib/Components/ButtonsPage.js
+++ b/docs/lib/Components/ButtonsPage.js
@@ -29,11 +29,12 @@ export default class ButtonsPage extends React.Component {
 {`Button.propTypes = {
   active: PropTypes.bool,
   block: PropTypes.bool,
-  color: PropTypes.string,
+  color: PropTypes.string, // default: 'secondary'
   disabled: PropTypes.bool,
 
   // Pass in a Component to override default button element
   // example: react-router Link
+  // default: 'button'
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
 
   onClick: PropTypes.func,
@@ -52,54 +53,54 @@ export default class ButtonsPage extends React.Component {
         </pre>
         <h3>Sizes</h3>
         <div className="docs-example">
-          <Button size="lg">Large Button</Button>
+          <Button color="primary" size="lg">Large Button</Button>
           <Button color="secondary" size="lg">Large Button</Button>
         </div>
         <pre>
           <PrismCode className="language-jsx">
-{`<Button size="lg">Large Button</Button>
+{`<Button color="primary" size="lg">Large Button</Button>
 <Button color="secondary" size="lg">Large Button</Button>`}
           </PrismCode>
         </pre>
         <div className="docs-example">
-          <Button size="sm">Small Button</Button>
+          <Button color="primary" size="sm">Small Button</Button>
           <Button color="secondary" size="sm">Small Button</Button>
         </div>
         <pre>
           <PrismCode className="language-jsx">
-{`<Button size="sm">Small Button</Button>
+{`<Button color="primary" size="sm">Small Button</Button>
 <Button color="secondary" size="sm">Small Button</Button>`}
           </PrismCode>
         </pre>
         <div className="docs-example">
-          <Button size="lg" block>Block level button</Button>
+          <Button color="primary" size="lg" block>Block level button</Button>
           <Button color="secondary" size="lg" block>Block level button</Button>
         </div>
         <pre>
           <PrismCode className="language-jsx">
-{`<Button size="lg" block>Block level button</Button>
+{`<Button color="primary" size="lg" block>Block level button</Button>
 <Button color="secondary" size="lg" block>Block level button</Button>`}
           </PrismCode>
         </pre>
         <h3>Active State</h3>
         <div className="docs-example">
-          <Button size="lg" active>Primary link</Button>
+          <Button color="primary" size="lg" active>Primary link</Button>
           <Button color="secondary" size="lg" active>Link</Button>
         </div>
         <pre>
           <PrismCode className="language-jsx">
-{`<Button size="lg" active>Primary link</Button>
+{`<Button color="primary" size="lg" active>Primary link</Button>
 <Button color="secondary" size="lg" active>Link</Button>`}
           </PrismCode>
         </pre>
         <h3>Disabled State</h3>
         <div className="docs-example">
-          <Button size="lg" disabled>Primary button</Button>
+          <Button color="primary" size="lg" disabled>Primary button</Button>
           <Button color="secondary" size="lg" disabled>Button</Button>
         </div>
         <pre>
           <PrismCode className="language-jsx">
-{`<Button size="lg" disabled>Primary button</Button>
+{`<Button color="primary" size="lg" disabled>Primary button</Button>
 <Button color="secondary" size="lg" disabled>Button</Button>`}
           </PrismCode>
         </pre>

--- a/docs/lib/Components/DropdownsPage.js
+++ b/docs/lib/Components/DropdownsPage.js
@@ -1,5 +1,6 @@
 /* eslint react/no-multi-comp: 0, react/prop-types: 0 */
 import React from 'react';
+import { Link } from 'react-router';
 import { PrismCode } from 'react-prism';
 import Helmet from 'react-helmet';
 import {
@@ -32,6 +33,13 @@ export default class DropdownPage extends React.Component {
       <div>
         <Helmet title="Dropdowns" />
         <h3>Dropdowns</h3>
+        <p>
+          The <code>Dropdown</code> component is used to pass the <code>isOpen</code> & <code>toggle</code> props via context to the following components: <code>DropdownToggle</code>, <code>DropdownMenu</code>. The <code>DropdownToggle</code> uses the <code>Button</code> component internally, meaning it also accepts all the props the <Link to="/components/buttons/">Button component</Link> accepts.
+        </p>
+        <h4>Advanced Positioning</h4>
+        <p>
+          The <code>DropdownMenu</code> can automatically be flipped (dropup vs dropdown) according to space available in the viewport by passing the <code>tether</code> prop to Dropdown <code>{`<Dropdown tether />`}</code>. For full customization, an object with <a href="http://tether.io/#options">Tether options</a> can be used instead.
+        </p>
         <div className="docs-example">
           <DropdownExample />
         </div>
@@ -48,7 +56,7 @@ export default class DropdownPage extends React.Component {
   dropup: PropTypes.bool,
   group: PropTypes.bool,
   isOpen: PropTypes.bool,
-  tag: PropTypes.string,
+  tag: PropTypes.string, // default: 'div'
   tether: PropTypes.oneOfType([PropTypes.object, PropTypes.bool]),
   toggle: PropTypes.func
 };
@@ -56,10 +64,14 @@ export default class DropdownPage extends React.Component {
 DropdownToggle.propTypes = {
   caret: PropTypes.bool,
   color: PropTypes.string,
+  className: PropTypes.any,
   disabled: PropTypes.bool,
   onClick: PropTypes.func,
   'data-toggle': PropTypes.string,
-  'aria-haspopup': PropTypes.bool
+  'aria-haspopup': PropTypes.bool,
+
+  // Defaults to Button component
+  tag: PropTypes.any
 };`}
           </PrismCode>
         </pre>

--- a/docs/lib/examples/ButtonDropdownMultiSplit.js
+++ b/docs/lib/examples/ButtonDropdownMultiSplit.js
@@ -21,9 +21,7 @@ export default class Example extends React.Component {
     return (
       <ButtonDropdown isOpen={this.state.dropdownOpen} toggle={this.toggle}>
         <Button id="caret" color={this.props.color}>{this.props.text}</Button>
-        <DropdownToggle caret split>
-          <Button color={this.props.color}><span className="sr-only">Toggle Dropdown</span></Button>
-        </DropdownToggle>
+        <DropdownToggle split color={this.props.color} />
         <DropdownMenu>
           <DropdownItem header>Header</DropdownItem>
           <DropdownItem disabled>Action</DropdownItem>

--- a/src/Button.js
+++ b/src/Button.js
@@ -15,7 +15,7 @@ const propTypes = {
 };
 
 const defaultProps = {
-  color: 'primary',
+  color: 'secondary',
   tag: 'button'
 };
 

--- a/src/DropdownToggle.js
+++ b/src/DropdownToggle.js
@@ -1,11 +1,11 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import Button from './Button';
 
 const propTypes = {
   caret: PropTypes.bool,
-  children: PropTypes.node.isRequired,
+  children: PropTypes.node,
   className: PropTypes.any,
-  color: PropTypes.string,
   disabled: PropTypes.bool,
   onClick: PropTypes.func,
   'data-toggle': PropTypes.string,
@@ -18,7 +18,7 @@ const defaultProps = {
   'data-toggle': 'dropdown',
   'aria-haspopup': true,
   color: 'secondary',
-  tag: 'button'
+  tag: Button
 };
 
 const contextTypes = {
@@ -47,39 +47,26 @@ class DropdownToggle extends React.Component {
   }
 
   render() {
-    const { className, children, caret, color, split, tag: Tag, ...props } = this.props;
+    const { className, caret, split, tag: Tag, ...props } = this.props;
+    const ariaLabel = props['aria-label'] || 'Toggle Dropdown';
     const classes = classNames(
       className,
       {
-        'dropdown-toggle': caret,
+        'dropdown-toggle': caret || split,
         'dropdown-toggle-split': split,
         active: this.context.isOpen,
       }
     );
-    const buttonClasses = classNames(
-      classes,
-      'btn',
-      'btn-' + color
-    );
-
-    if (React.isValidElement(children)) {
-      return React.cloneElement(React.Children.only(children), {
-        ...props,
-        className: classes,
-        onClick: this.onClick,
-        'aria-haspopup': true,
-        'aria-expanded': this.context.isOpen
-      });
-    }
+    const children = props.children || <span className="sr-only">{ariaLabel}</span>;
 
     return (
       <Tag
         {...props}
-        children={children}
-        className={buttonClasses}
+        className={classes}
         onClick={this.onClick}
         aria-haspopup="true"
         aria-expanded={this.context.isOpen}
+        children={children}
       />
     );
   }

--- a/test/Button.spec.js
+++ b/test/Button.spec.js
@@ -28,7 +28,7 @@ describe('Button', () => {
   it('should render buttons with default color', () => {
     const wrapper = shallow(<Button>Default Button</Button>);
 
-    expect(wrapper.hasClass('btn-primary')).toBe(true);
+    expect(wrapper.hasClass('btn-secondary')).toBe(true);
   });
 
   it('should render buttons with other colors', () => {
@@ -40,7 +40,7 @@ describe('Button', () => {
   it('should render buttons with outline variant', () => {
     const wrapper = shallow(<Button outline>Default Button</Button>);
 
-    expect(wrapper.hasClass('btn-outline-primary')).toBe(true);
+    expect(wrapper.hasClass('btn-outline-secondary')).toBe(true);
   });
 
   it('should render buttons with outline variant with different colors', () => {

--- a/test/DropdownToggle.spec.js
+++ b/test/DropdownToggle.spec.js
@@ -27,9 +27,39 @@ describe('DropdownToggle', () => {
     expect(wrapper.find('[data-toggle="dropdown"]').length).toBe(1);
   });
 
+  it('should add default sr-only content', () => {
+    const wrapper = mount(
+      <DropdownToggle />,
+      {
+        context: {
+          isOpen: isOpen,
+          toggle: toggle
+        }
+      }
+    );
+
+    expect(wrapper.text()).toBe('Toggle Dropdown');
+    expect(wrapper.find('.sr-only').length).toBe(1);
+  });
+
+  it('should add default sr-only content', () => {
+    const wrapper = mount(
+      <DropdownToggle aria-label="Dropup Toggle" />,
+      {
+        context: {
+          isOpen: isOpen,
+          toggle: toggle
+        }
+      }
+    );
+
+    expect(wrapper.text()).toBe('Dropup Toggle');
+    expect(wrapper.find('.sr-only').length).toBe(1);
+  });
+
   it('should render elements', () => {
     const wrapper = mount(
-      <DropdownToggle><Button>Click Me</Button></DropdownToggle>,
+      <DropdownToggle>Click Me</DropdownToggle>,
       {
         context: {
           isOpen: isOpen,


### PR DESCRIPTION
This fixes some inconsistencies within button and dropdown components and removes some weird behavior found in #98.

- Button color defaults to `secondary` (previously default style in bs3)
- DropdownToggle: no longer clones each element in props.children when it’s an array, instead it renders props.children inside a single component (Button) with the onClick toggle context.

<!--
BREAKING CHANGE: DropdownToggle no longer clones each element in props.children when it’s an array, instead it renders props.children inside a single component (Butt

BREAKING CHANGE: Button color now defaults to “secondary”. This behavior aligns with DropdownToggle color default.

Closes #98 
-->