### PR TITLE
fix(tooltip): fix when toggle is not provided

### DIFF
--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -26,7 +26,8 @@ const defaultProps = {
   isOpen: false,
   placement: 'bottom',
   delay: DEFAULT_DELAYS,
-  autohide: true
+  autohide: true,
+  toggle: function () {}
 };
 
 const defaultTetherConfig = {

--- a/src/__tests__/Tooltip.spec.js
+++ b/src/__tests__/Tooltip.spec.js
@@ -176,6 +176,22 @@ describe('Tooltip', () => {
     wrapper.detach();
   });
 
+  it('should not throw when props.toggle is not provided ', () => {
+    const event = jasmine.createSpyObj('event', ['preventDefault']);
+
+    const wrapper = mount(
+      <Tooltip target="target" isOpen={isOpen}>
+        Tooltip Content
+      </Tooltip>,
+      { attachTo: container }
+    );
+    const instance = wrapper.instance();
+
+    instance.toggle(event);
+
+    wrapper.detach();
+  });
+
   describe('delay', () => {
     it('should accept a number', () => {
       isOpen = true;


### PR DESCRIPTION
Before, when props.toggle was not provided, this.toggle would throw
Essentially when someone just provides the `isOpen` prop and wants
to manually control the hiding/showing.

`onMouseOverTooltip` would trigger `show`, which would trigger `toggle` when the tooltip was not being shown. Without `toggle` prop, it would error.