### PR TITLE
Fix eslint errors, add lint to Travis checks.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ cache:
 before_script:
   - chmod +x scripts/docs
 script:
+  - npm run lint
   - npm run cover
 after_script:
   - npm run report-coverage

--- a/src/Alert.js
+++ b/src/Alert.js
@@ -1,7 +1,7 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
-import { mapToCssModules } from './utils';
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
+import { mapToCssModules } from './utils';
 
 const FirstChild = ({ children }) => (
   React.Children.toArray(children)[0] || null

--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -4,8 +4,8 @@
 import React, { PropTypes } from 'react';
 import ReactDOM from 'react-dom';
 import classNames from 'classnames';
-import { mapToCssModules } from './utils';
 import omit from 'lodash.omit';
+import { mapToCssModules } from './utils';
 import TetherContent from './TetherContent';
 import DropdownMenu from './DropdownMenu';
 

--- a/src/Fade.js
+++ b/src/Fade.js
@@ -1,7 +1,7 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
-import { mapToCssModules } from './utils';
 import omit from 'lodash.omit';
+import { mapToCssModules } from './utils';
 
 const propTypes = {
   baseClass: PropTypes.string,

--- a/src/Popover.js
+++ b/src/Popover.js
@@ -1,9 +1,8 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
-import { mapToCssModules } from './utils';
 import omit from 'lodash.omit';
 import TetherContent from './TetherContent';
-import { getTetherAttachments, tetherAttachements } from './utils';
+import { getTetherAttachments, mapToCssModules, tetherAttachements } from './utils';
 
 const propTypes = {
   placement: React.PropTypes.oneOf(tetherAttachements),

--- a/src/Progress.js
+++ b/src/Progress.js
@@ -1,7 +1,7 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
-import { mapToCssModules } from './utils';
 import toNumber from 'lodash.tonumber';
+import { mapToCssModules } from './utils';
 
 const propTypes = {
   tag: PropTypes.string,

--- a/src/__tests__/TetherContent.spec.js
+++ b/src/__tests__/TetherContent.spec.js
@@ -78,8 +78,6 @@ describe('TetherContent', () => {
       expect(instance._tether).toBe(null);
     });
 
-
-
     it('should pass the new tether reference', () => {
       state = true;
       const tetherRef = jasmine.createSpy();


### PR DESCRIPTION
There were a few existing eslint errors, mostly around import order. I've fixed those, then set up Travis to run `npm run lint` after the tests to avoid these in the future.