### PR TITLE
docs(*): fix class changes from bs4a4 to bs4a5

### DIFF
--- a/docs/lib/Components/ButtonDropdownPage.js
+++ b/docs/lib/Components/ButtonDropdownPage.js
@@ -131,7 +131,7 @@ DropdownToggle.propTypes = {
               </DropdownMenu>
             </ButtonDropdown>
           </div>
-          <div className="m-t-1">
+          <div className="mt-1">
             <ButtonDropdown isOpen={this.state.btnSm} toggle={() => { this.setState({ btnSm: !this.state.btnSm }); }}>
               <DropdownToggle caret size="sm">
                 Small Button

--- a/docs/lib/Components/ButtonGroupPage.js
+++ b/docs/lib/Components/ButtonGroupPage.js
@@ -80,13 +80,13 @@ export default class ButtonGroupPage extends React.Component {
               <Button>Right</Button>
             </ButtonGroup>
             <br />
-            <ButtonGroup className="m-t-1">
+            <ButtonGroup className="mt-1">
               <Button>Left</Button>
               <Button>Middle</Button>
               <Button>Right</Button>
             </ButtonGroup>
             <br />
-            <ButtonGroup size="sm" className="m-t-1">
+            <ButtonGroup size="sm" className="mt-1">
               <Button>Left</Button>
               <Button>Middle</Button>
               <Button>Right</Button>

--- a/docs/lib/Components/DropdownsPage.js
+++ b/docs/lib/Components/DropdownsPage.js
@@ -138,8 +138,8 @@ DropdownToggle.propTypes = {
         <div className="docs-example">
           <div>
             <DropdownSizingExample group size="lg" />
-            <DropdownSizingExample className="m-t-1" />
-            <DropdownSizingExample className="m-t-1" group size="sm" />
+            <DropdownSizingExample className="mt-1" />
+            <DropdownSizingExample className="mt-1" group size="sm" />
           </div>
         </div>
         <pre>

--- a/docs/lib/Components/index.js
+++ b/docs/lib/Components/index.js
@@ -117,7 +117,7 @@ class Components extends React.Component {
       <Container fluid className="content">
         <Row>
           <Col md={{ size: 3, push: 9 }}>
-            <div className="docs-sidebar m-b-3">
+            <div className="docs-sidebar mb-3">
               <h5>Components</h5>
               <Nav>
                 {this.state.navItems.map((item, i) => {

--- a/docs/lib/Home/index.js
+++ b/docs/lib/Home/index.js
@@ -9,7 +9,7 @@ const importBasic = require('!!raw!../examples/import-basic');
 export default () => {
   return (
     <div>
-      <Jumbotron tag="section" className="jumbotron-header text-xs-center m-b-3">
+      <Jumbotron tag="section" className="jumbotron-header text-xs-center mb-3">
         <Container fluid>
           <Row>
             <Col>
@@ -54,7 +54,7 @@ export default () => {
               </PrismCode>
             </pre>
             <p>Check out the demo <a href="http://output.jsbin.com/dimive/latest">here</a></p>
-            <h2 className="m-t-3">About the Project</h2>
+            <h2 className="mt-3">About the Project</h2>
             <hr />
             <p>This library contains React Bootstrap 4 components that favor composition and control. The library does not depend on jQuery or Bootstrap javascript. However, <a href="http://tether.io/" target="_blank">Tether</a> is relied upon for advanced positioning of content like Tooltips, Popovers, and auto-flipping Dropdowns.</p>
             <p>There are a few core concepts to understand in order to make the most out of this library.</p>

--- a/docs/lib/NotFound/index.js
+++ b/docs/lib/NotFound/index.js
@@ -7,7 +7,7 @@ export default () => {
   return (
     <div>
       <Helmet title="404 Page Not Found" />
-      <section className="jumbotron text-xs-center m-b-3">
+      <section className="jumbotron text-xs-center mb-3">
         <Container fluid>
           <Row>
             <Col>
@@ -19,7 +19,7 @@ export default () => {
                 Can't find what you're looking for? <a href="https://github.com/reactstrap/reactstrap/issues/new">Open</a> up an issue.
               </p>
               <p>
-                <Button outline color="danger" className="m-r-1" tag={Link} to="/">Get Started</Button>
+                <Button outline color="danger" className="mr-1" tag={Link} to="/">Get Started</Button>
                 <Button color="danger" tag={Link} to="/components">View Components</Button>
               </p>
             </Col>

--- a/docs/lib/UI/Nav.js
+++ b/docs/lib/UI/Nav.js
@@ -7,7 +7,7 @@ export default () => {
     <Navbar className="header" color="faded" light>
       <Container fluid>
         <NavbarBrand tag={Link} to="/">reactstrap</NavbarBrand>
-        <Nav className="nav navbar-nav pull-xs-right">
+        <Nav className="nav navbar-nav float-xs-right">
           <NavItem>
             <NavLink tag={Link} className="nav-link" to="/components/" activeClassName="active">Components</NavLink>
           </NavItem>

--- a/docs/lib/examples/Jumbotron.js
+++ b/docs/lib/examples/Jumbotron.js
@@ -7,7 +7,7 @@ const Example = (props) => {
       <Jumbotron>
         <h1 className="display-3">Hello, world!</h1>
         <p className="lead">This is a simple hero unit, a simple Jumbotron-style component for calling extra attention to featured content or information.</p>
-        <hr className="m-y-2" />
+        <hr className="my-2" />
         <p>It uses utility classes for typgraphy and spacing to space content out within the larger container.</p>
         <p className="lead">
           <Button color="primary">Learn More</Button>

--- a/docs/lib/examples/MediaAlignment.js
+++ b/docs/lib/examples/MediaAlignment.js
@@ -15,7 +15,7 @@ const Example = () => {
           Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin commodo. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis. Fusce condimentum nunc ac nisi vulputate fringilla. Donec lacinia congue felis in faucibus.
         </Media>
       </Media>
-      <Media className="m-t-1">
+      <Media className="mt-1">
         <Media left middle href="#">
           <Media object data-src="holder.js/64x64" alt="Generic placeholder image" />
         </Media>
@@ -26,7 +26,7 @@ const Example = () => {
           Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin commodo. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis. Fusce condimentum nunc ac nisi vulputate fringilla. Donec lacinia congue felis in faucibus.
         </Media>
       </Media>
-      <Media className="m-t-1">
+      <Media className="mt-1">
         <Media left bottom href="#">
           <Media object data-src="holder.js/64x64" alt="Generic placeholder image" />
         </Media>

--- a/docs/lib/examples/Navbar.js
+++ b/docs/lib/examples/Navbar.js
@@ -7,7 +7,7 @@ export default class Example extends React.Component {
       <div>
         <Navbar color="faded" light>
           <NavbarBrand href="/">reactstrap</NavbarBrand>
-          <Nav className="pull-xs-right" navbar>
+          <Nav className="float-xs-right" navbar>
             <NavItem>
               <NavLink href="/components/">Components</NavLink>
             </NavItem>

--- a/docs/lib/examples/PopoverMulti.js
+++ b/docs/lib/examples/PopoverMulti.js
@@ -22,7 +22,7 @@ class PopoverItem extends React.Component {
   render() {
     return (
       <span>
-        <Button className="m-r-1" color="secondary" id={'Popover-' + this.props.id} onClick={this.toggle}>
+        <Button className="mr-1" color="secondary" id={'Popover-' + this.props.id} onClick={this.toggle}>
           {this.props.item.text}
         </Button>
         <Popover placement={this.props.item.placement} isOpen={this.state.popoverOpen} target={'Popover-' + this.props.id} toggle={this.toggle}>

--- a/docs/lib/examples/TooltipMulti.js
+++ b/docs/lib/examples/TooltipMulti.js
@@ -22,7 +22,7 @@ class TooltipItem extends React.Component {
   render() {
     return (
       <span>
-        <Button className="m-r-1" color="secondary" id={'Tooltip-' + this.props.id}>
+        <Button className="mr-1" color="secondary" id={'Tooltip-' + this.props.id}>
           {this.props.item.text}
         </Button>
         <Tooltip placement={this.props.item.placement} isOpen={this.state.tooltipOpen} target={'Tooltip-' + this.props.id} toggle={this.toggle}>


### PR DESCRIPTION
I noticed the docs were slightly off... A few things changed from BS4a4 to BS4a5 around utilities.
Spacers dropped the first hyphen (e.g. `p-t-2` -> `pt-2`)
Pulls are now floats (e.g. `pull-xs-right` -> `float-xs-right`)