### PR TITLE
fix(events): use capture events

### DIFF
--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -105,11 +105,11 @@ class Dropdown extends React.Component {
   }
 
   addEvents() {
-    document.addEventListener('click', this.handleDocumentClick);
+    document.addEventListener('click', this.handleDocumentClick, true);
   }
 
   removeEvents() {
-    document.removeEventListener('click', this.handleDocumentClick);
+    document.removeEventListener('click', this.handleDocumentClick, true);
   }
 
   handleDocumentClick(e) {

--- a/src/TetherContent.js
+++ b/src/TetherContent.js
@@ -80,7 +80,7 @@ class TetherContent extends React.Component {
   }
 
   hide() {
-    document.removeEventListener('click', this.handleDocumentClick);
+    document.removeEventListener('click', this.handleDocumentClick, true);
 
     if (this._element) {
       document.body.removeChild(this._element);
@@ -96,7 +96,7 @@ class TetherContent extends React.Component {
   }
 
   show() {
-    document.addEventListener('click', this.handleDocumentClick);
+    document.addEventListener('click', this.handleDocumentClick, true);
 
     this._element = document.createElement('div');
     document.body.appendChild(this._element);

--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -156,15 +156,15 @@ class Tooltip extends React.Component {
   }
 
   addTargetEvents() {
-    this._target.addEventListener('mouseover', this.onMouseOverTooltip);
-    this._target.addEventListener('mouseout', this.onMouseLeaveTooltip);
-    document.addEventListener('click', this.handleDocumentClick);
+    this._target.addEventListener('mouseover', this.onMouseOverTooltip, true);
+    this._target.addEventListener('mouseout', this.onMouseLeaveTooltip, true);
+    document.addEventListener('click', this.handleDocumentClick, true);
   }
 
   removeTargetEvents() {
-    this._target.removeEventListener('mouseover', this.onMouseOverTooltip);
-    this._target.removeEventListener('mouseout', this.onMouseLeaveTooltip);
-    document.removeEventListener('click', this.handleDocumentClick);
+    this._target.removeEventListener('mouseover', this.onMouseOverTooltip, true);
+    this._target.removeEventListener('mouseout', this.onMouseLeaveTooltip, true);
+    document.removeEventListener('click', this.handleDocumentClick, true);
   }
 
   toggle(e) {


### PR DESCRIPTION
Similar to a previous issue where an event was triggered AFTER some DOM manipulation which caused the event logic to run after things changed. This really only impacted when the thing that triggered the event was no longer in the DOM which changed the flow and triggered things to happen.

It is probably best to _globally_ do the same thing, which is to handle the event as soon as possible using `useCapture`.