### PR TITLE
feat: add delay prop to Tooltip

### DIFF
--- a/docs/lib/Components/TooltipsPage.js
+++ b/docs/lib/Components/TooltipsPage.js
@@ -34,6 +34,8 @@ export default class TooltipsPage extends React.Component {
   // target div ID, popover is attached to this element
   tether: PropTypes.oneOfType([PropTypes.object, PropTypes.bool]),
   // optionally overide tether config http://tether.io/#options
+  delay: PropTypes.oneOfType([PropTypes.object, PropTypes.number]),
+  // optionally override show/hide delays - default { show: 0, hide: 250 }
   placement: PropTypes.oneOf([
     'top',
     'bottom',

--- a/test/Tooltip.spec.js
+++ b/test/Tooltip.spec.js
@@ -137,10 +137,10 @@ describe('Tooltip', () => {
     wrapper.detach();
   });
 
-  it('should clear timeout if it exists on target click', () => {
+  it('should clear hide timeout if it exists on target click', () => {
     const wrapper = mount(
       (
-        <Tooltip target="target" isOpen={isOpen} toggle={toggle}>
+        <Tooltip target="target" isOpen={isOpen} toggle={toggle} delay={200}>
           Tooltip Content
         </Tooltip>
     ), { attachTo: container });
@@ -149,7 +149,7 @@ describe('Tooltip', () => {
     instance.onMouseLeaveTooltip();
     expect(isOpen).toBe(false);
     instance.handleDocumentClick({ target: target });
-    jasmine.clock().tick(250);
+    jasmine.clock().tick(200);
     expect(isOpen).toBe(true);
     wrapper.setProps({ isOpen: isOpen });
     instance.handleDocumentClick({ target: target });
@@ -178,7 +178,7 @@ describe('Tooltip', () => {
     wrapper.detach();
   });
 
-  describe('onTimeout', () => {
+  describe('hide', () => {
     it('should call toggle when isOpen', () => {
       spyOn(Tooltip.prototype, 'toggle').and.callThrough();
       isOpen = true;
@@ -192,7 +192,7 @@ describe('Tooltip', () => {
 
       expect(Tooltip.prototype.toggle).not.toHaveBeenCalled();
 
-      instance.onTimeout();
+      instance.hide();
 
       expect(Tooltip.prototype.toggle).toHaveBeenCalled();
 
@@ -211,7 +211,48 @@ describe('Tooltip', () => {
 
       expect(Tooltip.prototype.toggle).not.toHaveBeenCalled();
 
-      instance.onTimeout();
+      instance.hide();
+
+      expect(Tooltip.prototype.toggle).not.toHaveBeenCalled();
+
+      wrapper.detach();
+    });
+  });
+
+  describe('show', () => {
+    it('should call toggle when isOpen is false', () => {
+      spyOn(Tooltip.prototype, 'toggle').and.callThrough();
+      const wrapper = mount(
+        (
+          <Tooltip target="target" isOpen={isOpen} toggle={toggle}>
+            Tooltip Content
+          </Tooltip>
+      ), { attachTo: container });
+      const instance = wrapper.instance();
+
+      expect(Tooltip.prototype.toggle).not.toHaveBeenCalled();
+
+      instance.show();
+
+      expect(Tooltip.prototype.toggle).toHaveBeenCalled();
+
+      wrapper.detach();
+    });
+
+    it('should not call toggle when isOpen', () => {
+      spyOn(Tooltip.prototype, 'toggle').and.callThrough();
+      isOpen = true;
+      const wrapper = mount(
+        (
+          <Tooltip target="target" isOpen={isOpen} toggle={toggle}>
+            Tooltip Content
+          </Tooltip>
+      ), { attachTo: container });
+      const instance = wrapper.instance();
+
+      expect(Tooltip.prototype.toggle).not.toHaveBeenCalled();
+
+      instance.show();
 
       expect(Tooltip.prototype.toggle).not.toHaveBeenCalled();
 
@@ -224,7 +265,7 @@ describe('Tooltip', () => {
       spyOn(Tooltip.prototype, 'toggle').and.callThrough();
       const wrapper = mount(
         (
-          <Tooltip target="target" isOpen={isOpen} toggle={toggle}>
+          <Tooltip target="target" isOpen={isOpen} toggle={toggle} delay={{show: 200, hide: 200}}>
             Tooltip Content
           </Tooltip>
       ), { attachTo: container });
@@ -236,6 +277,7 @@ describe('Tooltip', () => {
       expect(Tooltip.prototype.toggle).not.toHaveBeenCalled();
 
       instance.onMouseOverTooltip();
+      jasmine.clock().tick(200);
 
       expect(Tooltip.prototype.toggle).toHaveBeenCalled();
 
@@ -247,7 +289,29 @@ describe('Tooltip', () => {
       isOpen = true;
       const wrapper = mount(
         (
-          <Tooltip target="target" isOpen={isOpen} toggle={toggle}>
+          <Tooltip target="target" isOpen={isOpen} toggle={toggle} delay={0}>
+            Tooltip Content
+          </Tooltip>
+      ), { attachTo: container });
+      const instance = wrapper.instance();
+
+      instance.onMouseOverTooltip();
+      jasmine.clock().tick(0);  // delay: 0 toggle is still async
+
+      expect(isOpen).toBe(true);
+      expect(Tooltip.prototype.toggle).not.toHaveBeenCalled();
+
+      wrapper.detach();
+    });
+  });
+
+  describe('onMouseLeaveTooltip', () => {
+    it('should clear timeout if it exists on target click', () => {
+      spyOn(Tooltip.prototype, 'toggle').and.callThrough();
+      isOpen = true;
+      const wrapper = mount(
+        (
+          <Tooltip target="target" isOpen={isOpen} toggle={toggle} delay={{show: 200, hide: 200}}>
             Tooltip Content
           </Tooltip>
       ), { attachTo: container });
@@ -256,6 +320,31 @@ describe('Tooltip', () => {
       instance.onMouseOverTooltip();
 
       expect(isOpen).toBe(true);
+      expect(Tooltip.prototype.toggle).not.toHaveBeenCalled();
+
+      instance.onMouseLeaveTooltip();
+      jasmine.clock().tick(200);
+
+      expect(Tooltip.prototype.toggle).toHaveBeenCalled();
+
+      wrapper.detach();
+    });
+
+    it('should not call .toggle if isOpen is false', () => {
+      spyOn(Tooltip.prototype, 'toggle').and.callThrough();
+      isOpen = false;
+      const wrapper = mount(
+        (
+          <Tooltip target="target" isOpen={isOpen} toggle={toggle} delay={0}>
+            Tooltip Content
+          </Tooltip>
+      ), { attachTo: container });
+      const instance = wrapper.instance();
+
+      instance.onMouseLeaveTooltip();
+      jasmine.clock().tick(0);  // delay: 0 toggle is still async
+
+      expect(isOpen).toBe(false);
       expect(Tooltip.prototype.toggle).not.toHaveBeenCalled();
 
       wrapper.detach();


### PR DESCRIPTION
Previous delay was a harcoded value of 250ms for the *hide*, and no delay for the
*show*.
New prop `delay` allows for either an object of form:
`{ show: 100, hide: 200 }` or simply a number to set these delays.
Default is `{ show: 0, hide: 250 }`

Closes #115