### PR TITLE
feat(cssModule): add support for css module

### DIFF
--- a/src/Alert.js
+++ b/src/Alert.js
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import { mapToCssModules } from './utils';
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 
 const FirstChild = ({ children }) => (
@@ -9,13 +10,14 @@ const FirstChild = ({ children }) => (
 const propTypes = {
   children: PropTypes.node,
   className: PropTypes.any,
+  cssModule: PropTypes.object,
   color: PropTypes.string,
   isOpen: PropTypes.bool,
   toggle: PropTypes.func,
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   transitionAppearTimeout: PropTypes.number,
   transitionEnterTimeout: PropTypes.number,
-  transitionLeaveTimeout: PropTypes.number
+  transitionLeaveTimeout: PropTypes.number,
 };
 
 const defaultProps = {
@@ -30,6 +32,7 @@ const defaultProps = {
 const Alert = (props) => {
   const {
     className,
+    cssModule,
     tag: Tag,
     color,
     isOpen,
@@ -41,12 +44,12 @@ const Alert = (props) => {
     ...attributes
   } = props;
 
-  const classes = classNames(
+  const classes = mapToCssModules(classNames(
     className,
     'alert',
     `alert-${color}`,
     { 'alert-dismissible': toggle }
-  );
+  ), cssModule);
 
   const alert = (
     <Tag {...attributes} className={classes} role="alert">

--- a/src/Breadcrumb.js
+++ b/src/Breadcrumb.js
@@ -1,9 +1,11 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import { mapToCssModules } from './utils';
 
 const propTypes = {
   tag: PropTypes.string,
-  className: PropTypes.any
+  className: PropTypes.any,
+  cssModule: PropTypes.object,
 };
 
 const defaultProps = {
@@ -13,13 +15,14 @@ const defaultProps = {
 const Breadcrumb = (props) => {
   const {
     className,
+    cssModule,
     tag: Tag,
     ...attributes
   } = props;
-  const classes = classNames(
+  const classes = mapToCssModules(classNames(
     className,
     'breadcrumb'
-  );
+  ), cssModule);
 
   return (
     <Tag {...attributes} className={classes} />

--- a/src/BreadcrumbItem.js
+++ b/src/BreadcrumbItem.js
@@ -1,10 +1,12 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import { mapToCssModules } from './utils';
 
 const propTypes = {
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   active: PropTypes.bool,
-  className: PropTypes.any
+  className: PropTypes.any,
+  cssModule: PropTypes.object,
 };
 
 const defaultProps = {
@@ -14,15 +16,16 @@ const defaultProps = {
 const BreadcrumbItem = (props) => {
   const {
     className,
+    cssModule,
     active,
     tag: Tag,
     ...attributes
   } = props;
-  const classes = classNames(
+  const classes = mapToCssModules(classNames(
     className,
     active ? 'active' : false,
     'breadcrumb-item'
-  );
+  ), cssModule);
 
   return (
     <Tag {...attributes} className={classes} />

--- a/src/Button.js
+++ b/src/Button.js
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import { mapToCssModules } from './utils';
 
 const propTypes = {
   active: PropTypes.bool,
@@ -11,7 +12,8 @@ const propTypes = {
   onClick: PropTypes.func,
   size: PropTypes.string,
   children: PropTypes.node,
-  className: PropTypes.any
+  className: PropTypes.any,
+  cssModule: PropTypes.object,
 };
 
 const defaultProps = {
@@ -42,6 +44,7 @@ class Button extends React.Component {
       active,
       block,
       className,
+      cssModule,
       color,
       outline,
       size,
@@ -49,14 +52,14 @@ class Button extends React.Component {
       ...attributes
     } = this.props;
 
-    const classes = classNames(
+    const classes = mapToCssModules(classNames(
       className,
       'btn',
       `btn${outline ? '-outline' : ''}-${color}`,
       size ? `btn-${size}` : false,
       block ? 'btn-block' : false,
       { active, disabled: this.props.disabled }
-    );
+    ), cssModule);
 
     if (attributes.href && Tag === 'button') {
       Tag = 'a';

--- a/src/ButtonDropdown.js
+++ b/src/ButtonDropdown.js
@@ -2,7 +2,7 @@ import React, { PropTypes } from 'react';
 import Dropdown from './Dropdown';
 
 const propTypes = {
-  children: PropTypes.node
+  children: PropTypes.node,
 };
 
 const ButtonDropdown = (props) => {

--- a/src/ButtonGroup.js
+++ b/src/ButtonGroup.js
@@ -1,12 +1,14 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import { mapToCssModules } from './utils';
 
 const propTypes = {
   'aria-label': PropTypes.string,
-  className: PropTypes.string,
+  className: PropTypes.any,
+  cssModule: PropTypes.object,
   role: PropTypes.string,
   size: PropTypes.string,
-  vertical: PropTypes.bool
+  vertical: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -16,16 +18,17 @@ const defaultProps = {
 const ButtonGroup = (props) => {
   const {
     className,
+    cssModule,
     size,
     vertical,
     ...attributes
   } = props;
 
-  const classes = classNames(
+  const classes = mapToCssModules(classNames(
     className,
     size ? 'btn-group-' + size : false,
     vertical ? 'btn-group-vertical' : 'btn-group'
-  );
+  ), cssModule);
 
   return (
     <div {...attributes} className={classes} />

--- a/src/ButtonToolbar.js
+++ b/src/ButtonToolbar.js
@@ -1,10 +1,12 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import { mapToCssModules } from './utils';
 
 const propTypes = {
   'aria-label': PropTypes.string,
-  className: PropTypes.string,
-  role: PropTypes.string
+  className: PropTypes.any,
+  cssModule: PropTypes.object,
+  role: PropTypes.string,
 };
 
 const defaultProps = {
@@ -14,13 +16,14 @@ const defaultProps = {
 const ButtonToolbar = (props) => {
   const {
     className,
+    cssModule,
     ...attributes
   } = props;
 
-  const classes = classNames(
+  const classes = mapToCssModules(classNames(
     className,
     'btn-toolbar'
-  );
+  ), cssModule);
 
   return (
     <div {...attributes} className={classes} />

--- a/src/Card.js
+++ b/src/Card.js
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import { mapToCssModules } from './utils';
 
 const propTypes = {
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
@@ -7,7 +8,8 @@ const propTypes = {
   color: PropTypes.string,
   block: PropTypes.bool,
   outline: PropTypes.bool,
-  className: PropTypes.any
+  className: PropTypes.any,
+  cssModule: PropTypes.object,
 };
 
 const defaultProps = {
@@ -17,6 +19,7 @@ const defaultProps = {
 const Card = (props) => {
   const {
     className,
+    cssModule,
     color,
     block,
     inverse,
@@ -24,13 +27,13 @@ const Card = (props) => {
     tag: Tag,
     ...attributes
   } = props;
-  const classes = classNames(
+  const classes = mapToCssModules(classNames(
     className,
     'card',
     inverse ? 'card-inverse' : false,
     block ? 'card-block' : false,
     color ? `card${outline ? '-outline' : ''}-${color}` : false
-  );
+  ), cssModule);
 
   return (
     <Tag {...attributes} className={classes} />

--- a/src/CardBlock.js
+++ b/src/CardBlock.js
@@ -1,9 +1,11 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import { mapToCssModules } from './utils';
 
 const propTypes = {
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  className: PropTypes.any
+  className: PropTypes.any,
+  cssModule: PropTypes.object,
 };
 
 const defaultProps = {
@@ -13,13 +15,14 @@ const defaultProps = {
 const CardBlock = (props) => {
   const {
     className,
+    cssModule,
     tag: Tag,
     ...attributes
   } = props;
-  const classes = classNames(
+  const classes = mapToCssModules(classNames(
     className,
     'card-block'
-  );
+  ), cssModule);
 
   return (
     <Tag {...attributes} className={classes} />

--- a/src/CardColumns.js
+++ b/src/CardColumns.js
@@ -1,9 +1,11 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import { mapToCssModules } from './utils';
 
 const propTypes = {
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  className: PropTypes.any
+  className: PropTypes.any,
+  cssModule: PropTypes.object,
 };
 
 const defaultProps = {
@@ -13,13 +15,14 @@ const defaultProps = {
 const CardColumns = (props) => {
   const {
     className,
+    cssModule,
     tag: Tag,
     ...attributes
   } = props;
-  const classes = classNames(
+  const classes = mapToCssModules(classNames(
     className,
     'card-columns'
-  );
+  ), cssModule);
 
   return (
     <Tag {...attributes} className={classes} />

--- a/src/CardDeck.js
+++ b/src/CardDeck.js
@@ -1,10 +1,12 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import { mapToCssModules } from './utils';
 
 const propTypes = {
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   className: PropTypes.any,
-  flex: PropTypes.bool
+  cssModule: PropTypes.object,
+  flex: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -15,14 +17,15 @@ const defaultProps = {
 const CardDeck = (props) => {
   const {
     className,
+    cssModule,
     tag: Tag,
     flex,
     ...attributes
   } = props;
-  const classes = classNames(
+  const classes = mapToCssModules(classNames(
     className,
     'card-deck'
-  );
+  ), cssModule);
 
   if (flex) {
     return (

--- a/src/CardFooter.js
+++ b/src/CardFooter.js
@@ -1,9 +1,11 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import { mapToCssModules } from './utils';
 
 const propTypes = {
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  className: PropTypes.any
+  className: PropTypes.any,
+  cssModule: PropTypes.object,
 };
 
 const defaultProps = {
@@ -13,13 +15,14 @@ const defaultProps = {
 const CardFooter = (props) => {
   const {
     className,
+    cssModule,
     tag: Tag,
     ...attributes
   } = props;
-  const classes = classNames(
+  const classes = mapToCssModules(classNames(
     className,
     'card-footer'
-  );
+  ), cssModule);
 
   return (
     <Tag {...attributes} className={classes} />

--- a/src/CardGroup.js
+++ b/src/CardGroup.js
@@ -1,9 +1,11 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import { mapToCssModules } from './utils';
 
 const propTypes = {
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  className: PropTypes.any
+  className: PropTypes.any,
+  cssModule: PropTypes.object,
 };
 
 const defaultProps = {
@@ -13,13 +15,14 @@ const defaultProps = {
 const CardGroup = (props) => {
   const {
     className,
+    cssModule,
     tag: Tag,
     ...attributes
   } = props;
-  const classes = classNames(
+  const classes = mapToCssModules(classNames(
     className,
     'card-group'
-  );
+  ), cssModule);
 
   return (
     <Tag {...attributes} className={classes} />

--- a/src/CardHeader.js
+++ b/src/CardHeader.js
@@ -1,9 +1,11 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import { mapToCssModules } from './utils';
 
 const propTypes = {
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  className: PropTypes.any
+  className: PropTypes.any,
+  cssModule: PropTypes.object,
 };
 
 const defaultProps = {
@@ -13,13 +15,14 @@ const defaultProps = {
 const CardHeader = (props) => {
   const {
     className,
+    cssModule,
     tag: Tag,
     ...attributes
   } = props;
-  const classes = classNames(
+  const classes = mapToCssModules(classNames(
     className,
     'card-header'
-  );
+  ), cssModule);
 
   return (
     <Tag {...attributes} className={classes} />

--- a/src/CardImg.js
+++ b/src/CardImg.js
@@ -1,11 +1,13 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import { mapToCssModules } from './utils';
 
 const propTypes = {
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   top: PropTypes.bool,
   bottom: PropTypes.bool,
-  className: PropTypes.any
+  className: PropTypes.any,
+  cssModule: PropTypes.object,
 };
 
 const defaultProps = {
@@ -15,6 +17,7 @@ const defaultProps = {
 const CardImg = (props) => {
   const {
     className,
+    cssModule,
     top,
     bottom,
     tag: Tag,
@@ -29,10 +32,10 @@ const CardImg = (props) => {
     cardImgClassName = 'card-img-bottom';
   }
 
-  const classes = classNames(
+  const classes = mapToCssModules(classNames(
     className,
     cardImgClassName
-  );
+  ), cssModule);
 
   return (
     <Tag {...attributes} className={classes} />

--- a/src/CardImgOverlay.js
+++ b/src/CardImgOverlay.js
@@ -1,9 +1,11 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import { mapToCssModules } from './utils';
 
 const propTypes = {
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  className: PropTypes.any
+  className: PropTypes.any,
+  cssModule: PropTypes.object,
 };
 
 const defaultProps = {
@@ -13,13 +15,14 @@ const defaultProps = {
 const CardImgOverlay = (props) => {
   const {
     className,
+    cssModule,
     tag: Tag,
     ...attributes
   } = props;
-  const classes = classNames(
+  const classes = mapToCssModules(classNames(
     className,
     'card-img-overlay'
-  );
+  ), cssModule);
 
   return (
     <Tag {...attributes} className={classes} />

--- a/src/CardLink.js
+++ b/src/CardLink.js
@@ -1,9 +1,11 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import { mapToCssModules } from './utils';
 
 const propTypes = {
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  className: PropTypes.any
+  className: PropTypes.any,
+  cssModule: PropTypes.object,
 };
 
 const defaultProps = {
@@ -13,13 +15,14 @@ const defaultProps = {
 const CardLink = (props) => {
   const {
     className,
+    cssModule,
     tag: Tag,
     ...attributes
   } = props;
-  const classes = classNames(
+  const classes = mapToCssModules(classNames(
     className,
     'card-link'
-  );
+  ), cssModule);
 
   return (
     <Tag {...attributes} className={classes} />

--- a/src/CardSubtitle.js
+++ b/src/CardSubtitle.js
@@ -1,9 +1,11 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import { mapToCssModules } from './utils';
 
 const propTypes = {
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  className: PropTypes.any
+  className: PropTypes.any,
+  cssModule: PropTypes.object,
 };
 
 const defaultProps = {
@@ -13,13 +15,14 @@ const defaultProps = {
 const CardSubtitle = (props) => {
   const {
     className,
+    cssModule,
     tag: Tag,
     ...attributes
   } = props;
-  const classes = classNames(
+  const classes = mapToCssModules(classNames(
     className,
     'card-subtitle'
-  );
+  ), cssModule);
 
   return (
     <Tag {...attributes} className={classes} />

--- a/src/CardText.js
+++ b/src/CardText.js
@@ -1,9 +1,11 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import { mapToCssModules } from './utils';
 
 const propTypes = {
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  className: PropTypes.any
+  className: PropTypes.any,
+  cssModule: PropTypes.object,
 };
 
 const defaultProps = {
@@ -13,13 +15,14 @@ const defaultProps = {
 const CardText = (props) => {
   const {
     className,
+    cssModule,
     tag: Tag,
     ...attributes
   } = props;
-  const classes = classNames(
+  const classes = mapToCssModules(classNames(
     className,
     'card-text'
-  );
+  ), cssModule);
 
   return (
     <Tag {...attributes} className={classes} />

--- a/src/CardTitle.js
+++ b/src/CardTitle.js
@@ -1,9 +1,11 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import { mapToCssModules } from './utils';
 
 const propTypes = {
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  className: PropTypes.any
+  className: PropTypes.any,
+  cssModule: PropTypes.object,
 };
 
 const defaultProps = {
@@ -13,13 +15,14 @@ const defaultProps = {
 const CardTitle = (props) => {
   const {
     className,
+    cssModule,
     tag: Tag,
     ...attributes
   } = props;
-  const classes = classNames(
+  const classes = mapToCssModules(classNames(
     className,
     'card-title'
-  );
+  ), cssModule);
 
   return (
     <Tag {...attributes} className={classes} />

--- a/src/Col.js
+++ b/src/Col.js
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import { mapToCssModules } from './utils';
 
 const colSizes = ['xs', 'sm', 'md', 'lg', 'xl'];
 const stringOrNumberProp = PropTypes.oneOfType([PropTypes.number, PropTypes.string]);
@@ -22,7 +23,8 @@ const propTypes = {
   md: columnProps,
   lg: columnProps,
   xl: columnProps,
-  className: PropTypes.node
+  className: PropTypes.node,
+  cssModule: PropTypes.object,
 };
 
 const defaultProps = {
@@ -32,6 +34,7 @@ const defaultProps = {
 const Col = (props) => {
   const {
     className,
+    cssModule,
     ...attributes
   } = props;
   const colClasses = [];
@@ -50,12 +53,12 @@ const Col = (props) => {
         colClass = `col-${colSize}-${columnProp.size}`;
       }
 
-      colClasses.push(classNames({
+      colClasses.push(mapToCssModules(classNames({
         [colClass]: columnProp.size,
         [`push-${colSize}-${columnProp.push}`]: columnProp.push,
         [`pull-${colSize}-${columnProp.pull}`]: columnProp.pull,
         [`offset-${colSize}-${columnProp.offset}`]: columnProp.offset
-      }));
+      })), cssModule);
     } else {
       if (columnProp === 'auto' || columnProp === true) {
         colClass = `col-${colSize}`;
@@ -67,10 +70,10 @@ const Col = (props) => {
     }
   });
 
-  const classes = classNames(
+  const classes = mapToCssModules(classNames(
     className,
     colClasses
-  );
+  ), cssModule);
 
   return (
     <div {...attributes} className={classes} />

--- a/src/Container.js
+++ b/src/Container.js
@@ -1,9 +1,11 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import { mapToCssModules } from './utils';
 
 const propTypes = {
   fluid: PropTypes.bool,
-  className: PropTypes.node
+  className: PropTypes.node,
+  cssModule: PropTypes.object,
 };
 
 const defaultProps = {};
@@ -11,14 +13,15 @@ const defaultProps = {};
 const Container = (props) => {
   const {
     className,
+    cssModule,
     fluid,
     ...attributes
   } = props;
 
-  const classes = classNames(
+  const classes = mapToCssModules(classNames(
     className,
     fluid ? 'container-fluid' : 'container'
-  );
+  ), cssModule);
 
   return (
     <div {...attributes} className={classes} />

--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -4,6 +4,7 @@
 import React, { PropTypes } from 'react';
 import ReactDOM from 'react-dom';
 import classNames from 'classnames';
+import { mapToCssModules } from './utils';
 import omit from 'lodash.omit';
 import TetherContent from './TetherContent';
 import DropdownMenu from './DropdownMenu';
@@ -18,7 +19,8 @@ const propTypes = {
   tether: PropTypes.oneOfType([PropTypes.object, PropTypes.bool]),
   toggle: PropTypes.func,
   children: PropTypes.node,
-  className: PropTypes.any
+  className: PropTypes.any,
+  cssModule: PropTypes.object,
 };
 
 const defaultProps = {
@@ -161,6 +163,7 @@ class Dropdown extends React.Component {
   render() {
     const {
       className,
+      cssModule,
       dropup,
       group,
       size,
@@ -169,7 +172,7 @@ class Dropdown extends React.Component {
       ...attributes
     } = omit(this.props, ['toggle', 'tether']);
 
-    const classes = classNames(
+    const classes = mapToCssModules(classNames(
       className,
       {
         'btn-group': group,
@@ -178,7 +181,7 @@ class Dropdown extends React.Component {
         open: isOpen,
         dropup: dropup
       }
-    );
+    ), cssModule);
 
     return (
       <Tag

--- a/src/DropdownItem.js
+++ b/src/DropdownItem.js
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import { mapToCssModules } from './utils';
 
 const propTypes = {
   children: PropTypes.node,
@@ -8,7 +9,8 @@ const propTypes = {
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   header: PropTypes.bool,
   onClick: PropTypes.func,
-  className: PropTypes.any
+  className: PropTypes.any,
+  cssModule: PropTypes.object,
 };
 
 const contextTypes = {
@@ -52,12 +54,13 @@ class DropdownItem extends React.Component {
     const tabIndex = this.getTabIndex();
     let {
       className,
+      cssModule,
       divider,
       tag: Tag,
       header,
       ...props } = this.props;
 
-    const classes = classNames(
+    const classes = mapToCssModules(classNames(
       className,
       {
         disabled: props.disabled,
@@ -65,7 +68,7 @@ class DropdownItem extends React.Component {
         'dropdown-header': header,
         'dropdown-divider': divider
       }
-    );
+    ), cssModule);
 
     if (Tag === 'button') {
       if (header) {

--- a/src/DropdownMenu.js
+++ b/src/DropdownMenu.js
@@ -1,10 +1,12 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import { mapToCssModules } from './utils';
 
 const propTypes = {
   children: PropTypes.node.isRequired,
   right: PropTypes.bool,
-  className: PropTypes.any
+  className: PropTypes.any,
+  cssModule: PropTypes.object,
 };
 
 const contextTypes = {
@@ -12,12 +14,12 @@ const contextTypes = {
 };
 
 const DropdownMenu = (props, context) => {
-  const { className, right, ...attributes } = props;
-  const classes = classNames(
+  const { className, cssModule, right, ...attributes } = props;
+  const classes = mapToCssModules(classNames(
     className,
     'dropdown-menu',
     { 'dropdown-menu-right': right }
-  );
+  ), cssModule);
 
   return (
     <div {...attributes} tabIndex="-1" aria-hidden={!context.isOpen} role="menu" className={classes} />

--- a/src/DropdownToggle.js
+++ b/src/DropdownToggle.js
@@ -1,18 +1,20 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import { mapToCssModules } from './utils';
 import Button from './Button';
 
 const propTypes = {
   caret: PropTypes.bool,
   children: PropTypes.node,
   className: PropTypes.any,
+  cssModule: PropTypes.object,
   disabled: PropTypes.bool,
   onClick: PropTypes.func,
   'data-toggle': PropTypes.string,
   'aria-haspopup': PropTypes.bool,
   split: PropTypes.bool,
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  nav: PropTypes.bool
+  nav: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -52,9 +54,9 @@ class DropdownToggle extends React.Component {
   }
 
   render() {
-    const { className, caret, split, nav, tag: Tag, ...props } = this.props;
+    const { className, cssModule, caret, split, nav, tag: Tag, ...props } = this.props;
     const ariaLabel = props['aria-label'] || 'Toggle Dropdown';
-    const classes = classNames(
+    const classes = mapToCssModules(classNames(
       className,
       {
         'dropdown-toggle': caret || split,
@@ -62,7 +64,7 @@ class DropdownToggle extends React.Component {
         active: this.context.isOpen,
         'nav-link': nav
       }
-    );
+    ), cssModule);
     const children = props.children || <span className="sr-only">{ariaLabel}</span>;
 
     if (nav) {

--- a/src/Fade.js
+++ b/src/Fade.js
@@ -1,12 +1,14 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import { mapToCssModules } from './utils';
 import omit from 'lodash.omit';
 
 const propTypes = {
   baseClass: PropTypes.string,
   baseClassIn: PropTypes.string,
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  className: PropTypes.string,
+  className: PropTypes.any,
+  cssModule: PropTypes.object,
   transitionAppearTimeout: PropTypes.number,
   transitionEnterTimeout: PropTypes.number,
   transitionLeaveTimeout: PropTypes.number,
@@ -14,7 +16,7 @@ const propTypes = {
   transitionEnter: PropTypes.bool,
   transitionLeave: PropTypes.bool,
   onLeave: PropTypes.func,
-  onEnter: PropTypes.func
+  onEnter: PropTypes.func,
 };
 
 const defaultProps = {
@@ -104,15 +106,16 @@ class Fade extends React.Component {
       baseClass,
       baseClassIn,
       className,
+      cssModule,
       tag: Tag
     } = this.props;
     const attributes = omit(this.props, Object.keys(propTypes));
 
-    const classes = classNames(
+    const classes = mapToCssModules(classNames(
       className,
       baseClass,
       this.state.mounted ? baseClassIn : false
-    );
+    ), cssModule);
 
     return (
       <Tag {...attributes} className={classes} />

--- a/src/Form.js
+++ b/src/Form.js
@@ -1,11 +1,13 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import { mapToCssModules } from './utils';
 
 const propTypes = {
   children: PropTypes.node,
   inline: PropTypes.bool,
   tag: PropTypes.string,
-  className: PropTypes.string,
+  className: PropTypes.any,
+  cssModule: PropTypes.object,
 };
 
 const defaultProps = {
@@ -15,15 +17,16 @@ const defaultProps = {
 const Form = (props) => {
   const {
     className,
+    cssModule,
     inline,
     tag: Tag,
     ...attributes,
   } = props;
 
-  const classes = classNames(
+  const classes = mapToCssModules(classNames(
     className,
     inline ? 'form-inline' : false
-  );
+  ), cssModule);
 
   return (
     <Tag {...attributes} className={classes} />

--- a/src/FormFeedback.js
+++ b/src/FormFeedback.js
@@ -1,10 +1,12 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import { mapToCssModules } from './utils';
 
 const propTypes = {
   children: PropTypes.node,
   tag: PropTypes.string,
-  className: PropTypes.string,
+  className: PropTypes.any,
+  cssModule: PropTypes.object,
 };
 
 const defaultProps = {
@@ -14,14 +16,15 @@ const defaultProps = {
 const FormFeedback = (props) => {
   const {
     className,
+    cssModule,
     tag: Tag,
     ...attributes,
   } = props;
 
-  const classes = classNames(
+  const classes = mapToCssModules(classNames(
     className,
     'form-control-feedback'
-  );
+  ), cssModule);
 
   return (
     <Tag {...attributes} className={classes} />

--- a/src/FormGroup.js
+++ b/src/FormGroup.js
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import { mapToCssModules } from './utils';
 
 const propTypes = {
   children: PropTypes.node,
@@ -8,7 +9,8 @@ const propTypes = {
   disabled: PropTypes.bool,
   tag: PropTypes.string,
   color: PropTypes.string,
-  className: PropTypes.string,
+  className: PropTypes.any,
+  cssModule: PropTypes.object,
 };
 
 const defaultProps = {
@@ -18,6 +20,7 @@ const defaultProps = {
 const FormGroup = (props) => {
   const {
     className,
+    cssModule,
     row,
     disabled,
     color,
@@ -26,13 +29,13 @@ const FormGroup = (props) => {
     ...attributes,
   } = props;
 
-  const classes = classNames(
+  const classes = mapToCssModules(classNames(
     className,
     color ? `has-${color}` : false,
     row ? 'row' : false,
     check ? 'form-check' : 'form-group',
     check && disabled ? 'disabled' : false
-  );
+  ), cssModule);
 
   return (
     <Tag {...attributes} className={classes} />

--- a/src/FormText.js
+++ b/src/FormText.js
@@ -1,12 +1,14 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import { mapToCssModules } from './utils';
 
 const propTypes = {
   children: PropTypes.node,
   inline: PropTypes.bool,
   tag: PropTypes.string,
   color: PropTypes.string,
-  className: PropTypes.string,
+  className: PropTypes.any,
+  cssModule: PropTypes.object,
 };
 
 const defaultProps = {
@@ -16,17 +18,18 @@ const defaultProps = {
 const FormText = (props) => {
   const {
     className,
+    cssModule,
     inline,
     color,
     tag: Tag,
     ...attributes,
   } = props;
 
-  const classes = classNames(
+  const classes = mapToCssModules(classNames(
     className,
     !inline ? 'form-text' : false,
     color ? `text-${color}` : false
-  );
+  ), cssModule);
 
   return (
     <Tag {...attributes} className={classes} />

--- a/src/Input.js
+++ b/src/Input.js
@@ -2,6 +2,7 @@
 
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import { mapToCssModules } from './utils';
 
 const propTypes = {
   children: PropTypes.node,
@@ -11,7 +12,8 @@ const propTypes = {
   tag: PropTypes.string,
   static: PropTypes.bool,
   addon: PropTypes.bool,
-  className: PropTypes.string,
+  className: PropTypes.any,
+  cssModule: PropTypes.object,
 };
 
 const defaultProps = {
@@ -23,6 +25,7 @@ class Input extends React.Component {
   render() {
     const {
       className,
+      cssModule,
       type,
       size,
       state,
@@ -54,12 +57,12 @@ class Input extends React.Component {
       }
     }
 
-    const classes = classNames(
+    const classes = mapToCssModules(classNames(
       className,
       state ? `form-control-${state}` : false,
       size ? `form-control-${size}` : false,
       formControlClass
-    );
+    ), cssModule);
 
     if (Tag === 'input') {
       attributes.type = type;

--- a/src/InputGroup.js
+++ b/src/InputGroup.js
@@ -1,10 +1,12 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import { mapToCssModules } from './utils';
 
 const propTypes = {
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   size: PropTypes.string,
-  className: PropTypes.any
+  className: PropTypes.any,
+  cssModule: PropTypes.object,
 };
 
 const defaultProps = {
@@ -14,15 +16,16 @@ const defaultProps = {
 const InputGroup = (props) => {
   const {
     className,
+    cssModule,
     tag: Tag,
     size,
     ...attributes
   } = props;
-  const classes = classNames(
+  const classes = mapToCssModules(classNames(
     className,
     'input-group',
     size ? `input-group-${size}` : null
-  );
+  ), cssModule);
 
   return (
     <Tag {...attributes} className={classes} />

--- a/src/InputGroupAddon.js
+++ b/src/InputGroupAddon.js
@@ -1,9 +1,11 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import { mapToCssModules } from './utils';
 
 const propTypes = {
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  className: PropTypes.any
+  className: PropTypes.any,
+  cssModule: PropTypes.object,
 };
 
 const defaultProps = {
@@ -13,13 +15,14 @@ const defaultProps = {
 const InputGroupAddon = (props) => {
   const {
     className,
+    cssModule,
     tag: Tag,
     ...attributes
   } = props;
-  const classes = classNames(
+  const classes = mapToCssModules(classNames(
     className,
     'input-group-addon'
-  );
+  ), cssModule);
 
   return (
     <Tag {...attributes} className={classes} />

--- a/src/InputGroupButton.js
+++ b/src/InputGroupButton.js
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import { mapToCssModules } from './utils';
 import Button from './Button';
 
 const propTypes = {
@@ -7,7 +8,8 @@ const propTypes = {
   children: PropTypes.node,
   groupClassName: PropTypes.any,
   groupAttributes: PropTypes.object,
-  className: PropTypes.any
+  className: PropTypes.any,
+  cssModule: PropTypes.object,
 };
 
 const defaultProps = {
@@ -17,6 +19,7 @@ const defaultProps = {
 const InputGroupButton = (props) => {
   let {
     className,
+    cssModule,
     tag: Tag,
     children,
     groupClassName,
@@ -25,10 +28,10 @@ const InputGroupButton = (props) => {
   } = props;
 
   if (typeof children === 'string') {
-    const groupClasses = classNames(
+    const groupClasses = mapToCssModules(classNames(
       groupClassName,
       'input-group-btn'
-    );
+    ), cssModule);
 
     return (
       <Tag {...groupAttributes} className={groupClasses}>
@@ -37,10 +40,10 @@ const InputGroupButton = (props) => {
     );
   }
 
-  const classes = classNames(
+  const classes = mapToCssModules(classNames(
     className,
     'input-group-btn'
-  );
+  ), cssModule);
 
   return (
     <Tag {...attributes} className={classes} children={children} />

--- a/src/Jumbotron.js
+++ b/src/Jumbotron.js
@@ -1,10 +1,12 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import { mapToCssModules } from './utils';
 
 const propTypes = {
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   fluid: PropTypes.bool,
-  className: PropTypes.any
+  className: PropTypes.any,
+  cssModule: PropTypes.object,
 };
 
 const defaultProps = {
@@ -14,16 +16,17 @@ const defaultProps = {
 const Jumbotron = (props) => {
   const {
     className,
+    cssModule,
     tag: Tag,
     fluid,
     ...attributes
   } = props;
 
-  const classes = classNames(
+  const classes = mapToCssModules(classNames(
     className,
     'jumbotron',
     fluid ? 'jumbotron-fluid' : false
-  );
+  ), cssModule);
 
   return (
     <Tag {...attributes} className={classes} />

--- a/src/Label.js
+++ b/src/Label.js
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import { mapToCssModules } from './utils';
 
 const colSizes = ['xs', 'sm', 'md', 'lg', 'xl'];
 
@@ -25,7 +26,8 @@ const propTypes = {
   size: PropTypes.string,
   for: PropTypes.string,
   tag: PropTypes.string,
-  className: PropTypes.string,
+  className: PropTypes.any,
+  cssModule: PropTypes.object,
   xs: columnProps,
   sm: columnProps,
   md: columnProps,
@@ -40,6 +42,7 @@ const defaultProps = {
 const Label = (props) => {
   const {
     className,
+    cssModule,
     hidden,
     tag: Tag,
     check,
@@ -57,18 +60,18 @@ const Label = (props) => {
     delete attributes[colSize];
 
     if (columnProp && columnProp.size) {
-      colClasses.push(classNames({
+      colClasses.push(mapToCssModules(classNames({
         [`col-${colSize}-${columnProp.size}`]: columnProp.size,
         [`push-${colSize}-${columnProp.push}`]: columnProp.push,
         [`pull-${colSize}-${columnProp.pull}`]: columnProp.pull,
         [`offset-${colSize}-${columnProp.offset}`]: columnProp.offset,
-      }));
+      })), cssModule);
     } else if (columnProp) {
       colClasses.push(`col-${colSize}-${columnProp}`);
     }
   });
 
-  const classes = classNames(
+  const classes = mapToCssModules(classNames(
     className,
     hidden ? 'sr-only' : false,
     check ? `form-check-${inline ? 'inline' : 'label'}` : false,
@@ -76,7 +79,7 @@ const Label = (props) => {
     size ? `col-form-label-${size}` : false,
     colClasses,
     colClasses.length ? 'col-form-label' : false
-  );
+  ), cssModule);
 
   return (
     <Tag htmlFor={htmlFor} {...attributes} className={classes} />

--- a/src/ListGroup.js
+++ b/src/ListGroup.js
@@ -1,10 +1,12 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import { mapToCssModules } from './utils';
 
 const propTypes = {
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   flush: PropTypes.bool,
-  className: PropTypes.any
+  className: PropTypes.any,
+  cssModule: PropTypes.object,
 };
 
 const defaultProps = {
@@ -14,15 +16,16 @@ const defaultProps = {
 const ListGroup = (props) => {
   const {
     className,
+    cssModule,
     tag: Tag,
     flush,
     ...attributes
   } = props;
-  const classes = classNames(
+  const classes = mapToCssModules(classNames(
     className,
     'list-group',
     flush ? 'list-group-flush' : false
-  );
+  ), cssModule);
 
   return (
     <Tag {...attributes} className={classes} />

--- a/src/Media.js
+++ b/src/Media.js
@@ -1,11 +1,13 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import { mapToCssModules } from './utils';
 
 const propTypes = {
   body: PropTypes.bool,
   bottom: PropTypes.bool,
   children: PropTypes.node,
-  className: PropTypes.string,
+  className: PropTypes.any,
+  cssModule: PropTypes.object,
   heading: PropTypes.bool,
   left: PropTypes.bool,
   list: PropTypes.bool,
@@ -21,6 +23,7 @@ const Media = (props) => {
     body,
     bottom,
     className,
+    cssModule,
     heading,
     left,
     list,
@@ -46,7 +49,7 @@ const Media = (props) => {
   }
   const Tag = tag || defaultTag;
 
-  const classes = classNames(
+  const classes = mapToCssModules(classNames(
     className,
     {
       'media-body': body,
@@ -60,7 +63,7 @@ const Media = (props) => {
       'media-list': list,
       media: !body && !heading && !left && !right && !top && !bottom && !middle && !object && !list,
     }
-  );
+  ), cssModule);
 
   return (
     <Tag {...attributes} className={classes} />

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -6,7 +6,8 @@ import Fade from './Fade';
 import {
   getOriginalBodyPadding,
   conditionallyUpdateScrollbar,
-  setScrollbarWidth
+  setScrollbarWidth,
+  mapToCssModules,
 } from './utils';
 
 const propTypes = {
@@ -21,7 +22,8 @@ const propTypes = {
   onEnter: PropTypes.func,
   onExit: PropTypes.func,
   children: PropTypes.node,
-  className: PropTypes.any
+  className: PropTypes.any,
+  cssModule: PropTypes.object,
 };
 
 const defaultProps = {
@@ -111,7 +113,7 @@ class Modal extends React.Component {
       this._element = null;
     }
 
-    document.body.className = classNames(classes).trim();
+    document.body.className = mapToCssModules(classNames(classes).trim(), this.props.cssModule);
     setScrollbarWidth(this.originalBodyPadding);
   }
 
@@ -129,10 +131,10 @@ class Modal extends React.Component {
 
     document.body.appendChild(this._element);
 
-    document.body.className = classNames(
+    document.body.className = mapToCssModules(classNames(
       classes,
       'modal-open'
-    );
+    ), this.props.cssModule);
 
     this.renderIntoSubtree();
   }
@@ -169,9 +171,9 @@ class Modal extends React.Component {
             tabIndex="-1"
           >
             <div
-              className={classNames('modal-dialog', this.props.className, {
+              className={mapToCssModules(classNames('modal-dialog', this.props.className, {
                 [`modal-${this.props.size}`]: this.props.size
-              })}
+              }), this.props.cssModule)}
               role="document"
               ref={(c) => (this._dialog = c)}
             >

--- a/src/ModalBody.js
+++ b/src/ModalBody.js
@@ -1,15 +1,17 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import { mapToCssModules } from './utils';
 
 const propTypes = {
-  className: PropTypes.string
+  className: PropTypes.any,
+  cssModule: PropTypes.object,
 };
 
 const ModalBody = (props) => {
-  const classes = classNames(
+  const classes = mapToCssModules(classNames(
     props.className,
     'modal-body'
-  );
+  ), props.cssModule);
 
   return (
     <div {...props} className={classes} />

--- a/src/ModalFooter.js
+++ b/src/ModalFooter.js
@@ -1,15 +1,17 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import { mapToCssModules } from './utils';
 
 const propTypes = {
-  className: PropTypes.string
+  className: PropTypes.any,
+  cssModule: PropTypes.object,
 };
 
 const ModalFooter = (props) => {
-  const classes = classNames(
+  const classes = mapToCssModules(classNames(
     props.className,
     'modal-footer'
-  );
+  ), props.cssModule);
 
   return (
     <div {...props} className={classes} />

--- a/src/ModalHeader.js
+++ b/src/ModalHeader.js
@@ -1,10 +1,12 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import { mapToCssModules } from './utils';
 
 const propTypes = {
   toggle: PropTypes.func,
   className: PropTypes.any,
-  children: PropTypes.node
+  cssModule: PropTypes.object,
+  children: PropTypes.node,
 };
 
 const defaultProps = {};
@@ -13,14 +15,15 @@ const ModalHeader = (props) => {
   let closeButton;
   const {
     className,
+    cssModule,
     children,
     toggle,
     ...attributes } = props;
 
-  const classes = classNames(
+  const classes = mapToCssModules(classNames(
     className,
     'modal-header'
-  );
+  ), cssModule);
 
   if (toggle) {
     closeButton = (

--- a/src/Nav.js
+++ b/src/Nav.js
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import { mapToCssModules } from './utils';
 
 const propTypes = {
   inline: PropTypes.bool,
@@ -9,7 +10,8 @@ const propTypes = {
   stacked: PropTypes.bool,
   navbar: PropTypes.bool,
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  className: PropTypes.any
+  className: PropTypes.any,
+  cssModule: PropTypes.object,
 };
 
 const defaultProps = {
@@ -19,6 +21,7 @@ const defaultProps = {
 const Nav = (props) => {
   const {
     className,
+    cssModule,
     tabs,
     pills,
     inline,
@@ -28,7 +31,7 @@ const Nav = (props) => {
     ...attributes
   } = props;
 
-  const classes = classNames(
+  const classes = mapToCssModules(classNames(
     className,
     'nav',
     {
@@ -39,7 +42,7 @@ const Nav = (props) => {
       'nav-stacked': stacked,
       disabled: attributes.disabled
     }
-  );
+  ), cssModule);
 
   return (
     <Tag {...attributes} className={classes} />

--- a/src/NavDropdown.js
+++ b/src/NavDropdown.js
@@ -1,11 +1,13 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import { mapToCssModules } from './utils';
 import Dropdown from './Dropdown';
 
 const propTypes = {
   children: PropTypes.node,
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  className: PropTypes.any
+  className: PropTypes.any,
+  cssModule: PropTypes.object,
 };
 
 const defaultProps = {
@@ -15,14 +17,15 @@ const defaultProps = {
 const NavDropdown = (props) => {
   const {
     className,
+    cssModule,
     tag: Tag,
     ...attributes
   } = props;
 
-  const classes = classNames(
+  const classes = mapToCssModules(classNames(
     className,
     'nav-item'
-  );
+  ), cssModule);
 
   return (
     <Dropdown {...attributes} tag={Tag} className={classes} />

--- a/src/NavItem.js
+++ b/src/NavItem.js
@@ -1,9 +1,11 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import { mapToCssModules } from './utils';
 
 const propTypes = {
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  className: PropTypes.any
+  className: PropTypes.any,
+  cssModule: PropTypes.object,
 };
 
 const defaultProps = {
@@ -13,14 +15,15 @@ const defaultProps = {
 const NavItem = (props) => {
   const {
     className,
+    cssModule,
     tag: Tag,
     ...attributes
   } = props;
 
-  const classes = classNames(
+  const classes = mapToCssModules(classNames(
     className,
     'nav-item'
-  );
+  ), cssModule);
 
   return (
     <Tag {...attributes} className={classes} />

--- a/src/NavLink.js
+++ b/src/NavLink.js
@@ -1,13 +1,15 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import { mapToCssModules } from './utils';
 
 const propTypes = {
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   disabled: PropTypes.bool,
   active: PropTypes.bool,
   className: PropTypes.any,
+  cssModule: PropTypes.object,
   onClick: PropTypes.func,
-  href: PropTypes.any
+  href: PropTypes.any,
 };
 
 const defaultProps = {
@@ -39,19 +41,20 @@ class NavLink extends React.Component {
   render() {
     let {
       className,
+      cssModule,
       active,
       tag: Tag,
       ...attributes
     } = this.props;
 
-    const classes = classNames(
+    const classes = mapToCssModules(classNames(
       className,
       'nav-link',
       {
         disabled: attributes.disabled,
         active: active
       }
-    );
+    ), cssModule);
 
     return (
       <Tag {...attributes} onClick={this.onClick} className={classes} />

--- a/src/Navbar.js
+++ b/src/Navbar.js
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import { mapToCssModules } from './utils';
 
 const propTypes = {
   light: PropTypes.bool,
@@ -9,7 +10,8 @@ const propTypes = {
   color: PropTypes.string,
   role: PropTypes.string,
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  className: PropTypes.any
+  className: PropTypes.any,
+  cssModule: PropTypes.object,
 };
 
 const defaultProps = {
@@ -20,6 +22,7 @@ const defaultProps = {
 const Navbar = (props) => {
   const {
     className,
+    cssModule,
     light,
     dark,
     full,
@@ -29,7 +32,7 @@ const Navbar = (props) => {
     ...attributes
   } = props;
 
-  const classes = classNames(
+  const classes = mapToCssModules(classNames(
     className,
     'navbar',
     {
@@ -39,7 +42,7 @@ const Navbar = (props) => {
       'navbar-full': full,
       [`navbar-fixed-${fixed}`]: fixed
     }
-  );
+  ), cssModule);
 
   return (
     <Tag {...attributes} className={classes} />

--- a/src/NavbarBrand.js
+++ b/src/NavbarBrand.js
@@ -1,9 +1,11 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import { mapToCssModules } from './utils';
 
 const propTypes = {
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  className: PropTypes.any
+  className: PropTypes.any,
+  cssModule: PropTypes.object,
 };
 
 const defaultProps = {
@@ -13,14 +15,15 @@ const defaultProps = {
 const NavbarBrand = (props) => {
   const {
     className,
+    cssModule,
     tag: Tag,
     ...attributes
   } = props;
 
-  const classes = classNames(
+  const classes = mapToCssModules(classNames(
     className,
     'navbar-brand'
-  );
+  ), cssModule);
 
   return (
     <Tag {...attributes} className={classes} />

--- a/src/NavbarToggler.js
+++ b/src/NavbarToggler.js
@@ -1,11 +1,13 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import { mapToCssModules } from './utils';
 
 const propTypes = {
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   type: PropTypes.string,
   className: PropTypes.any,
-  children: PropTypes.node
+  cssModule: PropTypes.object,
+  children: PropTypes.node,
 };
 
 const defaultProps = {
@@ -16,15 +18,16 @@ const defaultProps = {
 const NavbarToggler = (props) => {
   const {
     className,
+    cssModule,
     children,
     tag: Tag,
     ...attributes
   } = props;
 
-  const classes = classNames(
+  const classes = mapToCssModules(classNames(
     className,
     'navbar-toggler'
-  );
+  ), cssModule);
 
   return (
     <Tag {...attributes} className={classes}>

--- a/src/Pagination.js
+++ b/src/Pagination.js
@@ -1,9 +1,11 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import { mapToCssModules } from './utils';
 
 const propTypes = {
   children: PropTypes.node,
-  className: PropTypes.string,
+  className: PropTypes.any,
+  cssModule: PropTypes.object,
   size: PropTypes.string,
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
 };
@@ -15,18 +17,19 @@ const defaultProps = {
 const Pagination = (props) => {
   const {
     className,
+    cssModule,
     size,
     tag: Tag,
     ...attributes,
   } = props;
 
-  const classes = classNames(
+  const classes = mapToCssModules(classNames(
     className,
     'pagination',
     {
       [`pagination-${size}`]: !!size,
     }
-  );
+  ), cssModule);
 
   return (
     <Tag {...attributes} className={classes} />

--- a/src/PaginationItem.js
+++ b/src/PaginationItem.js
@@ -1,10 +1,12 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import { mapToCssModules } from './utils';
 
 const propTypes = {
   active: PropTypes.bool,
   children: PropTypes.node,
-  className: PropTypes.string,
+  className: PropTypes.any,
+  cssModule: PropTypes.object,
   disabled: PropTypes.bool,
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
 };
@@ -17,19 +19,20 @@ const PaginationItem = (props) => {
   const {
     active,
     className,
+    cssModule,
     disabled,
     tag: Tag,
     ...attributes,
   } = props;
 
-  const classes = classNames(
+  const classes = mapToCssModules(classNames(
     className,
     'page-item',
     {
       active,
       disabled,
     }
-  );
+  ), cssModule);
 
   return (
     <Tag {...attributes} className={classes} />

--- a/src/PaginationLink.js
+++ b/src/PaginationLink.js
@@ -1,10 +1,12 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import { mapToCssModules } from './utils';
 
 const propTypes = {
   'aria-label': PropTypes.string,
   children: PropTypes.node,
-  className: PropTypes.string,
+  className: PropTypes.any,
+  cssModule: PropTypes.object,
   next: PropTypes.bool,
   previous: PropTypes.bool,
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
@@ -17,16 +19,17 @@ const defaultProps = {
 const PaginationLink = (props) => {
   const {
     className,
+    cssModule,
     next,
     previous,
     tag: Tag,
     ...attributes,
   } = props;
 
-  const classes = classNames(
+  const classes = mapToCssModules(classNames(
     className,
     'page-link'
-  );
+  ), cssModule);
 
   let defaultAriaLabel;
   if (previous) {

--- a/src/Popover.js
+++ b/src/Popover.js
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import { mapToCssModules } from './utils';
 import omit from 'lodash.omit';
 import TetherContent from './TetherContent';
 import { getTetherAttachments, tetherAttachements } from './utils';
@@ -10,8 +11,9 @@ const propTypes = {
   isOpen: PropTypes.bool,
   tether: PropTypes.object,
   tetherRef: PropTypes.func,
-  className: PropTypes.string,
-  toggle: PropTypes.func
+  className: PropTypes.any,
+  cssModule: PropTypes.object,
+  toggle: PropTypes.func,
 };
 
 const defaultProps = {
@@ -53,10 +55,10 @@ class Popover extends React.Component {
 
     let tetherConfig = this.getTetherConfig();
 
-    const classes = classNames(
+    const classes = mapToCssModules(classNames(
       'popover-inner',
       this.props.className
-    );
+    ), this.props.cssModule);
 
     const attributes = omit(this.props, Object.keys(propTypes));
 

--- a/src/PopoverContent.js
+++ b/src/PopoverContent.js
@@ -1,9 +1,11 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import { mapToCssModules } from './utils';
 
 const propTypes = {
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  className: PropTypes.any
+  className: PropTypes.any,
+  cssModule: PropTypes.object,
 };
 
 const defaultProps = {
@@ -13,14 +15,15 @@ const defaultProps = {
 const PopoverContent = (props) => {
   const {
     className,
+    cssModule,
     tag: Tag,
     ...attributes
   } = props;
 
-  const classes = classNames(
+  const classes = mapToCssModules(classNames(
     className,
     'popover-content'
-  );
+  ), cssModule);
 
   return (
     <Tag {...attributes} className={classes} />

--- a/src/PopoverTitle.js
+++ b/src/PopoverTitle.js
@@ -1,9 +1,11 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import { mapToCssModules } from './utils';
 
 const propTypes = {
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  className: PropTypes.any
+  className: PropTypes.any,
+  cssModule: PropTypes.object,
 };
 
 const defaultProps = {
@@ -13,14 +15,15 @@ const defaultProps = {
 const PopoverTitle = (props) => {
   const {
     className,
+    cssModule,
     tag: Tag,
     ...attributes
   } = props;
 
-  const classes = classNames(
+  const classes = mapToCssModules(classNames(
     className,
     'popover-title'
-  );
+  ), cssModule);
 
   return (
     <Tag {...attributes} className={classes} />

--- a/src/Progress.js
+++ b/src/Progress.js
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import { mapToCssModules } from './utils';
 import toNumber from 'lodash.tonumber';
 
 const propTypes = {
@@ -15,7 +16,8 @@ const propTypes = {
   animated: PropTypes.bool,
   striped: PropTypes.bool,
   color: PropTypes.string,
-  className: PropTypes.any
+  className: PropTypes.any,
+  cssModule: PropTypes.object,
 };
 
 const defaultProps = {
@@ -27,6 +29,7 @@ const defaultProps = {
 const Progress = (props) => {
   const {
     className,
+    cssModule,
     value,
     max,
     animated,
@@ -38,23 +41,23 @@ const Progress = (props) => {
 
   const percent = ((toNumber(value) / toNumber(max)) * 100);
 
-  const nonProgressClasses = classNames(
+  const nonProgressClasses = mapToCssModules(classNames(
     className,
     'progress',
     animated ? 'progress-animated' : null
-  );
+  ), cssModule);
 
-  const progressClasses = classNames(
+  const progressClasses = mapToCssModules(classNames(
     nonProgressClasses,
     color ? `progress-${color}` : null,
     striped || animated ? 'progress-striped' : null
-  );
+  ), cssModule);
 
-  const fallbackClasses = classNames(
+  const fallbackClasses = mapToCssModules(classNames(
     'progress-bar',
     color ? `progress-${color}` : null,
     striped || animated ? 'progress-bar-striped' : null
-  );
+  ), cssModule);
 
   const fallbackFill = (
     <span

--- a/src/Row.js
+++ b/src/Row.js
@@ -1,9 +1,11 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import { mapToCssModules } from './utils';
 
 const propTypes = {
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  className: PropTypes.any
+  className: PropTypes.any,
+  cssModule: PropTypes.object,
 };
 
 const defaultProps = {
@@ -13,14 +15,15 @@ const defaultProps = {
 const Row = (props) => {
   const {
     className,
+    cssModule,
     tag: Tag,
     ...attributes
   } = props;
 
-  const classes = classNames(
+  const classes = mapToCssModules(classNames(
     className,
     'row'
-  );
+  ), cssModule);
 
   return (
     <Tag {...attributes} className={classes} />

--- a/src/TabContent.js
+++ b/src/TabContent.js
@@ -1,10 +1,12 @@
 import React, { PropTypes, Component } from 'react';
-import classnames from 'classnames';
+import classNames from 'classnames';
+import { mapToCssModules } from './utils';
 
 const propTypes = {
   children: PropTypes.node,
   activeTab: PropTypes.any,
-  className: PropTypes.string
+  className: PropTypes.any,
+  cssModule: PropTypes.object,
 };
 
 const childContextTypes = {
@@ -31,7 +33,7 @@ export default class TabContent extends Component {
     }
   }
   render() {
-    const classes = classnames('tab-content', this.props.className);
+    const classes = mapToCssModules(classNames('tab-content', this.props.className), this.props.cssModule);
     return (
       <div className={classes}>
         {this.props.children}

--- a/src/TabPane.js
+++ b/src/TabPane.js
@@ -1,11 +1,13 @@
 
 import React, { PropTypes } from 'react';
-import classnames from 'classnames';
+import classNames from 'classnames';
+import { mapToCssModules } from './utils';
 
 const propTypes = {
   children: PropTypes.node,
-  className: PropTypes.string,
-  tabId: PropTypes.any
+  className: PropTypes.any,
+  cssModule: PropTypes.object,
+  tabId: PropTypes.any,
 };
 const contextTypes = {
   activeTabId: PropTypes.any
@@ -14,11 +16,12 @@ const contextTypes = {
 export default function TabPane(props, context) {
   const {
     className,
+    cssModule,
     tabId,
     children,
     ...attributes
   } = props;
-  const classes = classnames('tab-pane', className, { active: tabId === context.activeTabId });
+  const classes = mapToCssModules(classNames('tab-pane', className, { active: tabId === context.activeTabId }), cssModule);
   return (
     <div {...attributes} className={classes}>
       {children}

--- a/src/Table.js
+++ b/src/Table.js
@@ -1,8 +1,10 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import { mapToCssModules } from './utils';
 
 const propTypes = {
   className: PropTypes.any,
+  cssModule: PropTypes.object,
   size: PropTypes.string,
   bordered: PropTypes.bool,
   striped: PropTypes.bool,
@@ -10,7 +12,7 @@ const propTypes = {
   hover: PropTypes.bool,
   reflow: PropTypes.bool,
   responsive: PropTypes.bool,
-  tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string])
+  tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
 };
 
 const defaultProps = {
@@ -20,6 +22,7 @@ const defaultProps = {
 const Table = (props) => {
   const {
     className,
+    cssModule,
     size,
     bordered,
     striped,
@@ -31,7 +34,7 @@ const Table = (props) => {
     ...attributes
   } = props;
 
-  const classes = classNames(
+  const classes = mapToCssModules(classNames(
     className,
     'table',
     size ? 'table-' + size : false,
@@ -40,7 +43,7 @@ const Table = (props) => {
     inverse ? 'table-inverse' : false,
     hover ? 'table-hover' : false,
     reflow ? 'table-reflow' : false
-  );
+  ), cssModule);
 
   const table = <Tag {...attributes} className={classes} />;
 

--- a/src/Tag.js
+++ b/src/Tag.js
@@ -1,12 +1,14 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import { mapToCssModules } from './utils';
 
 const propTypes = {
   color: PropTypes.string,
   pill: PropTypes.bool,
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   children: PropTypes.node,
-  className: PropTypes.any
+  className: PropTypes.any,
+  cssModule: PropTypes.object,
 };
 
 const defaultProps = {
@@ -18,18 +20,19 @@ const defaultProps = {
 const Tag = (props) => {
   const {
     className,
+    cssModule,
     color,
     pill,
     tag: Component,
     ...attributes
   } = props;
 
-  const classes = classNames(
+  const classes = mapToCssModules(classNames(
     className,
     'tag',
     'tag-' + color,
     pill ? 'tag-pill' : false
-  );
+  ), cssModule);
 
   return (
     <Component {...attributes} className={classes} />

--- a/src/TetherContent.js
+++ b/src/TetherContent.js
@@ -2,6 +2,7 @@ import React, { PropTypes } from 'react';
 import ReactDOM from 'react-dom';
 import isFunction from 'lodash.isfunction';
 import Tether from 'tether';
+import { mapToCssModules } from './utils';
 
 const propTypes = {
   children: PropTypes.node.isRequired,
@@ -11,7 +12,8 @@ const propTypes = {
   toggle: PropTypes.func.isRequired,
   tether: PropTypes.object.isRequired,
   tetherRef: PropTypes.func,
-  style: PropTypes.node
+  style: PropTypes.node,
+  cssModule: PropTypes.object,
 };
 
 const defaultProps = {
@@ -104,7 +106,7 @@ class TetherContent extends React.Component {
 
     if (this.props.arrow) {
       const arrow = document.createElement('div');
-      arrow.className = this.props.arrow + '-arrow';
+      arrow.className = mapToCssModules(this.props.arrow + '-arrow', this.props.cssModule);
       this._element.appendChild(arrow);
     }
 

--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -2,7 +2,7 @@ import React, { PropTypes } from 'react';
 import classNames from 'classnames';
 import omit from 'lodash.omit';
 import TetherContent from './TetherContent';
-import { getTetherAttachments, tetherAttachements } from './utils';
+import { getTetherAttachments, tetherAttachements, mapToCssModules } from './utils';
 
 const propTypes = {
   placement: React.PropTypes.oneOf(tetherAttachements),
@@ -11,13 +11,14 @@ const propTypes = {
   disabled: PropTypes.bool,
   tether: PropTypes.object,
   tetherRef: PropTypes.func,
-  classNames: PropTypes.string,
+  classNames: PropTypes.any,
+  cssModule: PropTypes.object,
   toggle: PropTypes.func,
   autohide: PropTypes.bool,
   delay: PropTypes.oneOfType([
     PropTypes.shape({ show: PropTypes.number, hide: PropTypes.number }),
-    PropTypes.number
-  ])
+    PropTypes.number,
+  ]),
 };
 
 const DEFAULT_DELAYS = {
@@ -181,10 +182,10 @@ class Tooltip extends React.Component {
     }
 
     const attributes = omit(this.props, Object.keys(propTypes));
-    const classes = classNames(
+    const classes = mapToCssModules(classNames(
       'tooltip-inner',
       this.props.classNames
-    );
+    ), this.props.cssModule);
 
     let tetherConfig = this.getTetherConfig();
 

--- a/src/__tests__/utils.spec.js
+++ b/src/__tests__/utils.spec.js
@@ -114,6 +114,46 @@ describe('Utils', () => {
     });
   });
 
+  describe('mapToCssModules', () => {
+    describe('without css module', () => {
+      it('should return a string', () => {
+        expect(Utils.mapToCssModules('btn btn-primary')).toEqual(jasmine.any(String));
+      });
+
+      it('should return the classnames it was given, unchanged', () => {
+        expect(Utils.mapToCssModules('btn btn-primary')).toBe('btn btn-primary');
+      });
+    });
+
+    describe('with css module', () => {
+      it('should return a string', () => {
+        const cssModule = {
+          btn: 'a1',
+          'btn-success': 'b1',
+          'btn-primary': 'c2',
+        };
+        expect(Utils.mapToCssModules('btn btn-primary', cssModule)).toEqual(jasmine.any(String));
+      });
+
+      it('should return the mapped classnames', () => {
+        const cssModule = {
+          btn: 'a1',
+          'btn-success': 'b1',
+          'btn-primary': 'c2',
+        };
+        expect(Utils.mapToCssModules('btn btn-primary', cssModule)).toBe('a1 c2');
+      });
+
+      it('should return the original classname when it is not in the map', () => {
+        const cssModule = {
+          btn: 'a1',
+          'btn-success': 'b1',
+        };
+        expect(Utils.mapToCssModules('btn btn-primary', cssModule)).toBe('a1 btn-primary');
+      });
+    });
+  });
+
   // TODO
   // describe('getScrollbarWidth', () => {
   //   // jsdom workaround https://github.com/tmpvar/jsdom/issues/135#issuecomment-68191941

--- a/src/utils.js
+++ b/src/utils.js
@@ -149,3 +149,8 @@ export function conditionallyUpdateScrollbar() {
     setScrollbarWidth(bodyPadding + scrollbarWidth);
   }
 }
+
+export function mapToCssModules(className, cssModule) {
+  if (!cssModule) return className;
+  return className.split(' ').map(c => cssModule[c] || c).join(' ');
+}


### PR DESCRIPTION
Add cssModule prop to every component which produces a css classname
Add mapToCssModule util will can turn a normal css className string
into module className if the module object/mapping is provided.
Closes #205