### PR TITLE
Making every URL like https://webpack.github.io/docs/webpack-dev-serv…

### DIFF
--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -41,6 +41,7 @@ var config = [{
   devtool: 'source-map',
   devServer: {
     contentBase: './build',
+    historyApiFallback: true,
     stats: {
       chunks: false
     }


### PR DESCRIPTION
…er.html to work when you hit F5 on dev mode.

Today.. if you type `npm start` and navigate to, let's say, `https://webpack.github.io/docs/webpack-dev-server.html`, and then you hit F5, the page doesn't display.

Now it does.