### PR TITLE
docs(components): fix typo in components page menu

### DIFF
--- a/docs/lib/Components/index.js
+++ b/docs/lib/Components/index.js
@@ -46,7 +46,7 @@ class Components extends React.Component {
           to: '/components/input-group/'
         },
         {
-          name: 'Breadscrumbs',
+          name: 'Breadcrumbs',
           to: '/components/breadcrumbs/'
         },
         {


### PR DESCRIPTION
Change menu item incorrectly spelled as "Breadscrumbs" to the correct form "Breadcrumbs".