### PR TITLE
DropdownToggle unknown prop warning

### DIFF
--- a/src/DropdownToggle.js
+++ b/src/DropdownToggle.js
@@ -23,7 +23,7 @@ const defaultProps = {
   'aria-haspopup': true,
   color: 'secondary',
   tag: null,
-  ariaLabel: "Dropdown"
+  ariaLabel: 'Dropdown'
 };
 
 const contextTypes = {
@@ -37,7 +37,6 @@ class DropdownToggle extends React.Component {
     this.onClick = this.onClick.bind(this);
     this.Tag = Button;
   }
-  
   componentWillMount() {
     if (this.props.nav) {
       this.Tag = 'a';
@@ -46,7 +45,6 @@ class DropdownToggle extends React.Component {
       this.Tag = this.props.tag;
     }
   }
-
   onClick(e) {
     if (this.props.disabled) {
       e.preventDefault();
@@ -63,7 +61,6 @@ class DropdownToggle extends React.Component {
 
     this.context.toggle();
   }
-  
   render() {
     const classes = mapToCssModules(classNames(
       this.props.className,
@@ -74,7 +71,6 @@ class DropdownToggle extends React.Component {
         'nav-link': this.props.nav
       }
     ), this.props.cssModule);
-
     return (
       <this.Tag
         href={(this.props.nav) ? '#' : false}

--- a/src/DropdownToggle.js
+++ b/src/DropdownToggle.js
@@ -15,13 +15,15 @@ const propTypes = {
   split: PropTypes.bool,
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   nav: PropTypes.bool,
+  ariaLabel: PropTypes.string
 };
 
 const defaultProps = {
   'data-toggle': 'dropdown',
   'aria-haspopup': true,
   color: 'secondary',
-  tag: null
+  tag: null,
+  ariaLabel: "Dropdown"
 };
 
 const contextTypes = {
@@ -32,10 +34,17 @@ const contextTypes = {
 class DropdownToggle extends React.Component {
   constructor(props) {
     super(props);
-
     this.onClick = this.onClick.bind(this);
-    
-    this.Tag = Button
+    this.Tag = Button;
+  }
+  
+  componentWillMount() {
+    if (this.props.nav) {
+      this.Tag = 'a';
+    }
+    if (this.props.tag) {
+      this.Tag = this.props.tag;
+    }
   }
 
   onClick(e) {
@@ -55,15 +64,6 @@ class DropdownToggle extends React.Component {
     this.context.toggle();
   }
   
-  componentWillMount() {
-    if (this.props.nav) {
-      this.Tag = 'a'
-    }
-    if (this.props.tag) {
-      this.Tag = this.props.tag
-    }
-  }
-
   render() {
     const classes = mapToCssModules(classNames(
       this.props.className,
@@ -82,8 +82,7 @@ class DropdownToggle extends React.Component {
         onClick={this.onClick}
         aria-haspopup="true"
         aria-expanded={this.context.isOpen}
-        aria-label="Dropdown"
-        children={this.props.children || <span className="sr-only">{ariaLabel}</span>}
+        children={this.props.children || <span className="sr-only">{this.props.ariaLabel}</span>}
       />
     );
   }

--- a/src/DropdownToggle.js
+++ b/src/DropdownToggle.js
@@ -21,7 +21,7 @@ const defaultProps = {
   'data-toggle': 'dropdown',
   'aria-haspopup': true,
   color: 'secondary',
-  tag: Button
+  tag: null
 };
 
 const contextTypes = {
@@ -34,6 +34,8 @@ class DropdownToggle extends React.Component {
     super(props);
 
     this.onClick = this.onClick.bind(this);
+    
+    this.Tag = Button
   }
 
   onClick(e) {
@@ -52,34 +54,36 @@ class DropdownToggle extends React.Component {
 
     this.context.toggle();
   }
+  
+  componentWillMount() {
+    if (this.props.nav) {
+      this.Tag = 'a'
+    }
+    if (this.props.tag) {
+      this.Tag = this.props.tag
+    }
+  }
 
   render() {
-    const { className, cssModule, caret, split, nav, tag: Tag, ...props } = this.props;
-    const ariaLabel = props['aria-label'] || 'Toggle Dropdown';
     const classes = mapToCssModules(classNames(
-      className,
+      this.props.className,
       {
-        'dropdown-toggle': caret || split,
-        'dropdown-toggle-split': split,
+        'dropdown-toggle': this.props.caret || this.props.split,
+        'dropdown-toggle-split': this.props.split,
         active: this.context.isOpen,
-        'nav-link': nav
+        'nav-link': this.props.nav
       }
-    ), cssModule);
-    const children = props.children || <span className="sr-only">{ariaLabel}</span>;
-
-    if (nav) {
-      props.tag = 'a';
-      props.href = '#';
-    }
+    ), this.props.cssModule);
 
     return (
-      <Tag
-        {...props}
+      <this.Tag
+        href={(this.props.nav) ? '#' : false}
         className={classes}
         onClick={this.onClick}
         aria-haspopup="true"
         aria-expanded={this.context.isOpen}
-        children={children}
+        aria-label="Dropdown"
+        children={this.props.children || <span className="sr-only">{ariaLabel}</span>}
       />
     );
   }

--- a/src/DropdownToggle.js
+++ b/src/DropdownToggle.js
@@ -23,7 +23,7 @@ const defaultProps = {
   'aria-haspopup': true,
   color: 'secondary',
   tag: null,
-  ariaLabel: 'Dropdown'
+  ariaLabel: 'Dropdown Toggle'
 };
 
 const contextTypes = {


### PR DESCRIPTION
React throws unknown prop warning when using the tag prop. This was due to the tag prop being set twice in the render method. I added componentWillMount in order to evaluate the tag prop before the component is rendered. I also removed the de-structured props variable.