### PR TITLE
fix(modal): fix event listener for modal

### DIFF
--- a/src/Modal.js
+++ b/src/Modal.js
@@ -100,7 +100,7 @@ class Modal extends React.Component {
   }
 
   removeEvents() {
-    document.removeEventListener('click', this.handleBackdropClick, false);
+    document.removeEventListener('click', this.handleBackdropClick, true);
     document.removeEventListener('keyup', this.handleEscape, false);
   }
 
@@ -115,7 +115,7 @@ class Modal extends React.Component {
     this._element.setAttribute('tabindex', '-1');
 
     document.body.appendChild(this._element);
-    document.addEventListener('click', this.handleBackdropClick, false);
+    document.addEventListener('click', this.handleBackdropClick, true);
     document.addEventListener('keyup', this.handleEscape, false);
 
     document.body.className = classNames(


### PR DESCRIPTION
Fixes #126
Change the event listeners for click and keyup in modal
to set `useCapture` to true to trigger the handler before
any other handler.