### PR TITLE
Add flex-support for Col component #169

### DIFF
--- a/docs/lib/Components/LayoutPage.js
+++ b/docs/lib/Components/LayoutPage.js
@@ -41,6 +41,7 @@ export default class LayoutsPage extends React.Component {
 const columnProps = PropTypes.oneOfType([
   PropTypes.string,
   PropTypes.number,
+  PropTypes.bool,
   PropTypes.shape({
     size: stringOrNumberProp,
     push: stringOrNumberProp,

--- a/docs/lib/examples/Layout.js
+++ b/docs/lib/examples/Layout.js
@@ -13,6 +13,10 @@ export default class Example extends React.Component {
           <Col xs="6">col-xs-6</Col>
         </Row>
         <Row>
+          <Col xs>.col-xs (flexbox)</Col>
+          <Col xs>.col-xs (flexbox)</Col>
+        </Row>
+        <Row>
           <Col xs="6" sm="4">col-xs-6 col-sm-4</Col>
           <Col xs="6" sm="4">col-xs-6 col-sm-4</Col>
           <Col sm="4">col-xs-12 col-sm-4</Col>
@@ -22,6 +26,10 @@ export default class Example extends React.Component {
         </Row>
         <Row>
           <Col sm="12" md={{ size: 8, offset: 2 }}>.col-xs-12 .col-sm-12 .col-md-6 .col-md-offset-3</Col>
+        </Row>
+        <Row>
+          <Col sm={{ size: 'auto', offset: 1 }}>.col-sm .col-sm-offset-1</Col>
+          <Col sm={{ size: 'auto', offset: 1 }}>.col-sm .col-sm-offset-1</Col>
         </Row>
       </Container>
     );

--- a/src/Col.js
+++ b/src/Col.js
@@ -2,7 +2,6 @@ import React, { PropTypes } from 'react';
 import classNames from 'classnames';
 
 const colSizes = ['xs', 'sm', 'md', 'lg', 'xl'];
-const colSizeProp = PropTypes.oneOfType([PropTypes.bool, PropTypes.number, PropTypes.string]);
 const stringOrNumberProp = PropTypes.oneOfType([PropTypes.number, PropTypes.string]);
 
 const columnProps = PropTypes.oneOfType([
@@ -10,7 +9,7 @@ const columnProps = PropTypes.oneOfType([
   PropTypes.number,
   PropTypes.string,
   PropTypes.shape({
-    size: colSizeProp,
+    size: stringOrNumberProp,
     push: stringOrNumberProp,
     pull: stringOrNumberProp,
     offset: stringOrNumberProp
@@ -45,7 +44,7 @@ const Col = (props) => {
     if (!columnProp) {
       return;
     } else if (columnProp.size) {
-      if (columnProp.size === 'auto' || columnProp.size === 'flex' || columnProp.size === true) {
+      if (columnProp.size === 'auto') {
         colClass = `col-${colSize}`;
       } else {
         colClass = `col-${colSize}-${columnProp.size}`;
@@ -58,7 +57,7 @@ const Col = (props) => {
         [`offset-${colSize}-${columnProp.offset}`]: columnProp.offset
       }));
     } else {
-      if (columnProp === 'auto' || columnProp === 'flex' || columnProp === true) {
+      if (columnProp === 'auto' || columnProp === true) {
         colClass = `col-${colSize}`;
       } else {
         colClass = `col-${colSize}-${columnProp}`;

--- a/src/Col.js
+++ b/src/Col.js
@@ -2,13 +2,15 @@ import React, { PropTypes } from 'react';
 import classNames from 'classnames';
 
 const colSizes = ['xs', 'sm', 'md', 'lg', 'xl'];
+const colSizeProp = PropTypes.oneOfType([PropTypes.bool, PropTypes.number, PropTypes.string]);
 const stringOrNumberProp = PropTypes.oneOfType([PropTypes.number, PropTypes.string]);
 
 const columnProps = PropTypes.oneOfType([
-  PropTypes.string,
+  PropTypes.bool,
   PropTypes.number,
+  PropTypes.string,
   PropTypes.shape({
-    size: stringOrNumberProp,
+    size: colSizeProp,
     push: stringOrNumberProp,
     pull: stringOrNumberProp,
     offset: stringOrNumberProp
@@ -38,18 +40,31 @@ const Col = (props) => {
   colSizes.forEach(colSize => {
     const columnProp = props[colSize];
     delete attributes[colSize];
+    let colClass;
 
     if (!columnProp) {
       return;
     } else if (columnProp.size) {
+      if (columnProp.size === 'auto' || columnProp.size === 'flex' || columnProp.size === true) {
+        colClass = `col-${colSize}`;
+      } else {
+        colClass = `col-${colSize}-${columnProp.size}`;
+      }
+
       colClasses.push(classNames({
-        [`col-${colSize}-${columnProp.size}`]: columnProp.size,
+        [colClass]: columnProp.size,
         [`push-${colSize}-${columnProp.push}`]: columnProp.push,
         [`pull-${colSize}-${columnProp.pull}`]: columnProp.pull,
         [`offset-${colSize}-${columnProp.offset}`]: columnProp.offset
       }));
     } else {
-      colClasses.push(`col-${colSize}-${columnProp}`);
+      if (columnProp === 'auto' || columnProp === 'flex' || columnProp === true) {
+        colClass = `col-${colSize}`;
+      } else {
+        colClass = `col-${colSize}-${columnProp}`;
+      }
+
+      colClasses.push(colClass);
     }
   });
 

--- a/src/__tests__/Col.spec.js
+++ b/src/__tests__/Col.spec.js
@@ -36,6 +36,14 @@ describe('Col', () => {
     expect(wrapper.hasClass('col-xs-12')).toBe(true);
   });
 
+  it('should pass col size as flex with values "flex" / "auto" or without value', () => {
+    const wrapper = shallow(<Col xs="auto" sm="flex" md />);
+
+    expect(wrapper.hasClass('col-xs')).toBe(true);
+    expect(wrapper.hasClass('col-sm')).toBe(true);
+    expect(wrapper.hasClass('col-md')).toBe(true);
+  });
+
   it('should pass col size specific classes via Objects', () => {
     const wrapper = shallow(<Col sm={{ size: 6, push: 2, pull: 2, offset: 2 }} />);
 
@@ -44,5 +52,17 @@ describe('Col', () => {
     expect(wrapper.hasClass('push-sm-2')).toBe(true);
     expect(wrapper.hasClass('pull-sm-2')).toBe(true);
     expect(wrapper.hasClass('offset-sm-2')).toBe(true);
+  });
+
+  it('should pass col size as flex when passing via object with size true / "auto" / "flex"', () => {
+    const wrapper = shallow(<Col
+      xs={{ size: true, push: 2, pull: 2, offset: 2 }}
+      sm={{ size: 'auto', push: 2, pull: 2, offset: 2 }}
+      md={{ size: 'flex', push: 2, pull: 2, offset: 2 }}
+    />);
+
+    expect(wrapper.hasClass('col-xs')).toBe(true);
+    expect(wrapper.hasClass('col-sm')).toBe(true);
+    expect(wrapper.hasClass('col-md')).toBe(true);
   });
 });

--- a/src/__tests__/Col.spec.js
+++ b/src/__tests__/Col.spec.js
@@ -36,12 +36,11 @@ describe('Col', () => {
     expect(wrapper.hasClass('col-xs-12')).toBe(true);
   });
 
-  it('should pass col size as flex with values "flex" / "auto" or without value', () => {
-    const wrapper = shallow(<Col xs="auto" sm="flex" md />);
+  it('should pass col size as flex with values "auto" or without value', () => {
+    const wrapper = shallow(<Col xs="auto" sm />);
 
     expect(wrapper.hasClass('col-xs')).toBe(true);
     expect(wrapper.hasClass('col-sm')).toBe(true);
-    expect(wrapper.hasClass('col-md')).toBe(true);
   });
 
   it('should pass col size specific classes via Objects', () => {
@@ -54,15 +53,11 @@ describe('Col', () => {
     expect(wrapper.hasClass('offset-sm-2')).toBe(true);
   });
 
-  it('should pass col size as flex when passing via object with size true / "auto" / "flex"', () => {
+  it('should pass col size as flex when passing via object with size "auto"', () => {
     const wrapper = shallow(<Col
-      xs={{ size: true, push: 2, pull: 2, offset: 2 }}
       sm={{ size: 'auto', push: 2, pull: 2, offset: 2 }}
-      md={{ size: 'flex', push: 2, pull: 2, offset: 2 }}
     />);
 
-    expect(wrapper.hasClass('col-xs')).toBe(true);
     expect(wrapper.hasClass('col-sm')).toBe(true);
-    expect(wrapper.hasClass('col-md')).toBe(true);
   });
 });


### PR DESCRIPTION
Hi!

As requested in issue #169 I implemented support for dropping the size for the Col component, respectively flexbox support.

I added support for all suggestions by @eddywashere, meaning a value can be dropped at all, or set to "flex" and "auto", like:

```html
<Col xs />
<Col xs="auto" />
<Col xs="flex" />

<Col
      xs={{ size: true, push: 2, pull: 2, offset: 2 }}
      sm={{ size: 'auto', push: 2, pull: 2, offset: 2 }}
      md={{ size: 'flex', push: 2, pull: 2, offset: 2 }}
/>
```

If the object's size shall accept boolean as well, and both "flex" and "auto" should be supported may needs some discussion?

Corresponding unit tests were added as well.

Looking forward to your feedback
Ronny