### PR TITLE
fix(label): add disabled class when form-check-inline and disabled

### DIFF
--- a/src/Label.js
+++ b/src/Label.js
@@ -21,6 +21,7 @@ const propTypes = {
   hidden: PropTypes.bool,
   check: PropTypes.bool,
   inline: PropTypes.bool,
+  disabled: PropTypes.bool,
   size: PropTypes.string,
   for: PropTypes.string,
   tag: PropTypes.string,
@@ -43,6 +44,7 @@ const Label = (props) => {
     tag: Tag,
     check,
     inline,
+    disabled,
     size,
     for: htmlFor,
     ...attributes,
@@ -70,6 +72,7 @@ const Label = (props) => {
     className,
     hidden ? 'sr-only' : false,
     check ? `form-check-${inline ? 'inline' : 'label'}` : false,
+    check && inline && disabled ? 'disabled' : false,
     size ? `col-form-label-${size}` : false,
     colClasses,
     colClasses.length ? 'col-form-label' : false

--- a/src/__tests__/Label.spec.js
+++ b/src/__tests__/Label.spec.js
@@ -57,6 +57,12 @@ describe('Label', () => {
     expect(wrapper.hasClass('form-check-inline')).toBe(false);
   });
 
+  it('should not render with "disabled" class when check and disabled props are truthy and inline is not', () => {
+    const wrapper = shallow(<Label check disabled>Yo!</Label>);
+
+    expect(wrapper.hasClass('disabled')).toBe(false);
+  });
+
   it('should render with "form-check-inline" class when check and inline props are truthy', () => {
     const wrapper = shallow(<Label check inline>Yo!</Label>);
 
@@ -69,10 +75,22 @@ describe('Label', () => {
     expect(wrapper.hasClass('form-check-label')).toBe(false);
   });
 
+  it('should not render with "disabled" class when check, inline, and disabled props are truthy', () => {
+    const wrapper = shallow(<Label check inline disabled>Yo!</Label>);
+
+    expect(wrapper.hasClass('disabled')).toBe(true);
+  });
+
   it('should not render with "form-check-inline" class when inline prop is truthy and check is not', () => {
     const wrapper = shallow(<Label inline>Yo!</Label>);
 
     expect(wrapper.hasClass('form-check-inline')).toBe(false);
+  });
+
+  it('should not render with "disabled" class when inline and disabled props are truthy and check is not', () => {
+    const wrapper = shallow(<Label inline disabled>Yo!</Label>);
+
+    expect(wrapper.hasClass('disabled')).toBe(false);
   });
 
   it('should not render with "form-check-inline" nor "form-check-label" by default', () => {


### PR DESCRIPTION
Adds the disabled class when the label has both the inline and
check props. This is the way bootstrap disables inline radio
and checkboxes since there is no wrapping element.

I must have missed this use-case before when creating the forms and labels. The whole form-check classes are new to bootstrap 4.

Note: there is currently an open issue with bootstrap (twbs/bootstrap#20799) to correct the color of the disabled label's text (and to clarify how to denote disabled inline radio/checkboxes in the docs as it is not there, I had to infer it from [the styles](https://github.com/twbs/bootstrap/blob/v4.0.0-alpha.4/scss/_forms.scss#L241-L243))