### PR TITLE
fix: fix lint task on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "prebuild": "babel src --out-dir lib",
     "create-release": "npm test && sh ./scripts/release",
     "publish-release": "npm test && sh ./scripts/publish",
-    "lint": "eslint 'src/**'"
+    "lint": "eslint src/**"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
By the looks of it the `eslint 'src/**'` was not matching any src files on windows. Possibly only tested on MAC?
Changing it to `eslint src/**` uncovers many linting errors.
Fixing those errors should probably go in this PR too.

