### PR TITLE
docs(Navs): Update nav dropdown markup

### DIFF
--- a/docs/lib/examples/NavPills.js
+++ b/docs/lib/examples/NavPills.js
@@ -25,8 +25,8 @@ export default class Example extends React.Component {
             <NavLink href="#" active>Link</NavLink>
           </NavItem>
           <NavDropdown isOpen={this.state.dropdownOpen} toggle={this.toggle}>
-            <DropdownToggle caret>
-              <NavLink href="#">Dropdown</NavLink>
+            <DropdownToggle tag={NavLink} href="#" onClick={(e) => e.preventDefault()} caret>
+              Dropdown
             </DropdownToggle>
             <DropdownMenu>
               <DropdownItem header>Header</DropdownItem>

--- a/docs/lib/examples/NavTabs.js
+++ b/docs/lib/examples/NavTabs.js
@@ -25,8 +25,8 @@ export default class Example extends React.Component {
             <NavLink href="#" active>Link</NavLink>
           </NavItem>
           <NavDropdown isOpen={this.state.dropdownOpen} toggle={this.toggle}>
-            <DropdownToggle caret>
-              <NavLink href="#">Dropdown</NavLink>
+            <DropdownToggle tag={NavLink} href="#" onClick={(e) => e.preventDefault()} caret>
+              Dropdown
             </DropdownToggle>
             <DropdownMenu>
               <DropdownItem header>Header</DropdownItem>


### PR DESCRIPTION
Noticed an issue where the dropdown in nav (pills and tabs) were looking weird. It turns out it was using incorrect markup. Instead of nesting nav-link in the dropdown toggle, it should be combined. I’m not sure if this was part of alpha v5, or if the markup and classes were always off.

I’m hesitant to add a new component to simplify this or to add a prop to DropdownToggle to enable this common usage. For now, I’m updating the docs to use the built in flexibility of the existing dropdown toggle component.