### PR TITLE
feat(Input): enable refs on Input components

### DIFF
--- a/src/Input.js
+++ b/src/Input.js
@@ -1,3 +1,5 @@
+/* eslint react/prefer-stateless-function: 0 */
+
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
 
@@ -17,55 +19,57 @@ const defaultProps = {
   type: 'text',
 };
 
-const Input = (props) => {
-  const {
-    className,
-    type,
-    size,
-    state,
-    tag,
-    addon,
-    static: staticInput,
-    ...attributes,
-  } = props;
+class Input extends React.Component {
+  render() {
+    const {
+      className,
+      type,
+      size,
+      state,
+      tag,
+      addon,
+      static: staticInput,
+      ...attributes,
+    } = this.props;
 
-  const checkInput = ['radio', 'checkbox'].indexOf(type) > -1;
+    const checkInput = ['radio', 'checkbox'].indexOf(type) > -1;
 
-  const fileInput = type === 'file';
-  const textareaInput = type === 'textarea';
-  const selectInput = type === 'select';
-  let Tag = selectInput || textareaInput ? type : 'input';
+    const fileInput = type === 'file';
+    const textareaInput = type === 'textarea';
+    const selectInput = type === 'select';
+    let Tag = selectInput || textareaInput ? type : 'input';
 
-  let formControlClass = 'form-control';
+    let formControlClass = 'form-control';
 
-  if (staticInput) {
-    formControlClass = `${formControlClass}-static`;
-    Tag = tag;
-  } else if (fileInput) {
-    formControlClass = `${formControlClass}-file`;
-  } else if (checkInput) {
-    if (addon) {
-      formControlClass = null;
-    } else {
-      formControlClass = 'form-check-input';
+    if (staticInput) {
+      formControlClass = `${formControlClass}-static`;
+      Tag = tag;
+    } else if (fileInput) {
+      formControlClass = `${formControlClass}-file`;
+    } else if (checkInput) {
+      if (addon) {
+        formControlClass = null;
+      } else {
+        formControlClass = 'form-check-input';
+      }
     }
+
+    const classes = classNames(
+      className,
+      state ? `form-control-${state}` : false,
+      size ? `form-control-${size}` : false,
+      formControlClass
+    );
+
+    if (Tag === 'input') {
+      attributes.type = type;
+    }
+
+    return (
+      <Tag {...attributes} className={classes} />
+    );
   }
-
-  const classes = classNames(
-    className,
-    state ? `form-control-${state}` : false,
-    size ? `form-control-${size}` : false,
-    formControlClass
-  );
-
-  if (Tag === 'input') {
-    attributes.type = type;
-  }
-
-  return (
-    <Tag {...attributes} className={classes} />
-  );
-};
+}
 
 Input.propTypes = propTypes;
 Input.defaultProps = defaultProps;


### PR DESCRIPTION
PR enables refs on Input components. I think it’s fairly common to want to add a ref to an input for doing blur/focus or other events on the dom element.

Info can be found here: https://facebook.github.io/react/docs/more-about-refs.html#cautions

> Refs may not be attached to a stateless function, because the component does not have a backing instance. You can always wrap a stateless component in a standard composite component and attach a ref to the composite component.

Related to #172