### PR TITLE
fix(docs): Update Bootstrap to alpha.5 and switch to flexbox enabled …

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "babel-preset-react": "^6.11.1",
     "babel-preset-stage-0": "^6.5.0",
     "babel-preset-react-app": "^0.2.1",
-    "bootstrap": "^4.0.0-alpha.4",
+    "bootstrap": "^4.0.0-alpha.5",
     "clean-webpack-plugin": "^0.1.8",
     "conventional-changelog-cli": "^1.1.1",
     "conventional-recommended-bump": "^0.3.0",

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -94,7 +94,7 @@ var config = [{
   resolve: {
     extensions: ['', '.js', '.json'],
     alias: {
-      'bootstrap-css': path.join(__dirname,'node_modules/bootstrap/dist/css/bootstrap.css'),
+      'bootstrap-css': path.join(__dirname,'node_modules/bootstrap/dist/css/bootstrap-flex.css'),
       reactstrap: path.resolve('./src')
     }
   }


### PR DESCRIPTION
Updated to Bootstrap v4-alpha.5 which contains a precompiled CSS file with flex enabled, and updated Webpack alias to use this one.

Now the Layout example in the docs is fine.