### PR TITLE
fix(TabContent): fix TabContent test coverage

### DIFF
--- a/src/TabContent.js
+++ b/src/TabContent.js
@@ -34,7 +34,7 @@ export default class TabContent extends Component {
     const classes = classnames('tab-content', this.props.className);
     return (
       <div className={classes}>
-        { this.props.children }
+        {this.props.children}
       </div>
     );
   }

--- a/test/Tabs.spec.js
+++ b/test/Tabs.spec.js
@@ -1,10 +1,7 @@
 /* eslint react/no-multi-comp: 0, react/prop-types: 0 */
 import React from 'react';
-import ReactDOM from 'react-dom';
-
 import { mount } from 'enzyme';
-import { Nav, NavItem, NavLink, TabContent, TabPane } from 'reactstrap';
-import classnames from 'classnames';
+import { TabContent } from 'reactstrap';
 // Not sure if this is correct but didn't want to repeat a whole bunch of code.
 import TabsExample from '../docs/lib/examples/Tabs';
 
@@ -16,12 +13,14 @@ describe('Tabs', () => {
     expect(tab1.find('.tab-content').length).toBe(1);
     expect(tab1.find('.tab-pane').length).toBe(2);
   });
+
   it('should have tab1 as active', () => {
     let tab1 = mount(<TabsExample />);
     expect(tab1.find('.nav .nav-item .nav-link').at(0).hasClass('active')).toBe(true);
     expect(tab1.find('.nav .nav-item .nav-link').at(1).hasClass('active')).toBe(false);
     expect(tab1.find('.tab-content .tab-pane').at(0).hasClass('active')).toBe(true);
   });
+
   it('should switch to tab2 as active when clicked', () => {
     let tab1 = mount(<TabsExample />);
     expect(tab1.find('.nav .nav-item .nav-link').at(0).hasClass('active')).toBe(true);
@@ -33,6 +32,15 @@ describe('Tabs', () => {
     expect(tab1.find('.tab-content .tab-pane').at(1).hasClass('active')).toBe(true);
     tab1.find('.nav .nav-item .nav-link').at(0).simulate('click');
   });
+
+  it('should not setState when the active tab does not change during a prop update', () => {
+    const tab1 = mount(<TabContent activeTab={1} />);
+    const instance = tab1.instance();
+    spyOn(instance, 'setState').and.callThrough();
+    tab1.setProps({ style: { textAlign: 'left' } });
+    expect(instance.setState).not.toHaveBeenCalled();
+  });
+
   it('should show no active tabs if active tab id is unknown', () => {
     let tab1 = mount(<TabsExample />);
     const instance = tab1.instance();
@@ -47,6 +55,7 @@ describe('Tabs', () => {
     expect(tab1.find('.nav .nav-item .nav-link').at(1).hasClass('active')).toBe(false);
     expect(tab1.find('.tab-content .tab-pane').at(0).hasClass('active')).toBe(false);
   });
+
   it('should do nothing clicking on the same tab', () => {
     let tab1 = mount(<TabsExample />);
     expect(tab1.find('.nav .nav-item .nav-link').at(0).hasClass('active')).toBe(true);


### PR DESCRIPTION
Adds additional test to bring coverage back up to 100%

Also, just throwing this in here. I do not like the way the tests were written for the Tab components. Testing is supposed to improve code confidence, but I do not feel these tests did that for me.