### PR TITLE
feat(Modal): allow for multiple modals

### DIFF
--- a/src/Modal.js
+++ b/src/Modal.js
@@ -88,7 +88,6 @@ class Modal extends React.Component {
 
   destroy() {
     const classes = document.body.className.replace('modal-open', '');
-    this.removeEvents();
 
     if (this._element) {
       ReactDOM.unmountComponentAtNode(this._element);
@@ -99,14 +98,8 @@ class Modal extends React.Component {
     document.body.className = classNames(classes).trim();
   }
 
-  removeEvents() {
-    document.removeEventListener('click', this.handleBackdropClick, true);
-    document.removeEventListener('keyup', this.handleEscape, false);
-  }
-
   hide() {
     this.renderIntoSubtree();
-    this.removeEvents();
   }
 
   show() {
@@ -115,8 +108,6 @@ class Modal extends React.Component {
     this._element.setAttribute('tabindex', '-1');
 
     document.body.appendChild(this._element);
-    document.addEventListener('click', this.handleBackdropClick, true);
-    document.addEventListener('keyup', this.handleEscape, false);
 
     document.body.className = classNames(
       classes,
@@ -135,7 +126,7 @@ class Modal extends React.Component {
 
     // check if modal should receive focus
     if (this._focus) {
-      this._element.focus();
+      this._dialog.parentNode.focus();
       this._focus = false;
     }
   }
@@ -151,6 +142,8 @@ class Modal extends React.Component {
             transitionAppearTimeout={300}
             transitionEnterTimeout={300}
             transitionLeaveTimeout={300}
+            onClickCapture={this.handleBackdropClick}
+            onKeyUp={this.handleEscape}
             className="modal"
             style={{ display: 'block' }}
             tabIndex="-1"

--- a/test/Modal.spec.js
+++ b/test/Modal.spec.js
@@ -266,7 +266,7 @@ describe('Modal', () => {
 
     expect(isOpen).toBe(true);
 
-    document.getElementsByClassName('modal-backdrop')[0].click();
+    document.getElementsByClassName('modal')[0].click();
     jasmine.clock().tick(300);
 
     expect(isOpen).toBe(false);


### PR DESCRIPTION
Resolves #137
Moves the click and keyup listeners from the document to the
`.modal` div, which wraps the modal-dialog. This allows for each
modal to be individually triggered to close.