### PR TITLE
Standardize on string for className props.

### DIFF
--- a/docs/lib/Components/AlertsPage.js
+++ b/docs/lib/Components/AlertsPage.js
@@ -30,7 +30,7 @@ export default class AlertsPage extends React.Component {
         <pre>
           <PrismCode className="language-jsx">
 {`Alert.propTypes = {
-  className: PropTypes.any,
+  className: PropTypes.string,
   color: PropTypes.string, // default: 'success'
   isOpen: PropTypes.bool,  // default: true
   toggle: PropTypes.func,

--- a/docs/lib/Components/CardPage.js
+++ b/docs/lib/Components/CardPage.js
@@ -53,25 +53,25 @@ export default class CardPage extends React.Component {
   inverse: PropTypes.bool,
   color: PropTypes.string,
   block: PropTypes.bool,
-  className: PropTypes.any
+  className: PropTypes.string
 };
 
 CardBlock.propTypes = {
   // Pass in a Component to override default element
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  className: PropTypes.any
+  className: PropTypes.string
 };
 
 CardColumns.propTypes = {
   // Pass in a Component to override default element
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  className: PropTypes.any
+  className: PropTypes.string
 };
 
 CardDeck.propTypes = {
   // Pass in a Component to override default element
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  className: PropTypes.any,
+  className: PropTypes.string,
   // enable flexbox version of component (removes extra classes)
   flex: PropTypes.bool
 };
@@ -79,25 +79,25 @@ CardDeck.propTypes = {
 CardFooter.propTypes = {
   // Pass in a Component to override default element
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  className: PropTypes.any
+  className: PropTypes.string
 };
 
 CardGroup.propTypes = {
   // Pass in a Component to override default element
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  className: PropTypes.any
+  className: PropTypes.string
 };
 
 CardHeader.propTypes = {
   // Pass in a Component to override default element
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  className: PropTypes.any
+  className: PropTypes.string
 };
 
 CardImg.propTypes = {
   // Pass in a Component to override default element
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  className: PropTypes.any,
+  className: PropTypes.string,
   // Use top or bottom to position image via "card-img-top" or "card-img-bottom"
   top: PropTypes.bool,
   bottom: PropTypes.bool
@@ -106,31 +106,31 @@ CardImg.propTypes = {
 CardImgOverlay.propTypes = {
   // Pass in a Component to override default element
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  className: PropTypes.any
+  className: PropTypes.string
 };
 
 CardLink.propTypes = {
   // Pass in a Component to override default element
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  className: PropTypes.any
+  className: PropTypes.string
 };
 
 CardSubtitle.propTypes = {
   // Pass in a Component to override default element
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  className: PropTypes.any
+  className: PropTypes.string
 };
 
 CardText.propTypes = {
   // Pass in a Component to override default element
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  className: PropTypes.any
+  className: PropTypes.string
 };
 
 CardTitle.propTypes = {
   // Pass in a Component to override default element
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  className: PropTypes.any
+  className: PropTypes.string
 };`}
           </PrismCode>
         </pre>

--- a/docs/lib/Components/DropdownsPage.js
+++ b/docs/lib/Components/DropdownsPage.js
@@ -64,7 +64,7 @@ export default class DropdownPage extends React.Component {
 DropdownToggle.propTypes = {
   caret: PropTypes.bool,
   color: PropTypes.string,
-  className: PropTypes.any,
+  className: PropTypes.string,
   disabled: PropTypes.bool,
   onClick: PropTypes.func,
   'data-toggle': PropTypes.string,

--- a/docs/lib/Components/InputGroupPage.js
+++ b/docs/lib/Components/InputGroupPage.js
@@ -48,20 +48,20 @@ export default class InputGroupPage extends React.Component {
 {`InputGroup.propTypes = {
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   size: PropTypes.string,
-  className: PropTypes.any
+  className: PropTypes.string
 };
 
 InputGroupAddOn.propTypes = {
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  className: PropTypes.any
+  className: PropTypes.string
 };
 
 InputGroupButton.propTypes = {
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   children: PropTypes.node,
-  groupClassName: PropTypes.any, // only used in shorthand
+  groupClassName: PropTypes.string, // only used in shorthand
   groupAttributes: PropTypes.object, // only used in shorthand
-  className: PropTypes.any
+  className: PropTypes.string
 };`}
           </PrismCode>
         </pre>

--- a/docs/lib/Components/JumbotronPage.js
+++ b/docs/lib/Components/JumbotronPage.js
@@ -30,7 +30,7 @@ export default class JumbotronPage extends React.Component {
   // Pass in a Component to override default element
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   fluid: PropTypes.bool,
-  className: PropTypes.any
+  className: PropTypes.string
 };`}
           </PrismCode>
         </pre>

--- a/docs/lib/Components/ProgressPage.js
+++ b/docs/lib/Components/ProgressPage.js
@@ -44,7 +44,7 @@ export default class ProgressPage extends React.Component {
   animated: PropTypes.bool,
   stripped: PropTypes.bool,
   color: PropTypes.string,
-  className: PropTypes.any
+  className: PropTypes.string
 };
 
 Progress.defaultProps = {

--- a/src/Alert.js
+++ b/src/Alert.js
@@ -9,7 +9,7 @@ const FirstChild = ({ children }) => (
 
 const propTypes = {
   children: PropTypes.node,
-  className: PropTypes.any,
+  className: PropTypes.string,
   cssModule: PropTypes.object,
   color: PropTypes.string,
   isOpen: PropTypes.bool,

--- a/src/Breadcrumb.js
+++ b/src/Breadcrumb.js
@@ -4,7 +4,7 @@ import { mapToCssModules } from './utils';
 
 const propTypes = {
   tag: PropTypes.string,
-  className: PropTypes.any,
+  className: PropTypes.string,
   cssModule: PropTypes.object,
 };
 

--- a/src/BreadcrumbItem.js
+++ b/src/BreadcrumbItem.js
@@ -5,7 +5,7 @@ import { mapToCssModules } from './utils';
 const propTypes = {
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   active: PropTypes.bool,
-  className: PropTypes.any,
+  className: PropTypes.string,
   cssModule: PropTypes.object,
 };
 

--- a/src/Button.js
+++ b/src/Button.js
@@ -12,7 +12,7 @@ const propTypes = {
   onClick: PropTypes.func,
   size: PropTypes.string,
   children: PropTypes.node,
-  className: PropTypes.any,
+  className: PropTypes.string,
   cssModule: PropTypes.object,
 };
 

--- a/src/ButtonGroup.js
+++ b/src/ButtonGroup.js
@@ -4,7 +4,7 @@ import { mapToCssModules } from './utils';
 
 const propTypes = {
   'aria-label': PropTypes.string,
-  className: PropTypes.any,
+  className: PropTypes.string,
   cssModule: PropTypes.object,
   role: PropTypes.string,
   size: PropTypes.string,

--- a/src/ButtonToolbar.js
+++ b/src/ButtonToolbar.js
@@ -4,7 +4,7 @@ import { mapToCssModules } from './utils';
 
 const propTypes = {
   'aria-label': PropTypes.string,
-  className: PropTypes.any,
+  className: PropTypes.string,
   cssModule: PropTypes.object,
   role: PropTypes.string,
 };

--- a/src/Card.js
+++ b/src/Card.js
@@ -8,7 +8,7 @@ const propTypes = {
   color: PropTypes.string,
   block: PropTypes.bool,
   outline: PropTypes.bool,
-  className: PropTypes.any,
+  className: PropTypes.string,
   cssModule: PropTypes.object,
 };
 

--- a/src/CardBlock.js
+++ b/src/CardBlock.js
@@ -4,7 +4,7 @@ import { mapToCssModules } from './utils';
 
 const propTypes = {
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  className: PropTypes.any,
+  className: PropTypes.string,
   cssModule: PropTypes.object,
 };
 

--- a/src/CardColumns.js
+++ b/src/CardColumns.js
@@ -4,7 +4,7 @@ import { mapToCssModules } from './utils';
 
 const propTypes = {
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  className: PropTypes.any,
+  className: PropTypes.string,
   cssModule: PropTypes.object,
 };
 

--- a/src/CardDeck.js
+++ b/src/CardDeck.js
@@ -4,7 +4,7 @@ import { mapToCssModules } from './utils';
 
 const propTypes = {
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  className: PropTypes.any,
+  className: PropTypes.string,
   cssModule: PropTypes.object,
   flex: PropTypes.bool,
 };

--- a/src/CardFooter.js
+++ b/src/CardFooter.js
@@ -4,7 +4,7 @@ import { mapToCssModules } from './utils';
 
 const propTypes = {
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  className: PropTypes.any,
+  className: PropTypes.string,
   cssModule: PropTypes.object,
 };
 

--- a/src/CardGroup.js
+++ b/src/CardGroup.js
@@ -4,7 +4,7 @@ import { mapToCssModules } from './utils';
 
 const propTypes = {
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  className: PropTypes.any,
+  className: PropTypes.string,
   cssModule: PropTypes.object,
 };
 

--- a/src/CardHeader.js
+++ b/src/CardHeader.js
@@ -4,7 +4,7 @@ import { mapToCssModules } from './utils';
 
 const propTypes = {
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  className: PropTypes.any,
+  className: PropTypes.string,
   cssModule: PropTypes.object,
 };
 

--- a/src/CardImg.js
+++ b/src/CardImg.js
@@ -6,7 +6,7 @@ const propTypes = {
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   top: PropTypes.bool,
   bottom: PropTypes.bool,
-  className: PropTypes.any,
+  className: PropTypes.string,
   cssModule: PropTypes.object,
 };
 

--- a/src/CardImgOverlay.js
+++ b/src/CardImgOverlay.js
@@ -4,7 +4,7 @@ import { mapToCssModules } from './utils';
 
 const propTypes = {
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  className: PropTypes.any,
+  className: PropTypes.string,
   cssModule: PropTypes.object,
 };
 

--- a/src/CardLink.js
+++ b/src/CardLink.js
@@ -4,7 +4,7 @@ import { mapToCssModules } from './utils';
 
 const propTypes = {
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  className: PropTypes.any,
+  className: PropTypes.string,
   cssModule: PropTypes.object,
 };
 

--- a/src/CardSubtitle.js
+++ b/src/CardSubtitle.js
@@ -4,7 +4,7 @@ import { mapToCssModules } from './utils';
 
 const propTypes = {
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  className: PropTypes.any,
+  className: PropTypes.string,
   cssModule: PropTypes.object,
 };
 

--- a/src/CardText.js
+++ b/src/CardText.js
@@ -4,7 +4,7 @@ import { mapToCssModules } from './utils';
 
 const propTypes = {
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  className: PropTypes.any,
+  className: PropTypes.string,
   cssModule: PropTypes.object,
 };
 

--- a/src/CardTitle.js
+++ b/src/CardTitle.js
@@ -4,7 +4,7 @@ import { mapToCssModules } from './utils';
 
 const propTypes = {
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  className: PropTypes.any,
+  className: PropTypes.string,
   cssModule: PropTypes.object,
 };
 

--- a/src/Col.js
+++ b/src/Col.js
@@ -23,7 +23,7 @@ const propTypes = {
   md: columnProps,
   lg: columnProps,
   xl: columnProps,
-  className: PropTypes.node,
+  className: PropTypes.string,
   cssModule: PropTypes.object,
 };
 

--- a/src/Container.js
+++ b/src/Container.js
@@ -4,7 +4,7 @@ import { mapToCssModules } from './utils';
 
 const propTypes = {
   fluid: PropTypes.bool,
-  className: PropTypes.node,
+  className: PropTypes.string,
   cssModule: PropTypes.object,
 };
 

--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -19,7 +19,7 @@ const propTypes = {
   tether: PropTypes.oneOfType([PropTypes.object, PropTypes.bool]),
   toggle: PropTypes.func,
   children: PropTypes.node,
-  className: PropTypes.any,
+  className: PropTypes.string,
   cssModule: PropTypes.object,
 };
 

--- a/src/DropdownItem.js
+++ b/src/DropdownItem.js
@@ -9,7 +9,7 @@ const propTypes = {
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   header: PropTypes.bool,
   onClick: PropTypes.func,
-  className: PropTypes.any,
+  className: PropTypes.string,
   cssModule: PropTypes.object,
 };
 

--- a/src/DropdownMenu.js
+++ b/src/DropdownMenu.js
@@ -5,7 +5,7 @@ import { mapToCssModules } from './utils';
 const propTypes = {
   children: PropTypes.node.isRequired,
   right: PropTypes.bool,
-  className: PropTypes.any,
+  className: PropTypes.string,
   cssModule: PropTypes.object,
 };
 

--- a/src/DropdownToggle.js
+++ b/src/DropdownToggle.js
@@ -6,7 +6,7 @@ import Button from './Button';
 const propTypes = {
   caret: PropTypes.bool,
   children: PropTypes.node,
-  className: PropTypes.any,
+  className: PropTypes.string,
   cssModule: PropTypes.object,
   disabled: PropTypes.bool,
   onClick: PropTypes.func,

--- a/src/Fade.js
+++ b/src/Fade.js
@@ -7,7 +7,7 @@ const propTypes = {
   baseClass: PropTypes.string,
   baseClassIn: PropTypes.string,
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  className: PropTypes.any,
+  className: PropTypes.string,
   cssModule: PropTypes.object,
   transitionAppearTimeout: PropTypes.number,
   transitionEnterTimeout: PropTypes.number,

--- a/src/Form.js
+++ b/src/Form.js
@@ -6,7 +6,7 @@ const propTypes = {
   children: PropTypes.node,
   inline: PropTypes.bool,
   tag: PropTypes.string,
-  className: PropTypes.any,
+  className: PropTypes.string,
   cssModule: PropTypes.object,
 };
 

--- a/src/FormFeedback.js
+++ b/src/FormFeedback.js
@@ -5,7 +5,7 @@ import { mapToCssModules } from './utils';
 const propTypes = {
   children: PropTypes.node,
   tag: PropTypes.string,
-  className: PropTypes.any,
+  className: PropTypes.string,
   cssModule: PropTypes.object,
 };
 

--- a/src/FormGroup.js
+++ b/src/FormGroup.js
@@ -9,7 +9,7 @@ const propTypes = {
   disabled: PropTypes.bool,
   tag: PropTypes.string,
   color: PropTypes.string,
-  className: PropTypes.any,
+  className: PropTypes.string,
   cssModule: PropTypes.object,
 };
 

--- a/src/FormText.js
+++ b/src/FormText.js
@@ -7,7 +7,7 @@ const propTypes = {
   inline: PropTypes.bool,
   tag: PropTypes.string,
   color: PropTypes.string,
-  className: PropTypes.any,
+  className: PropTypes.string,
   cssModule: PropTypes.object,
 };
 

--- a/src/Input.js
+++ b/src/Input.js
@@ -12,7 +12,7 @@ const propTypes = {
   tag: PropTypes.string,
   static: PropTypes.bool,
   addon: PropTypes.bool,
-  className: PropTypes.any,
+  className: PropTypes.string,
   cssModule: PropTypes.object,
 };
 

--- a/src/InputGroup.js
+++ b/src/InputGroup.js
@@ -5,7 +5,7 @@ import { mapToCssModules } from './utils';
 const propTypes = {
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   size: PropTypes.string,
-  className: PropTypes.any,
+  className: PropTypes.string,
   cssModule: PropTypes.object,
 };
 

--- a/src/InputGroupAddon.js
+++ b/src/InputGroupAddon.js
@@ -4,7 +4,7 @@ import { mapToCssModules } from './utils';
 
 const propTypes = {
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  className: PropTypes.any,
+  className: PropTypes.string,
   cssModule: PropTypes.object,
 };
 

--- a/src/InputGroupButton.js
+++ b/src/InputGroupButton.js
@@ -6,9 +6,9 @@ import Button from './Button';
 const propTypes = {
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   children: PropTypes.node,
-  groupClassName: PropTypes.any,
+  groupClassName: PropTypes.string,
   groupAttributes: PropTypes.object,
-  className: PropTypes.any,
+  className: PropTypes.string,
   cssModule: PropTypes.object,
 };
 

--- a/src/Jumbotron.js
+++ b/src/Jumbotron.js
@@ -5,7 +5,7 @@ import { mapToCssModules } from './utils';
 const propTypes = {
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   fluid: PropTypes.bool,
-  className: PropTypes.any,
+  className: PropTypes.string,
   cssModule: PropTypes.object,
 };
 

--- a/src/Label.js
+++ b/src/Label.js
@@ -26,7 +26,7 @@ const propTypes = {
   size: PropTypes.string,
   for: PropTypes.string,
   tag: PropTypes.string,
-  className: PropTypes.any,
+  className: PropTypes.string,
   cssModule: PropTypes.object,
   xs: columnProps,
   sm: columnProps,

--- a/src/ListGroup.js
+++ b/src/ListGroup.js
@@ -5,7 +5,7 @@ import { mapToCssModules } from './utils';
 const propTypes = {
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   flush: PropTypes.bool,
-  className: PropTypes.any,
+  className: PropTypes.string,
   cssModule: PropTypes.object,
 };
 

--- a/src/Media.js
+++ b/src/Media.js
@@ -6,7 +6,7 @@ const propTypes = {
   body: PropTypes.bool,
   bottom: PropTypes.bool,
   children: PropTypes.node,
-  className: PropTypes.any,
+  className: PropTypes.string,
   cssModule: PropTypes.object,
   heading: PropTypes.bool,
   left: PropTypes.bool,

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -22,7 +22,7 @@ const propTypes = {
   onEnter: PropTypes.func,
   onExit: PropTypes.func,
   children: PropTypes.node,
-  className: PropTypes.any,
+  className: PropTypes.string,
   cssModule: PropTypes.object,
 };
 

--- a/src/ModalBody.js
+++ b/src/ModalBody.js
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 import { mapToCssModules } from './utils';
 
 const propTypes = {
-  className: PropTypes.any,
+  className: PropTypes.string,
   cssModule: PropTypes.object,
 };
 

--- a/src/ModalFooter.js
+++ b/src/ModalFooter.js
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 import { mapToCssModules } from './utils';
 
 const propTypes = {
-  className: PropTypes.any,
+  className: PropTypes.string,
   cssModule: PropTypes.object,
 };
 

--- a/src/ModalHeader.js
+++ b/src/ModalHeader.js
@@ -4,7 +4,7 @@ import { mapToCssModules } from './utils';
 
 const propTypes = {
   toggle: PropTypes.func,
-  className: PropTypes.any,
+  className: PropTypes.string,
   cssModule: PropTypes.object,
   children: PropTypes.node,
 };

--- a/src/Nav.js
+++ b/src/Nav.js
@@ -10,7 +10,7 @@ const propTypes = {
   stacked: PropTypes.bool,
   navbar: PropTypes.bool,
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  className: PropTypes.any,
+  className: PropTypes.string,
   cssModule: PropTypes.object,
 };
 

--- a/src/NavDropdown.js
+++ b/src/NavDropdown.js
@@ -6,7 +6,7 @@ import Dropdown from './Dropdown';
 const propTypes = {
   children: PropTypes.node,
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  className: PropTypes.any,
+  className: PropTypes.string,
   cssModule: PropTypes.object,
 };
 

--- a/src/NavItem.js
+++ b/src/NavItem.js
@@ -4,7 +4,7 @@ import { mapToCssModules } from './utils';
 
 const propTypes = {
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  className: PropTypes.any,
+  className: PropTypes.string,
   cssModule: PropTypes.object,
 };
 

--- a/src/NavLink.js
+++ b/src/NavLink.js
@@ -6,7 +6,7 @@ const propTypes = {
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   disabled: PropTypes.bool,
   active: PropTypes.bool,
-  className: PropTypes.any,
+  className: PropTypes.string,
   cssModule: PropTypes.object,
   onClick: PropTypes.func,
   href: PropTypes.any,

--- a/src/Navbar.js
+++ b/src/Navbar.js
@@ -10,7 +10,7 @@ const propTypes = {
   color: PropTypes.string,
   role: PropTypes.string,
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  className: PropTypes.any,
+  className: PropTypes.string,
   cssModule: PropTypes.object,
 };
 

--- a/src/NavbarBrand.js
+++ b/src/NavbarBrand.js
@@ -4,7 +4,7 @@ import { mapToCssModules } from './utils';
 
 const propTypes = {
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  className: PropTypes.any,
+  className: PropTypes.string,
   cssModule: PropTypes.object,
 };
 

--- a/src/NavbarToggler.js
+++ b/src/NavbarToggler.js
@@ -5,7 +5,7 @@ import { mapToCssModules } from './utils';
 const propTypes = {
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   type: PropTypes.string,
-  className: PropTypes.any,
+  className: PropTypes.string,
   cssModule: PropTypes.object,
   children: PropTypes.node,
 };

--- a/src/Pagination.js
+++ b/src/Pagination.js
@@ -4,7 +4,7 @@ import { mapToCssModules } from './utils';
 
 const propTypes = {
   children: PropTypes.node,
-  className: PropTypes.any,
+  className: PropTypes.string,
   cssModule: PropTypes.object,
   size: PropTypes.string,
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),

--- a/src/PaginationItem.js
+++ b/src/PaginationItem.js
@@ -5,7 +5,7 @@ import { mapToCssModules } from './utils';
 const propTypes = {
   active: PropTypes.bool,
   children: PropTypes.node,
-  className: PropTypes.any,
+  className: PropTypes.string,
   cssModule: PropTypes.object,
   disabled: PropTypes.bool,
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),

--- a/src/PaginationLink.js
+++ b/src/PaginationLink.js
@@ -5,7 +5,7 @@ import { mapToCssModules } from './utils';
 const propTypes = {
   'aria-label': PropTypes.string,
   children: PropTypes.node,
-  className: PropTypes.any,
+  className: PropTypes.string,
   cssModule: PropTypes.object,
   next: PropTypes.bool,
   previous: PropTypes.bool,

--- a/src/Popover.js
+++ b/src/Popover.js
@@ -11,7 +11,7 @@ const propTypes = {
   isOpen: PropTypes.bool,
   tether: PropTypes.object,
   tetherRef: PropTypes.func,
-  className: PropTypes.any,
+  className: PropTypes.string,
   cssModule: PropTypes.object,
   toggle: PropTypes.func,
 };

--- a/src/PopoverContent.js
+++ b/src/PopoverContent.js
@@ -4,7 +4,7 @@ import { mapToCssModules } from './utils';
 
 const propTypes = {
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  className: PropTypes.any,
+  className: PropTypes.string,
   cssModule: PropTypes.object,
 };
 

--- a/src/PopoverTitle.js
+++ b/src/PopoverTitle.js
@@ -4,7 +4,7 @@ import { mapToCssModules } from './utils';
 
 const propTypes = {
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  className: PropTypes.any,
+  className: PropTypes.string,
   cssModule: PropTypes.object,
 };
 

--- a/src/Progress.js
+++ b/src/Progress.js
@@ -16,7 +16,7 @@ const propTypes = {
   animated: PropTypes.bool,
   striped: PropTypes.bool,
   color: PropTypes.string,
-  className: PropTypes.any,
+  className: PropTypes.string,
   cssModule: PropTypes.object,
 };
 

--- a/src/Row.js
+++ b/src/Row.js
@@ -4,7 +4,7 @@ import { mapToCssModules } from './utils';
 
 const propTypes = {
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  className: PropTypes.any,
+  className: PropTypes.string,
   cssModule: PropTypes.object,
 };
 

--- a/src/TabContent.js
+++ b/src/TabContent.js
@@ -5,7 +5,7 @@ import { mapToCssModules } from './utils';
 const propTypes = {
   children: PropTypes.node,
   activeTab: PropTypes.any,
-  className: PropTypes.any,
+  className: PropTypes.string,
   cssModule: PropTypes.object,
 };
 

--- a/src/TabPane.js
+++ b/src/TabPane.js
@@ -5,7 +5,7 @@ import { mapToCssModules } from './utils';
 
 const propTypes = {
   children: PropTypes.node,
-  className: PropTypes.any,
+  className: PropTypes.string,
   cssModule: PropTypes.object,
   tabId: PropTypes.any,
 };

--- a/src/Table.js
+++ b/src/Table.js
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 import { mapToCssModules } from './utils';
 
 const propTypes = {
-  className: PropTypes.any,
+  className: PropTypes.string,
   cssModule: PropTypes.object,
   size: PropTypes.string,
   bordered: PropTypes.bool,

--- a/src/Tag.js
+++ b/src/Tag.js
@@ -7,7 +7,7 @@ const propTypes = {
   pill: PropTypes.bool,
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   children: PropTypes.node,
-  className: PropTypes.any,
+  className: PropTypes.string,
   cssModule: PropTypes.object,
 };
 


### PR DESCRIPTION
Fixes #209.

This is possibly a minor breaking change (dev only). Although React doesn't support className props other than strings, it's possible to extend render methods to accept other types (Radium does this), although I think it's then that library's responsibility to change the propTypes validation.