### PR TITLE
chore(docs): button spacing

### DIFF
--- a/docs/lib/Components/ButtonsPage.js
+++ b/docs/lib/Components/ButtonsPage.js
@@ -53,22 +53,22 @@ export default class ButtonsPage extends React.Component {
         </pre>
         <h3>Sizes</h3>
         <div className="docs-example">
-          <Button color="primary" size="lg">Large Button</Button>
+          <Button color="primary" size="lg">Large Button</Button>{' '}
           <Button color="secondary" size="lg">Large Button</Button>
         </div>
         <pre>
           <PrismCode className="language-jsx">
-{`<Button color="primary" size="lg">Large Button</Button>
+{`<Button color="primary" size="lg">Large Button</Button>{' '}
 <Button color="secondary" size="lg">Large Button</Button>`}
           </PrismCode>
         </pre>
         <div className="docs-example">
-          <Button color="primary" size="sm">Small Button</Button>
+          <Button color="primary" size="sm">Small Button</Button>{' '}
           <Button color="secondary" size="sm">Small Button</Button>
         </div>
         <pre>
           <PrismCode className="language-jsx">
-{`<Button color="primary" size="sm">Small Button</Button>
+{`<Button color="primary" size="sm">Small Button</Button>{' '}
 <Button color="secondary" size="sm">Small Button</Button>`}
           </PrismCode>
         </pre>
@@ -84,23 +84,23 @@ export default class ButtonsPage extends React.Component {
         </pre>
         <h3>Active State</h3>
         <div className="docs-example">
-          <Button color="primary" size="lg" active>Primary link</Button>
+          <Button color="primary" size="lg" active>Primary link</Button>{' '}
           <Button color="secondary" size="lg" active>Link</Button>
         </div>
         <pre>
           <PrismCode className="language-jsx">
-{`<Button color="primary" size="lg" active>Primary link</Button>
+{`<Button color="primary" size="lg" active>Primary link</Button>{' '}
 <Button color="secondary" size="lg" active>Link</Button>`}
           </PrismCode>
         </pre>
         <h3>Disabled State</h3>
         <div className="docs-example">
-          <Button color="primary" size="lg" disabled>Primary button</Button>
+          <Button color="primary" size="lg" disabled>Primary button</Button>{' '}
           <Button color="secondary" size="lg" disabled>Button</Button>
         </div>
         <pre>
           <PrismCode className="language-jsx">
-{`<Button color="primary" size="lg" disabled>Primary button</Button>
+{`<Button color="primary" size="lg" disabled>Primary button</Button>{' '}
 <Button color="secondary" size="lg" disabled>Button</Button>`}
           </PrismCode>
         </pre>

--- a/docs/lib/examples/Button.js
+++ b/docs/lib/examples/Button.js
@@ -5,12 +5,12 @@ export default class Example extends React.Component {
   render() {
     return (
       <div>
-        <Button color="primary">primary</Button>
-        <Button color="secondary">secondary</Button>
-        <Button color="success">success</Button>
-        <Button color="info">info</Button>
-        <Button color="warning">warning</Button>
-        <Button color="danger">danger</Button>
+        <Button color="primary">primary</Button>{' '}
+        <Button color="secondary">secondary</Button>{' '}
+        <Button color="success">success</Button>{' '}
+        <Button color="info">info</Button>{' '}
+        <Button color="warning">warning</Button>{' '}
+        <Button color="danger">danger</Button>{' '}
         <Button color="link">link</Button>
       </div>
     );

--- a/docs/lib/examples/ButtonGroup.js
+++ b/docs/lib/examples/ButtonGroup.js
@@ -5,8 +5,8 @@ export default class Example extends React.Component {
   render() {
     return (
       <ButtonGroup>
-        <Button>Left</Button>
-        <Button>Middle</Button>
+        <Button>Left</Button>{' '}
+        <Button>Middle</Button>{' '}
         <Button>Right</Button>
       </ButtonGroup>
     );

--- a/docs/lib/examples/ButtonOutline.js
+++ b/docs/lib/examples/ButtonOutline.js
@@ -5,11 +5,11 @@ export default class Example extends React.Component {
   render() {
     return (
       <div>
-        <Button outline color="primary">primary</Button>
-        <Button outline color="secondary">secondary</Button>
-        <Button outline color="success">success</Button>
-        <Button outline color="info">info</Button>
-        <Button outline color="warning">warning</Button>
+        <Button outline color="primary">primary</Button>{' '}
+        <Button outline color="secondary">secondary</Button>{' '}
+        <Button outline color="success">success</Button>{' '}
+        <Button outline color="info">info</Button>{' '}
+        <Button outline color="warning">warning</Button>{' '}
         <Button outline color="danger">danger</Button>
       </div>
     );

--- a/docs/lib/examples/TagPills.js
+++ b/docs/lib/examples/TagPills.js
@@ -5,11 +5,11 @@ export default class Example extends React.Component {
   render() {
     return (
       <div>
-        <Tag color="default" pill>default</Tag>
-        <Tag color="primary" pill>primary</Tag>
-        <Tag color="success" pill>success</Tag>
-        <Tag color="info" pill>info</Tag>
-        <Tag color="warning" pill>warning</Tag>
+        <Tag color="default" pill>default</Tag>{' '}
+        <Tag color="primary" pill>primary</Tag>{' '}
+        <Tag color="success" pill>success</Tag>{' '}
+        <Tag color="info" pill>info</Tag>{' '}
+        <Tag color="warning" pill>warning</Tag>{' '}
         <Tag color="danger" pill>danger</Tag>
       </div>
     );

--- a/docs/static/docs.css
+++ b/docs/static/docs.css
@@ -122,21 +122,6 @@ h1,h2,h3 {
   display: table;
 }
 
-.docs-example > div > .btn + .btn,
-.docs-example > .btn + .btn,
-.docs-example > div > .label + .label,
-.docs-example > div > .btn-group + .btn-group {
-  margin-left: 5px;
-}
-
-.docs-example .btn-group-vertical .btn + .btn {
-  margin-left: 0 !important;
-}
-
-.docs-example .btn-block+.btn-block {
-  margin-left: 0;
-}
-
 .docs-example .card {
   max-width: 320px;
 }


### PR DESCRIPTION
This removes the special button margin which is in the docs and
replaces it with `{' '}` to add an actual space in the HTML markup.
This makes the button spacing work like bootstrap does and documents
`{' '}` being used.

I am addressing this because I feel that it should be addressed. I have seen many developers not have spacing between buttons because they followed/copy&paste the docs here (which did not have a space, only special css) and it makes it look bad. Bootstrap intended there to be a space separating the buttons. Documenting the space saves headaches and prevents users from adding special CSS to add the space... and not have the space in some places (such as the CSS the docs were using)