### PR TITLE
fix(DropdownToggle): only set tag prop if the Tag is default button

### DIFF
--- a/src/DropdownToggle.js
+++ b/src/DropdownToggle.js
@@ -41,7 +41,7 @@ class DropdownToggle extends React.Component {
       return;
     }
 
-    if (this.props.nav) {
+    if (this.props.nav && !this.props.tag) {
       e.preventDefault();
     }
 
@@ -53,7 +53,7 @@ class DropdownToggle extends React.Component {
   }
 
   render() {
-    const { className, cssModule, caret, split, nav, ...props } = this.props;
+    const { className, cssModule, caret, split, nav, tag, ...props } = this.props;
     const ariaLabel = props['aria-label'] || 'Toggle Dropdown';
     const classes = mapToCssModules(classNames(
       className,
@@ -66,13 +66,19 @@ class DropdownToggle extends React.Component {
     ), cssModule);
     const children = props.children || <span className="sr-only">{ariaLabel}</span>;
 
-    if (nav && !props.tag) {
-      props.tag = 'a';
+    let Tag;
+
+    if (nav && !tag) {
+      Tag = 'a';
       props.href = '#';
+    } else if (!tag) {
+      Tag = Button;
+    } else {
+      Tag = tag;
     }
 
     return (
-      <Button
+      <Tag
         {...props}
         className={classes}
         onClick={this.onClick}

--- a/src/DropdownToggle.js
+++ b/src/DropdownToggle.js
@@ -21,7 +21,6 @@ const defaultProps = {
   'data-toggle': 'dropdown',
   'aria-haspopup': true,
   color: 'secondary',
-  tag: Button
 };
 
 const contextTypes = {
@@ -54,7 +53,7 @@ class DropdownToggle extends React.Component {
   }
 
   render() {
-    const { className, cssModule, caret, split, nav, tag: Tag, ...props } = this.props;
+    const { className, cssModule, caret, split, nav, ...props } = this.props;
     const ariaLabel = props['aria-label'] || 'Toggle Dropdown';
     const classes = mapToCssModules(classNames(
       className,
@@ -67,13 +66,13 @@ class DropdownToggle extends React.Component {
     ), cssModule);
     const children = props.children || <span className="sr-only">{ariaLabel}</span>;
 
-    if (nav) {
+    if (nav && !props.tag) {
       props.tag = 'a';
       props.href = '#';
     }
 
     return (
-      <Tag
+      <Button
         {...props}
         className={classes}
         onClick={this.onClick}

--- a/src/__tests__/DropdownToggle.spec.js
+++ b/src/__tests__/DropdownToggle.spec.js
@@ -181,7 +181,7 @@ describe('DropdownToggle', () => {
         }
       );
 
-      expect(wrapper.find('span').prop('tag')).toBe(undefined);
+      expect(wrapper.find('[aria-haspopup="true"]').prop('tag')).toBe(undefined);
     });
 
     it('should preventDefault', () => {

--- a/src/__tests__/DropdownToggle.spec.js
+++ b/src/__tests__/DropdownToggle.spec.js
@@ -170,6 +170,20 @@ describe('DropdownToggle', () => {
       expect(wrapper.find('.nav-link').length).toBe(1);
     });
 
+    it('should not set the tag prop when the tag is defined', () => {
+      const wrapper = mount(
+        <DropdownToggle nav tag="span">Ello world</DropdownToggle>,
+        {
+          context: {
+            isOpen: isOpen,
+            toggle: toggle
+          }
+        }
+      );
+
+      expect(wrapper.find('span').prop('tag')).toBe(undefined);
+    });
+
     it('should preventDefault', () => {
       const e = { preventDefault: jasmine.createSpy('preventDefault') };
       const wrapper = mount(


### PR DESCRIPTION
Supersedes #220 
This is one of those interesting 'defaults' which in the case of `nav`, it would tell the Button to become an anchor tag, but if the tag was already being override via DropdownToggle's `tag` prop, it would try to set the `tag` prop on that thing, which may not support the `tag` prop.