### PR TITLE
Add Alert Component

### DIFF
--- a/docs/lib/Components/AlertPage.js
+++ b/docs/lib/Components/AlertPage.js
@@ -1,0 +1,41 @@
+/* eslint react/no-multi-comp: 0, react/prop-types: 0 */
+import React from 'react';
+import { PrismCode } from 'react-prism';
+import { Alert } from 'reactstrap';
+import Helmet from 'react-helmet';
+
+import AlertExample from '../examples/Alert';
+const AlertExampleSource = require('!!raw!../examples/Alert');
+
+import AlertDismissExample from '../examples/AlertDismiss';
+const AlertDismissExampleSource = require('!!raw!../examples/AlertDismiss');
+
+export default class AlertPage extends React.Component {
+  render() {
+    return (
+      <div>
+        <Helmet title="Alerts" />
+
+        <h3>Alert</h3>
+        <div className="docs-example">
+          <AlertExample />
+        </div>
+        <pre>
+          <PrismCode className="language-jsx">
+            {AlertExampleSource}
+          </PrismCode>
+        </pre>
+
+        <h3>Dismissing</h3>
+        <div className="docs-example">
+          <AlertDismissExample />
+        </div>
+        <pre>
+          <PrismCode className="language-jsx">
+            {AlertDismissExampleSource}
+          </PrismCode>
+        </pre>
+      </div>
+    );
+  }
+}

--- a/docs/lib/Components/AlertsPage.js
+++ b/docs/lib/Components/AlertsPage.js
@@ -10,13 +10,13 @@ const AlertExampleSource = require('!!raw!../examples/Alert');
 import AlertDismissExample from '../examples/AlertDismiss';
 const AlertDismissExampleSource = require('!!raw!../examples/AlertDismiss');
 
-export default class AlertPage extends React.Component {
+export default class AlertsPage extends React.Component {
   render() {
     return (
       <div>
         <Helmet title="Alerts" />
 
-        <h3>Alert</h3>
+        <h3>Alerts</h3>
         <div className="docs-example">
           <AlertExample />
         </div>

--- a/docs/lib/Components/AlertsPage.js
+++ b/docs/lib/Components/AlertsPage.js
@@ -26,6 +26,24 @@ export default class AlertsPage extends React.Component {
           </PrismCode>
         </pre>
 
+        <h3>Properties</h3>
+        <pre>
+          <PrismCode className="language-jsx">
+{`Alert.propTypes = {
+  className: PropTypes.any,
+  color: PropTypes.string, // default: 'success'
+  isOpen: PropTypes.bool,  // default: true
+  toggle: PropTypes.func,
+  tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+
+  // Set any of the timeouts to 0 to disable animation
+  transitionAppearTimeout: PropTypes.number,
+  transitionEnterTimeout: PropTypes.number,
+  transitionLeaveTimeout: PropTypes.number
+}`}
+          </PrismCode>
+        </pre>
+
         <h3>Dismissing</h3>
         <div className="docs-example">
           <AlertDismissExample />

--- a/docs/lib/Components/index.js
+++ b/docs/lib/Components/index.js
@@ -106,8 +106,8 @@ class Components extends React.Component {
           to: '/components/jumbotron/'
         },
         {
-          name: 'Alert',
-          to: '/components/alert/'
+          name: 'Alerts',
+          to: '/components/alerts/'
         }
       ]
     };

--- a/docs/lib/Components/index.js
+++ b/docs/lib/Components/index.js
@@ -104,6 +104,10 @@ class Components extends React.Component {
         {
           name: 'Jumbotron',
           to: '/components/jumbotron/'
+        },
+        {
+          name: 'Alert',
+          to: '/components/alert/'
         }
       ]
     };

--- a/docs/lib/Home/index.js
+++ b/docs/lib/Home/index.js
@@ -36,7 +36,7 @@ export default () => {
             <h3>NPM</h3>
             <p>Install reactstrap and peer dependencies via NPM</p>
             <pre>
-              <PrismCode className="language-bash">npm install --save reactstrap react-addons-transition-group react react-dom</PrismCode>
+              <PrismCode className="language-bash">npm install --save reactstrap react-addons-transition-group react-addons-css-transition-group react react-dom</PrismCode>
             </pre>
             <p>ES6 - import the components you need</p>
             <div className="docs-example">

--- a/docs/lib/examples/Alert.js
+++ b/docs/lib/examples/Alert.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Alert } from 'reactstrap';
+
+const Example = (props) => {
+  return (
+    <div>
+      <Alert color="success">
+        <strong>Well done!</strong> You successfully read this important alert message.
+      </Alert>
+      <Alert color="info">
+        <strong>Heads up!</strong> This alert needs your attention, but it's not super important.
+      </Alert>
+      <Alert color="warning">
+        <strong>Warning!</strong> Better check yourself, you're not looking too good.
+      </Alert>
+      <Alert color="danger">
+        <strong>Oh snap!</strong> Change a few things up and try submitting again.
+      </Alert>
+    </div>
+  );
+};
+
+export default Example;

--- a/docs/lib/examples/AlertDismiss.js
+++ b/docs/lib/examples/AlertDismiss.js
@@ -1,12 +1,26 @@
 import React from 'react';
 import { Alert } from 'reactstrap';
 
-const Example = (props) => {
-  return (
-    <Alert color="info" dismissible>
-      I am an alert and I can be dismissed!
-    </Alert>
-  );
-};
+class AlertExample extends React.Component {
+  constructor(props) {
+    super(props);
 
-export default Example;
+    this.state = {
+      visible: true
+    }
+  }
+
+  onDismiss = () => {
+    this.setState({ visible: false });
+  }
+
+  render() {
+    return (
+      <Alert color="info" isOpen={this.state.visible} toggle={this.onDismiss}>
+        I am an alert and I can be dismissed!
+      </Alert>
+    );
+  }
+}
+
+export default AlertExample;

--- a/docs/lib/examples/AlertDismiss.js
+++ b/docs/lib/examples/AlertDismiss.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Alert } from 'reactstrap';
+
+const Example = (props) => {
+  return (
+    <Alert color="info" dismissible>
+      I am an alert and I can be dismissed!
+    </Alert>
+  );
+};
+
+export default Example;

--- a/docs/lib/routes.js
+++ b/docs/lib/routes.js
@@ -22,7 +22,7 @@ import TablesPage from './Components/TablesPage';
 import PaginationPage from './Components/PaginationPage';
 import TabsPage from './Components/TabsPage';
 import JumbotronPage from './Components/JumbotronPage';
-import AlertPage from './Components/AlertPage';
+import AlertsPage from './Components/AlertsPage';
 import NotFound from './NotFound';
 import Components from './Components';
 import UI from './UI';
@@ -52,7 +52,7 @@ const routes = (
       <Route path="media/" component={MediaPage} />
       <Route path="pagination/" component={PaginationPage} />
       <Route path="tabs/" component={TabsPage} />
-      <Route path="alert/" component={AlertPage} />
+      <Route path="alerts/" component={AlertsPage} />
       <Route path="jumbotron/" component={JumbotronPage} />
     </Route>
     <Route path="*" component={NotFound} />

--- a/docs/lib/routes.js
+++ b/docs/lib/routes.js
@@ -22,6 +22,7 @@ import TablesPage from './Components/TablesPage';
 import PaginationPage from './Components/PaginationPage';
 import TabsPage from './Components/TabsPage';
 import JumbotronPage from './Components/JumbotronPage';
+import AlertPage from './Components/AlertPage';
 import NotFound from './NotFound';
 import Components from './Components';
 import UI from './UI';
@@ -51,6 +52,7 @@ const routes = (
       <Route path="media/" component={MediaPage} />
       <Route path="pagination/" component={PaginationPage} />
       <Route path="tabs/" component={TabsPage} />
+      <Route path="alert/" component={AlertPage} />
       <Route path="jumbotron/" component={JumbotronPage} />
     </Route>
     <Route path="*" component={NotFound} />

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0",
     "react-addons-transition-group": "^0.14.0 || ^15.0.0",
+    "react-addons-css-transition-group": "^0.14.0 || ^15.0.0",
     "react-dom": "^0.14.0 || ^15.0.0"
   },
   "devDependencies": {
@@ -84,6 +85,7 @@
     "json-loader": "^0.5.4",
     "raw-loader": "^0.5.1",
     "react": "^15.3.0",
+    "react-addons-css-transition-group": "^15.3.2",
     "react-addons-test-utils": "^15.3.0",
     "react-addons-transition-group": "^15.3.0",
     "react-dom": "^15.3.0",

--- a/src/Alert.js
+++ b/src/Alert.js
@@ -1,0 +1,96 @@
+import React, { PropTypes } from 'react';
+import classNames from 'classnames';
+import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
+
+const propTypes = {
+  className: PropTypes.any,
+  color: PropTypes.string,
+  onDismiss: PropTypes.func,
+  tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string])
+};
+
+const defaultProps = {
+  color: 'warning',
+  tag: 'div'
+};
+
+export const Alert = (props) => {
+  const {
+    className,
+    tag: Tag,
+    color,
+    onDismiss,
+    ...attributes
+  } = props;
+
+  const classes = classNames(
+    className,
+    'alert',
+    `alert-${color}`,
+    { 'alert-dismissible': onDismiss }
+  );
+
+  return (
+    <Tag {...attributes} className={classes} role="alert">
+      { onDismiss ?
+        <button type="button" className="close" aria-label="Close" onClick={onDismiss}>
+          <span aria-hidden="true">&times;</span>
+        </button>
+        : null }
+      {props.children}
+    </Tag>
+  );
+};
+
+Alert.propTypes = propTypes;
+Alert.defaultProps = defaultProps;
+
+const wrapperPropTypes = {
+  dismissible: PropTypes.bool
+}
+
+const wrapperDefaultPropTypes = {
+  dismissible: false
+}
+
+class AlertWrapper extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      visible: true
+    }
+  }
+
+  onDismiss = () => {
+    this.setState({ visible: false });
+  }
+
+  render() {
+    const { dismissible, ...props } = this.props
+        , alert = <Alert {...props}
+                    key="alert"
+                    onDismiss={dismissible ? this.onDismiss : undefined} />
+
+    if (dismissible) {
+      return (
+        <ReactCSSTransitionGroup
+          transitionName={{
+            leave: 'fade',
+            leaveActive: 'out'
+          }}
+          transitionEnter={false}
+          transitionLeaveTimeout={300}>
+          {this.state.visible ? alert : null}
+        </ReactCSSTransitionGroup>
+      )
+    } else {
+      return alert;
+    }
+  }
+}
+
+AlertWrapper.propTypes = wrapperPropTypes;
+AlertWrapper.defaultProps = wrapperDefaultPropTypes;
+
+export default AlertWrapper;

--- a/src/Alert.js
+++ b/src/Alert.js
@@ -11,13 +11,19 @@ const propTypes = {
   color: PropTypes.string,
   isOpen: PropTypes.bool,
   toggle: PropTypes.func,
-  tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string])
+  tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  transitionAppearTimeout: PropTypes.number,
+  transitionEnterTimeout: PropTypes.number,
+  transitionLeaveTimeout: PropTypes.number
 };
 
 const defaultProps = {
   color: 'success',
   isOpen: true,
-  tag: 'div'
+  tag: 'div',
+  transitionAppearTimeout: 150,
+  transitionEnterTimeout: 150,
+  transitionLeaveTimeout: 150
 };
 
 const Alert = (props) => {
@@ -28,6 +34,9 @@ const Alert = (props) => {
     isOpen,
     toggle,
     children,
+    transitionAppearTimeout,
+    transitionEnterTimeout,
+    transitionLeaveTimeout,
     ...attributes
   } = props;
 
@@ -53,11 +62,20 @@ const Alert = (props) => {
     <ReactCSSTransitionGroup
       component={FirstChild}
       transitionName={{
+        appear: 'fade',
+        appearActive: 'in',
+        enter: 'fade',
+        enterActive: 'in',
         leave: 'fade',
         leaveActive: 'out'
       }}
-      transitionEnter={false}
-      transitionLeaveTimeout={300}>
+      transitionAppear={transitionAppearTimeout > 0}
+      transitionAppearTimeout={transitionAppearTimeout}
+      transitionEnter={transitionEnterTimeout > 0}
+      transitionEnterTimeout={transitionEnterTimeout}
+      transitionLeave={transitionLeaveTimeout > 0}
+      transitionLeaveTimeout={transitionLeaveTimeout}
+      >
       {isOpen ? alert : null}
     </ReactCSSTransitionGroup>
   );

--- a/src/Alert.js
+++ b/src/Alert.js
@@ -10,7 +10,7 @@ const propTypes = {
 };
 
 const defaultProps = {
-  color: 'warning',
+  color: 'success',
   tag: 'div'
 };
 

--- a/src/Alert.js
+++ b/src/Alert.js
@@ -2,24 +2,32 @@ import React, { PropTypes } from 'react';
 import classNames from 'classnames';
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 
+const FirstChild = ({ children }) => (
+  React.Children.toArray(children)[0] || null
+);
+
 const propTypes = {
   className: PropTypes.any,
   color: PropTypes.string,
-  onDismiss: PropTypes.func,
+  isOpen: PropTypes.bool,
+  toggle: PropTypes.func,
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string])
 };
 
 const defaultProps = {
   color: 'success',
+  isOpen: true,
   tag: 'div'
 };
 
-export const Alert = (props) => {
+const Alert = (props) => {
   const {
     className,
     tag: Tag,
     color,
-    onDismiss,
+    isOpen,
+    toggle,
+    children,
     ...attributes
   } = props;
 
@@ -27,70 +35,35 @@ export const Alert = (props) => {
     className,
     'alert',
     `alert-${color}`,
-    { 'alert-dismissible': onDismiss }
+    { 'alert-dismissible': toggle }
   );
 
-  return (
+  const alert = (
     <Tag {...attributes} className={classes} role="alert">
-      { onDismiss ?
-        <button type="button" className="close" aria-label="Close" onClick={onDismiss}>
+      { toggle ?
+        <button type="button" className="close" aria-label="Close" onClick={toggle}>
           <span aria-hidden="true">&times;</span>
         </button>
         : null }
-      {props.children}
+      { children }
     </Tag>
   );
-};
+
+  return (
+    <ReactCSSTransitionGroup
+      component={FirstChild}
+      transitionName={{
+        leave: 'fade',
+        leaveActive: 'out'
+      }}
+      transitionEnter={false}
+      transitionLeaveTimeout={300}>
+      {isOpen ? alert : null}
+    </ReactCSSTransitionGroup>
+  );
+}
 
 Alert.propTypes = propTypes;
 Alert.defaultProps = defaultProps;
 
-const wrapperPropTypes = {
-  dismissible: PropTypes.bool
-}
-
-const wrapperDefaultPropTypes = {
-  dismissible: false
-}
-
-class AlertWrapper extends React.Component {
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      visible: true
-    }
-  }
-
-  onDismiss = () => {
-    this.setState({ visible: false });
-  }
-
-  render() {
-    const { dismissible, ...props } = this.props
-        , alert = <Alert {...props}
-                    key="alert"
-                    onDismiss={dismissible ? this.onDismiss : undefined} />
-
-    if (dismissible) {
-      return (
-        <ReactCSSTransitionGroup
-          transitionName={{
-            leave: 'fade',
-            leaveActive: 'out'
-          }}
-          transitionEnter={false}
-          transitionLeaveTimeout={300}>
-          {this.state.visible ? alert : null}
-        </ReactCSSTransitionGroup>
-      )
-    } else {
-      return alert;
-    }
-  }
-}
-
-AlertWrapper.propTypes = wrapperPropTypes;
-AlertWrapper.defaultProps = wrapperDefaultPropTypes;
-
-export default AlertWrapper;
+export default Alert;

--- a/src/__tests__/Alert.spec.js
+++ b/src/__tests__/Alert.spec.js
@@ -9,6 +9,47 @@ describe('Alert', () => {
     expect(alert.text()).toBe('Yo!');
   });
 
+  it('should transition on appear, enter, and leave using fade', () => {
+    const alert = shallow(<Alert>Yo!</Alert>);
+    expect(alert.prop('transitionName')).toEqual({
+      appear: 'fade',
+      appearActive: 'in',
+      enter: 'fade',
+      enterActive: 'in',
+      leave: 'fade',
+      leaveActive: 'out'
+    });
+  });
+
+  it('should have default transitionTimeouts', () => {
+    const alert = shallow(<Alert>Yo!</Alert>);
+
+    expect(alert.prop('transitionAppearTimeout')).toBe(150);
+    expect(alert.prop('transitionAppear')).toBe(true);
+    expect(alert.prop('transitionEnterTimeout')).toBe(150);
+    expect(alert.prop('transitionEnter')).toBe(true);
+    expect(alert.prop('transitionLeaveTimeout')).toBe(150);
+    expect(alert.prop('transitionLeave')).toBe(true);
+  });
+
+  it('should have support configurable transitionTimeouts', () => {
+    const alert = shallow(
+      <Alert
+        transitionAppearTimeout={0}
+        transitionEnterTimeout={0}
+        transitionLeaveTimeout={0}>
+        Yo!
+      </Alert>
+    );
+
+    expect(alert.prop('transitionAppearTimeout')).toBe(0);
+    expect(alert.prop('transitionAppear')).toBe(false);
+    expect(alert.prop('transitionEnterTimeout')).toBe(0);
+    expect(alert.prop('transitionEnter')).toBe(false);
+    expect(alert.prop('transitionLeaveTimeout')).toBe(0);
+    expect(alert.prop('transitionLeave')).toBe(false);
+  });
+
   it('should have "success" as default color', () => {
     const alert = shallow(<Alert>Yo!</Alert>).find('div');
     expect(alert.hasClass('alert-success')).toBe(true);

--- a/src/__tests__/Alert.spec.js
+++ b/src/__tests__/Alert.spec.js
@@ -1,65 +1,56 @@
 import React from 'react';
-import { shallow, mount } from 'enzyme';
+import { shallow } from 'enzyme';
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
-import AlertWrapper, { Alert } from '../Alert';
+import Alert from '../Alert';
 
 describe('Alert', () => {
   it('should render children', () => {
-    const alert = shallow(<Alert>Yo!</Alert>);
+    const alert = shallow(<Alert>Yo!</Alert>).find('div');
     expect(alert.text()).toBe('Yo!');
   });
 
   it('should have "success" as default color', () => {
-    const alert = shallow(<Alert>Yo!</Alert>);
+    const alert = shallow(<Alert>Yo!</Alert>).find('div');
     expect(alert.hasClass('alert-success')).toBe(true);
   });
 
   it('should accept color prop', () => {
-    const alert = shallow(<Alert color="warning">Yo!</Alert>);
+    const alert = shallow(<Alert color="warning">Yo!</Alert>).find('div');
     expect(alert.hasClass('alert-warning')).toBe(true);
   });
 
   it('should use a div tag by default', () => {
-    const alert = shallow(<Alert>Yo!</Alert>);
+    const alert = shallow(<Alert>Yo!</Alert>).children().first();
     expect(alert.type()).toBe('div');
   });
 
   it('should be non dismissible by default', () => {
-    const alert = shallow(<Alert>Yo!</Alert>);
+    const alert = shallow(<Alert>Yo!</Alert>).find('div');
     expect(alert.find('button').length).toEqual(0);
     expect(alert.hasClass('alert-dismissible')).toBe(false);
   });
 
-  it('should show dismiss button if passed onDismiss', () => {
-    const alert = shallow(<Alert color="danger" onDismiss={() => {}}>Yo!</Alert>);
+  it('should show dismiss button if passed toggle', () => {
+    const alert = shallow(<Alert color="danger" toggle={() => {}}>Yo!</Alert>).find('div');
     expect(alert.find('button').length).toEqual(1);
     expect(alert.hasClass('alert-dismissible')).toBe(true);
   });
 
   it('should support custom tag', () => {
-    const alert = shallow(<Alert tag="p">Yo!</Alert>);
+    const alert = shallow(<Alert tag="p">Yo!</Alert>).children().first();
     expect(alert.type()).toBe('p');
   });
 
-  it('should not pass onDismiss when not dismissible', () => {
-    const alertWrapper = shallow(<AlertWrapper color="warning">Yo!</AlertWrapper>);
-    expect(alertWrapper.prop('onDismiss')).toBeFalsy();
-    expect(alertWrapper.find(ReactCSSTransitionGroup).length).toEqual(0);
+  it('should be empty if not isOpen', () => {
+    const alert = shallow(<Alert isOpen={false}>Yo!</Alert>);
+    expect(alert.html()).toBe('');
   });
 
   it('should be dismissible', () => {
-    jasmine.clock().install();
+    const onClick = jasmine.createSpy('onClick');
+    const alert = shallow(<Alert color="danger" toggle={onClick}>Yo!</Alert>);
 
-    const alertWrapper = mount(<AlertWrapper dismissible color="info">Yo!</AlertWrapper>);
-    expect(alertWrapper.find(ReactCSSTransitionGroup).length).toEqual(1);
-    expect(alertWrapper.state('visible')).toBe(true);
-
-    alertWrapper.find('button').simulate('click');
-    expect(alertWrapper.state('visible')).toBe(false);
-
-    jasmine.clock().tick(300);
-    expect(alertWrapper.text()).toBe('');
-
-    jasmine.clock().uninstall();
+    alert.find('button').simulate('click');
+    expect(onClick).toHaveBeenCalled();
   });
 });

--- a/src/__tests__/Alert.spec.js
+++ b/src/__tests__/Alert.spec.js
@@ -9,14 +9,14 @@ describe('Alert', () => {
     expect(alert.text()).toBe('Yo!');
   });
 
-  it('should have "warning" as default color', () => {
+  it('should have "success" as default color', () => {
     const alert = shallow(<Alert>Yo!</Alert>);
-    expect(alert.hasClass('alert-warning')).toBe(true);
+    expect(alert.hasClass('alert-success')).toBe(true);
   });
 
   it('should accept color prop', () => {
-    const alert = shallow(<Alert color="success">Yo!</Alert>);
-    expect(alert.hasClass('alert-success')).toBe(true);
+    const alert = shallow(<Alert color="warning">Yo!</Alert>);
+    expect(alert.hasClass('alert-warning')).toBe(true);
   });
 
   it('should use a div tag by default', () => {

--- a/src/__tests__/Alert.spec.js
+++ b/src/__tests__/Alert.spec.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import { shallow, mount } from 'enzyme';
+import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
+import AlertWrapper, { Alert } from '../Alert';
+
+describe('Alert', () => {
+  it('should render children', () => {
+    const alert = shallow(<Alert>Yo!</Alert>);
+    expect(alert.text()).toBe('Yo!');
+  });
+
+  it('should have "warning" as default color', () => {
+    const alert = shallow(<Alert>Yo!</Alert>);
+    expect(alert.hasClass('alert-warning')).toBe(true);
+  });
+
+  it('should accept color prop', () => {
+    const alert = shallow(<Alert color="success">Yo!</Alert>);
+    expect(alert.hasClass('alert-success')).toBe(true);
+  });
+
+  it('should use a div tag by default', () => {
+    const alert = shallow(<Alert>Yo!</Alert>);
+    expect(alert.type()).toBe('div');
+  });
+
+  it('should be non dismissible by default', () => {
+    const alert = shallow(<Alert>Yo!</Alert>);
+    expect(alert.find('button').length).toEqual(0);
+    expect(alert.hasClass('alert-dismissible')).toBe(false);
+  });
+
+  it('should show dismiss button if passed onDismiss', () => {
+    const alert = shallow(<Alert color="danger" onDismiss={() => {}}>Yo!</Alert>);
+    expect(alert.find('button').length).toEqual(1);
+    expect(alert.hasClass('alert-dismissible')).toBe(true);
+  });
+
+  it('should support custom tag', () => {
+    const alert = shallow(<Alert tag="p">Yo!</Alert>);
+    expect(alert.type()).toBe('p');
+  });
+
+  it('should not pass onDismiss when not dismissible', () => {
+    const alertWrapper = shallow(<AlertWrapper color="warning">Yo!</AlertWrapper>);
+    expect(alertWrapper.prop('onDismiss')).toBeFalsy();
+    expect(alertWrapper.find(ReactCSSTransitionGroup).length).toEqual(0);
+  });
+
+  it('should be dismissible', () => {
+    jasmine.clock().install();
+
+    const alertWrapper = mount(<AlertWrapper dismissible color="info">Yo!</AlertWrapper>);
+    expect(alertWrapper.find(ReactCSSTransitionGroup).length).toEqual(1);
+    expect(alertWrapper.state('visible')).toBe(true);
+
+    alertWrapper.find('button').simulate('click');
+    expect(alertWrapper.state('visible')).toBe(false);
+
+    jasmine.clock().tick(300);
+    expect(alertWrapper.text()).toBe('');
+
+    jasmine.clock().uninstall();
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -61,8 +61,10 @@ import PaginationLink from './PaginationLink';
 import TabContent from './TabContent';
 import TabPane from './TabPane';
 import Jumbotron from './Jumbotron';
+import Alert from './Alert';
 
 export {
+  Alert,
   Container,
   Row,
   Col,

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -34,6 +34,7 @@ var paths = [
   '/components/pagination/',
   '/components/tabs/',
   '/components/jumbotron/',
+  '/components/alert/',
   '/404.html'
 ];
 

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -34,7 +34,7 @@ var paths = [
   '/components/pagination/',
   '/components/tabs/',
   '/components/jumbotron/',
-  '/components/alert/',
+  '/components/alerts/',
   '/404.html'
 ];
 


### PR DESCRIPTION
Hello! I was working on a small project using reactstrap, made an alert, and thought it would be cool to clean things up and make a PR.  In summary, this simply adds a Bootstrap 4 alert, and a documentation page with some examples.

I would like to note a few things for discussion, in addition to any comments or suggestions you might have!
- I've added a peer dependency on `react-addons-css-transition-group`.  It wasn't my favorite thing to do; however, it made implementing the dismissible fade-out easier.
- I didn't know the order for the documentation pages, so I've added it to the end.
- Should there be a link to the Bootstrap docs describing how to use `.alert-heading` and `.alert-link`?  I only ask to maintain some feature parity with Bootstrap 4.
- In issue #6, there props outlined include 'isOpen' and 'toggle', but those didn't seem to match the bootstrap behavior (from my understanding).  It would be cool to add though...apologies for not asking before submitting a PR--it's easy to change and modify!
- The accessibility attributes are also included.

Thanks!