### PR TITLE
feat(DropdownToggle): add nav prop to enable Nav specific functionality

### DIFF
--- a/docs/lib/Components/DropdownsPage.js
+++ b/docs/lib/Components/DropdownsPage.js
@@ -69,7 +69,8 @@ DropdownToggle.propTypes = {
   onClick: PropTypes.func,
   'data-toggle': PropTypes.string,
   'aria-haspopup': PropTypes.bool,
-
+  // For DropdownToggle usage inside a Nav
+  nav: PropTypes.bool,
   // Defaults to Button component
   tag: PropTypes.any
 };`}

--- a/docs/lib/examples/NavPills.js
+++ b/docs/lib/examples/NavPills.js
@@ -25,7 +25,7 @@ export default class Example extends React.Component {
             <NavLink href="#" active>Link</NavLink>
           </NavItem>
           <NavDropdown isOpen={this.state.dropdownOpen} toggle={this.toggle}>
-            <DropdownToggle tag={NavLink} href="#" onClick={(e) => e.preventDefault()} caret>
+            <DropdownToggle nav caret>
               Dropdown
             </DropdownToggle>
             <DropdownMenu>

--- a/docs/lib/examples/NavTabs.js
+++ b/docs/lib/examples/NavTabs.js
@@ -25,7 +25,7 @@ export default class Example extends React.Component {
             <NavLink href="#" active>Link</NavLink>
           </NavItem>
           <NavDropdown isOpen={this.state.dropdownOpen} toggle={this.toggle}>
-            <DropdownToggle tag={NavLink} href="#" onClick={(e) => e.preventDefault()} caret>
+            <DropdownToggle nav caret>
               Dropdown
             </DropdownToggle>
             <DropdownMenu>

--- a/src/DropdownToggle.js
+++ b/src/DropdownToggle.js
@@ -1,7 +1,6 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
 import Button from './Button';
-import NavLink from './NavLink';
 
 const propTypes = {
   caret: PropTypes.bool,
@@ -67,7 +66,7 @@ class DropdownToggle extends React.Component {
     const children = props.children || <span className="sr-only">{ariaLabel}</span>;
 
     if (nav) {
-      props.tag = NavLink;
+      props.tag = 'a';
       props.href = '#';
     }
 

--- a/src/DropdownToggle.js
+++ b/src/DropdownToggle.js
@@ -1,6 +1,7 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
 import Button from './Button';
+import NavLink from './NavLink';
 
 const propTypes = {
   caret: PropTypes.bool,
@@ -11,7 +12,8 @@ const propTypes = {
   'data-toggle': PropTypes.string,
   'aria-haspopup': PropTypes.bool,
   split: PropTypes.bool,
-  tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string])
+  tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  nav: PropTypes.bool
 };
 
 const defaultProps = {
@@ -39,6 +41,10 @@ class DropdownToggle extends React.Component {
       return;
     }
 
+    if (this.props.nav) {
+      e.preventDefault();
+    }
+
     if (this.props.onClick) {
       this.props.onClick(e);
     }
@@ -47,7 +53,7 @@ class DropdownToggle extends React.Component {
   }
 
   render() {
-    const { className, caret, split, tag: Tag, ...props } = this.props;
+    const { className, caret, split, nav, tag: Tag, ...props } = this.props;
     const ariaLabel = props['aria-label'] || 'Toggle Dropdown';
     const classes = classNames(
       className,
@@ -55,9 +61,15 @@ class DropdownToggle extends React.Component {
         'dropdown-toggle': caret || split,
         'dropdown-toggle-split': split,
         active: this.context.isOpen,
+        'nav-link': nav
       }
     );
     const children = props.children || <span className="sr-only">{ariaLabel}</span>;
+
+    if (nav) {
+      props.tag = NavLink;
+      props.href = '#';
+    }
 
     return (
       <Tag

--- a/src/__tests__/DropdownToggle.spec.js
+++ b/src/__tests__/DropdownToggle.spec.js
@@ -153,4 +153,38 @@ describe('DropdownToggle', () => {
       expect(e.preventDefault).toHaveBeenCalled();
     });
   });
+
+  describe('nav', () => {
+    it('should add .nav-link class', () => {
+      const wrapper = mount(
+        <DropdownToggle nav>Ello world</DropdownToggle>,
+        {
+          context: {
+            isOpen: isOpen,
+            toggle: toggle
+          }
+        }
+      );
+
+      expect(wrapper.find('a').length).toBe(1);
+      expect(wrapper.find('.nav-link').length).toBe(1);
+    });
+
+    it('should preventDefault', () => {
+      const e = { preventDefault: jasmine.createSpy('preventDefault') };
+      const wrapper = mount(
+        <DropdownToggle nav>Ello world</DropdownToggle>,
+        {
+          context: {
+            isOpen: isOpen,
+            toggle: toggle
+          }
+        }
+      );
+      const instance = wrapper.instance();
+
+      instance.onClick(e);
+      expect(e.preventDefault).toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
Follow up to #196. Decided to go with prop to simplify adding a DropdownToggle inside a Nav. There were drawbacks to using what I documented previously in #196, most around losing out on Button prop support when switching from Button to NavLink in the wrapping element for this component. By using a prop, the Button is still used, and Button props can be passed along, like color/size/etc. 