### PR TITLE
ListGroup doc #185

### DIFF
--- a/docs/lib/Components/ListGroupPage.js
+++ b/docs/lib/Components/ListGroupPage.js
@@ -81,17 +81,6 @@ export default class ListGroupPage extends React.Component {
             {ListGroupCustomContentExampleSource}
           </PrismCode>
         </pre>
-
-
-        <h4>Container Properties</h4>
-        <pre>
-          <PrismCode className="language-jsx">
-{`Container.propTypes = {
-  fluid:  PropTypes.bool
-  // applies .container-fluid class
-}`}
-          </PrismCode>
-        </pre>
       </div>
     );
   }

--- a/docs/lib/Components/ListGroupPage.js
+++ b/docs/lib/Components/ListGroupPage.js
@@ -3,7 +3,18 @@ import React from 'react';
 import { PrismCode } from 'react-prism';
 import Helmet from 'react-helmet';
 import ListGroupExample from '../examples/ListGroup';
+import ListGroupTagExample from '../examples/ListGroupTag';
+import ListGroupDisabledItemsExample from '../examples/ListGroupDisabledItems';
+import ListGroupAnchorsAndButtonsExample from '../examples/ListGroupAnchorsAndButtons';
+import ListGroupContextualClassesExample from '../examples/ListGroupContextualClasses';
+import ListGroupCustomContentExample from '../examples/ListGroupCustomContent';
+
+const ListGroupTagExampleSource = require('!!raw!../examples/ListGroupTag');
 const ListGroupExampleSource = require('!!raw!../examples/ListGroup');
+const ListGroupDisabledItemsExampleSource = require('!!raw!../examples/ListGroupDisabledItems');
+const ListGroupAnchorsAndButtonsExampleSource = require('!!raw!../examples/ListGroupAnchorsAndButtons');
+const ListGroupContextualClassesExampleSource = require('!!raw!../examples/ListGroupContextualClasses');
+const ListGroupCustomContentExampleSource = require('!!raw!../examples/ListGroupCustomContent');
 
 export default class ListGroupPage extends React.Component {
   render() {
@@ -19,6 +30,59 @@ export default class ListGroupPage extends React.Component {
             {ListGroupExampleSource}
           </PrismCode>
         </pre>
+
+        <legend>Tags</legend>
+        <div className="docs-example">
+          <ListGroupTagExample />
+        </div>
+        <pre>
+          <PrismCode className="language-jsx">
+            {ListGroupTagExampleSource}
+          </PrismCode>
+        </pre>
+
+        <legend>Disabled items</legend>
+        <div className="docs-example">
+          <ListGroupDisabledItemsExample />
+        </div>
+        <pre>
+          <PrismCode className="language-jsx">
+            {ListGroupDisabledItemsExampleSource}
+          </PrismCode>
+        </pre>
+
+        <legend>Anchors and buttons</legend>
+        <div className="docs-example">
+          <p>Note: you need add action props to make these buttons fit the list.</p>
+          <ListGroupAnchorsAndButtonsExample />
+        </div>
+        <pre>
+          <PrismCode className="language-jsx">
+            {ListGroupAnchorsAndButtonsExampleSource}
+          </PrismCode>
+        </pre>
+
+        <legend>Contextual classes</legend>
+        <div className="docs-example">
+          <ListGroupContextualClassesExample />
+        </div>
+        <pre>
+          <PrismCode className="language-jsx">
+            {ListGroupContextualClassesExampleSource}
+          </PrismCode>
+        </pre>
+
+        <legend>Custom content</legend>
+        <div className="docs-example">
+          <ListGroupCustomContentExample />
+        </div>
+        <pre>
+          <PrismCode className="language-jsx">
+            {ListGroupCustomContentExampleSource}
+          </PrismCode>
+        </pre>
+
+
         <h4>Container Properties</h4>
         <pre>
           <PrismCode className="language-jsx">

--- a/docs/lib/Components/ListGroupPage.js
+++ b/docs/lib/Components/ListGroupPage.js
@@ -1,0 +1,34 @@
+/* eslint react/no-multi-comp: 0, react/prop-types: 0 */
+import React from 'react';
+import { PrismCode } from 'react-prism';
+import Helmet from 'react-helmet';
+import ListGroupExample from '../examples/ListGroup';
+const ListGroupExampleSource = require('!!raw!../examples/ListGroup');
+
+export default class ListGroupPage extends React.Component {
+  render() {
+    return (
+      <div>
+        <Helmet title="ListGroup Components" />
+        <h3>ListGroup</h3>
+        <div className="docs-example">
+          <ListGroupExample />
+        </div>
+        <pre>
+          <PrismCode className="language-jsx">
+            {ListGroupExampleSource}
+          </PrismCode>
+        </pre>
+        <h4>Container Properties</h4>
+        <pre>
+          <PrismCode className="language-jsx">
+{`Container.propTypes = {
+  fluid:  PropTypes.bool
+  // applies .container-fluid class
+}`}
+          </PrismCode>
+        </pre>
+      </div>
+    );
+  }
+}

--- a/docs/lib/Components/index.js
+++ b/docs/lib/Components/index.js
@@ -108,6 +108,10 @@ class Components extends React.Component {
         {
           name: 'Alerts',
           to: '/components/alerts/'
+        },
+        {
+          name: 'List Group',
+          to: '/components/listgroup/'
         }
       ]
     };

--- a/docs/lib/Components/index.js
+++ b/docs/lib/Components/index.js
@@ -110,13 +110,12 @@ class Components extends React.Component {
           to: '/components/alerts/'
         },
         {
-<<<<<<< HEAD
-          name: 'List Group',
-          to: '/components/listgroup/'
-=======
           name: 'Collapse',
           to: '/components/collapse/',
->>>>>>> reactstrap/master
+        },
+        {
+          name: 'List Group',
+          to: '/components/listgroup/'
         }
       ]
     };

--- a/docs/lib/examples/ListGroup.js
+++ b/docs/lib/examples/ListGroup.js
@@ -1,11 +1,15 @@
 import React from 'react';
-import { ListGroup } from 'reactstrap';
+import { ListGroup, ListGroupItem } from 'reactstrap';
 
 export default class Example extends React.Component {
   render() {
     return (
       <ListGroup>
-
+        <ListGroupItem>Cras justo odio</ListGroupItem>
+        <ListGroupItem>Dapibus ac facilisis in</ListGroupItem>
+        <ListGroupItem>Morbi leo risus</ListGroupItem>
+        <ListGroupItem>Porta ac consectetur ac</ListGroupItem>
+        <ListGroupItem>Vestibulum at eros</ListGroupItem>
       </ListGroup>
     );
   }

--- a/docs/lib/examples/ListGroup.js
+++ b/docs/lib/examples/ListGroup.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { ListGroup } from 'reactstrap';
+
+export default class Example extends React.Component {
+  render() {
+    return (
+      <ListGroup>
+
+      </ListGroup>
+    );
+  }
+}

--- a/docs/lib/examples/ListGroupAnchorsAndButtons.js
+++ b/docs/lib/examples/ListGroupAnchorsAndButtons.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { ListGroup, ListGroupItem } from 'reactstrap';
+
+export default class Example extends React.Component {
+  render() {
+    return (
+      <div>
+        <h3>Anchors </h3>
+        <p>Be sure to <strong>not use the standard <code>.btn</code> classes here</strong>.</p>
+        <ListGroup>
+          <ListGroupItem active tag="a" href="#" action>Cras justo odio</ListGroupItem>
+          <ListGroupItem tag="a" href="#" action>Dapibus ac facilisis in</ListGroupItem>
+          <ListGroupItem tag="a" href="#" action>Morbi leo risus</ListGroupItem>
+          <ListGroupItem tag="a" href="#" action>Porta ac consectetur ac</ListGroupItem>
+          <ListGroupItem disabled tag="a" href="#" action>Vestibulum at eros</ListGroupItem>
+        </ListGroup>
+        <p />
+        <h3>Buttons </h3>
+        <ListGroup>
+          <ListGroupItem active tag="button" action>Cras justo odio</ListGroupItem>
+          <ListGroupItem tag="button" action>Dapibus ac facilisis in</ListGroupItem>
+          <ListGroupItem tag="button" action>Morbi leo risus</ListGroupItem>
+          <ListGroupItem tag="button" action>Porta ac consectetur ac</ListGroupItem>
+          <ListGroupItem disabled tag="button" action>Vestibulum at eros</ListGroupItem>
+        </ListGroup>
+      </div>
+    );
+  }
+}

--- a/docs/lib/examples/ListGroupContextualClasses.js
+++ b/docs/lib/examples/ListGroupContextualClasses.js
@@ -5,10 +5,10 @@ export default class Example extends React.Component {
   render() {
     return (
       <ListGroup>
-        <ListGroupItem success>Cras justo odio</ListGroupItem>
-        <ListGroupItem info>Dapibus ac facilisis in</ListGroupItem>
-        <ListGroupItem warning>Morbi leo risus</ListGroupItem>
-        <ListGroupItem danger>Porta ac consectetur ac</ListGroupItem>
+        <ListGroupItem color="success">Cras justo odio</ListGroupItem>
+        <ListGroupItem color="info">Dapibus ac facilisis in</ListGroupItem>
+        <ListGroupItem color="warning">Morbi leo risus</ListGroupItem>
+        <ListGroupItem color="danger">Porta ac consectetur ac</ListGroupItem>
       </ListGroup>
     );
   }

--- a/docs/lib/examples/ListGroupContextualClasses.js
+++ b/docs/lib/examples/ListGroupContextualClasses.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { ListGroup, ListGroupItem } from 'reactstrap';
+
+export default class Example extends React.Component {
+  render() {
+    return (
+      <ListGroup>
+        <ListGroupItem success>Cras justo odio</ListGroupItem>
+        <ListGroupItem info>Dapibus ac facilisis in</ListGroupItem>
+        <ListGroupItem warning>Morbi leo risus</ListGroupItem>
+        <ListGroupItem danger>Porta ac consectetur ac</ListGroupItem>
+      </ListGroup>
+    );
+  }
+}

--- a/docs/lib/examples/ListGroupCustomContent.js
+++ b/docs/lib/examples/ListGroupCustomContent.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { ListGroup, ListGroupItem, ListGroupItemHeading, ListGroupItemText } from 'reactstrap';
+
+export default class Example extends React.Component {
+  render() {
+    return (
+      <ListGroup>
+        <ListGroupItem active>
+          <ListGroupItemHeading>List group item heading</ListGroupItemHeading>
+          <ListGroupItemText>
+          Donec id elit non mi porta gravida at eget metus. Maecenas sed diam eget risus varius blandit.
+          </ListGroupItemText>
+        </ListGroupItem>
+        <ListGroupItem>
+          <ListGroupItemHeading>List group item heading</ListGroupItemHeading>
+          <ListGroupItemText>
+          Donec id elit non mi porta gravida at eget metus. Maecenas sed diam eget risus varius blandit.
+          </ListGroupItemText>
+        </ListGroupItem>
+        <ListGroupItem>
+          <ListGroupItemHeading>List group item heading</ListGroupItemHeading>
+          <ListGroupItemText>
+          Donec id elit non mi porta gravida at eget metus. Maecenas sed diam eget risus varius blandit.
+          </ListGroupItemText>
+        </ListGroupItem>
+      </ListGroup>
+    );
+  }
+}

--- a/docs/lib/examples/ListGroupDisabledItems.js
+++ b/docs/lib/examples/ListGroupDisabledItems.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { ListGroup, ListGroupItem } from 'reactstrap';
+
+export default class Example extends React.Component {
+  render() {
+    return (
+      <ListGroup>
+        <ListGroupItem disabled tag="a" href="#">Cras justo odio</ListGroupItem>
+        <ListGroupItem tag="a" href="#">Dapibus ac facilisis in</ListGroupItem>
+        <ListGroupItem tag="a" href="#">Morbi leo risus</ListGroupItem>
+        <ListGroupItem tag="a" href="#">Porta ac consectetur ac</ListGroupItem>
+        <ListGroupItem tag="a" href="#">Vestibulum at eros</ListGroupItem>
+      </ListGroup>
+    );
+  }
+}

--- a/docs/lib/examples/ListGroupTag.js
+++ b/docs/lib/examples/ListGroupTag.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { ListGroup, ListGroupItem, Tag } from 'reactstrap';
+
+export default class Example extends React.Component {
+  render() {
+    return (
+      <ListGroup>
+        <ListGroupItem><Tag pill className="float-xs-right">14</Tag>Cras justo odio</ListGroupItem>
+        <ListGroupItem><Tag pill className="float-xs-right">2</Tag>Dapibus ac facilisis in</ListGroupItem>
+        <ListGroupItem><Tag pill className="float-xs-right">1</Tag>Morbi leo risus</ListGroupItem>
+      </ListGroup>
+    );
+  }
+}

--- a/docs/lib/routes.js
+++ b/docs/lib/routes.js
@@ -23,6 +23,7 @@ import PaginationPage from './Components/PaginationPage';
 import TabsPage from './Components/TabsPage';
 import JumbotronPage from './Components/JumbotronPage';
 import AlertsPage from './Components/AlertsPage';
+import ListGroupPage from './Components/ListGroupPage';
 import NotFound from './NotFound';
 import Components from './Components';
 import UI from './UI';
@@ -54,6 +55,7 @@ const routes = (
       <Route path="tabs/" component={TabsPage} />
       <Route path="alerts/" component={AlertsPage} />
       <Route path="jumbotron/" component={JumbotronPage} />
+      <Route path="listgroup/" component={ListGroupPage} />
     </Route>
     <Route path="*" component={NotFound} />
   </Route>

--- a/docs/lib/routes.js
+++ b/docs/lib/routes.js
@@ -23,11 +23,8 @@ import PaginationPage from './Components/PaginationPage';
 import TabsPage from './Components/TabsPage';
 import JumbotronPage from './Components/JumbotronPage';
 import AlertsPage from './Components/AlertsPage';
-<<<<<<< HEAD
-import ListGroupPage from './Components/ListGroupPage';
-=======
 import CollapsePage from './Components/CollapsePage';
->>>>>>> reactstrap/master
+import ListGroupPage from './Components/ListGroupPage';
 import NotFound from './NotFound';
 import Components from './Components';
 import UI from './UI';
@@ -59,11 +56,8 @@ const routes = (
       <Route path="tabs/" component={TabsPage} />
       <Route path="alerts/" component={AlertsPage} />
       <Route path="jumbotron/" component={JumbotronPage} />
-<<<<<<< HEAD
-      <Route path="listgroup/" component={ListGroupPage} />
-=======
       <Route path="collapse/" component={CollapsePage} />
->>>>>>> reactstrap/master
+      <Route path="listgroup/" component={ListGroupPage} />
     </Route>
     <Route path="*" component={NotFound} />
   </Route>

--- a/src/ListGroupItem.js
+++ b/src/ListGroupItem.js
@@ -8,6 +8,10 @@ const propTypes = {
   color: PropTypes.string,
   action: PropTypes.bool,
   className: PropTypes.any,
+  success: PropTypes.bool,
+  warning: PropTypes.bool,
+  danger: PropTypes.bool,
+  info: PropTypes.bool
 };
 
 const defaultProps = {
@@ -21,15 +25,22 @@ const ListGroupItem = (props) => {
     active,
     disabled,
     action,
-    color,
+    success,
+    warning,
+    danger,
+    info,
     ...attributes
   } = props;
+
   const classes = classNames(
     className,
     active ? 'active' : false,
     disabled ? 'disabled' : false,
     action ? 'list-group-item-action' : false,
-    color ? `list-group-item-${color}` : false,
+    success ? 'list-group-item-success' : false,
+    warning ? 'list-group-item-warning' : false,
+    danger ? 'list-group-item-danger' : false,
+    info ? 'list-group-item-info' : false,
     'list-group-item'
   );
 

--- a/src/ListGroupItem.js
+++ b/src/ListGroupItem.js
@@ -33,6 +33,12 @@ const ListGroupItem = (props) => {
     'list-group-item'
   );
 
+  // Prevent click event when disabled.
+  if (disabled) {
+    attributes.onClick = (event) => {
+      event.preventDefault();
+    };
+  }
   return (
     <Tag {...attributes} className={classes} />
   );

--- a/src/ListGroupItem.js
+++ b/src/ListGroupItem.js
@@ -14,6 +14,10 @@ const defaultProps = {
   tag: 'li'
 };
 
+const handleDisabledOnClick = (e) => {
+  e.preventDefault();
+};
+
 const ListGroupItem = (props) => {
   const {
     className,
@@ -35,9 +39,7 @@ const ListGroupItem = (props) => {
 
   // Prevent click event when disabled.
   if (disabled) {
-    attributes.onClick = (event) => {
-      event.preventDefault();
-    };
+    attributes.onClick = handleDisabledOnClick;
   }
   return (
     <Tag {...attributes} className={classes} />

--- a/src/ListGroupItem.js
+++ b/src/ListGroupItem.js
@@ -8,10 +8,6 @@ const propTypes = {
   color: PropTypes.string,
   action: PropTypes.bool,
   className: PropTypes.any,
-  success: PropTypes.bool,
-  warning: PropTypes.bool,
-  danger: PropTypes.bool,
-  info: PropTypes.bool
 };
 
 const defaultProps = {
@@ -25,22 +21,15 @@ const ListGroupItem = (props) => {
     active,
     disabled,
     action,
-    success,
-    warning,
-    danger,
-    info,
+    color,
     ...attributes
   } = props;
-
   const classes = classNames(
     className,
     active ? 'active' : false,
     disabled ? 'disabled' : false,
     action ? 'list-group-item-action' : false,
-    success ? 'list-group-item-success' : false,
-    warning ? 'list-group-item-warning' : false,
-    danger ? 'list-group-item-danger' : false,
-    info ? 'list-group-item-info' : false,
+    color ? `list-group-item-${color}` : false,
     'list-group-item'
   );
 

--- a/src/__tests__/ListGroupItem.spec.js
+++ b/src/__tests__/ListGroupItem.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import ListGroupItem from '../ListGroupItem';
 
 describe('ListGroupItem', () => {
@@ -46,5 +46,12 @@ describe('ListGroupItem', () => {
   it('should render with "list-group-item-danger" class when danger is passed', () => {
     const wrapper = shallow(<ListGroupItem danger>Yo!</ListGroupItem>);
     expect(wrapper.hasClass('list-group-item-danger')).toBe(true);
+  });
+
+  it('should prevent click event when disabled is passed', () => {
+    const onDisableClick = jasmine.createSpy('click');
+    const wrapper = mount(<ListGroupItem disabled onClick={onDisableClick}>Yo!</ListGroupItem>);
+    wrapper.find('li').simulate('click');
+    expect(onDisableClick).not.toHaveBeenCalled();
   });
 });

--- a/src/__tests__/ListGroupItem.spec.js
+++ b/src/__tests__/ListGroupItem.spec.js
@@ -28,24 +28,9 @@ describe('ListGroupItem', () => {
     expect(wrapper.hasClass('list-group-item-action')).toBe(true);
   });
 
-  it('should render with "list-group-item-success" class when success is passed', () => {
-    const wrapper = shallow(<ListGroupItem success>Yo!</ListGroupItem>);
+  it('should render with "list-group-item-${color}" class when color is passed', () => {
+    const wrapper = shallow(<ListGroupItem color="success">Yo!</ListGroupItem>);
     expect(wrapper.hasClass('list-group-item-success')).toBe(true);
-  });
-
-  it('should render with "list-group-item-info" class when info is passed', () => {
-    const wrapper = shallow(<ListGroupItem info>Yo!</ListGroupItem>);
-    expect(wrapper.hasClass('list-group-item-info')).toBe(true);
-  });
-
-  it('should render with "list-group-item-warning" class when warning is passed', () => {
-    const wrapper = shallow(<ListGroupItem warning>Yo!</ListGroupItem>);
-    expect(wrapper.hasClass('list-group-item-warning')).toBe(true);
-  });
-
-  it('should render with "list-group-item-danger" class when danger is passed', () => {
-    const wrapper = shallow(<ListGroupItem danger>Yo!</ListGroupItem>);
-    expect(wrapper.hasClass('list-group-item-danger')).toBe(true);
   });
 
   it('should prevent click event when disabled is passed', () => {

--- a/src/__tests__/ListGroupItem.spec.js
+++ b/src/__tests__/ListGroupItem.spec.js
@@ -28,8 +28,23 @@ describe('ListGroupItem', () => {
     expect(wrapper.hasClass('list-group-item-action')).toBe(true);
   });
 
-  it('should render with "list-group-item-${color}" class when color is passed', () => {
-    const wrapper = shallow(<ListGroupItem color="success">Yo!</ListGroupItem>);
+  it('should render with "list-group-item-success" class when success is passed', () => {
+    const wrapper = shallow(<ListGroupItem success>Yo!</ListGroupItem>);
     expect(wrapper.hasClass('list-group-item-success')).toBe(true);
+  });
+
+  it('should render with "list-group-item-info" class when info is passed', () => {
+    const wrapper = shallow(<ListGroupItem info>Yo!</ListGroupItem>);
+    expect(wrapper.hasClass('list-group-item-info')).toBe(true);
+  });
+
+  it('should render with "list-group-item-warning" class when warning is passed', () => {
+    const wrapper = shallow(<ListGroupItem warning>Yo!</ListGroupItem>);
+    expect(wrapper.hasClass('list-group-item-warning')).toBe(true);
+  });
+
+  it('should render with "list-group-item-danger" class when danger is passed', () => {
+    const wrapper = shallow(<ListGroupItem danger>Yo!</ListGroupItem>);
+    expect(wrapper.hasClass('list-group-item-danger')).toBe(true);
   });
 });

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -35,11 +35,8 @@ var paths = [
   '/components/tabs/',
   '/components/jumbotron/',
   '/components/alerts/',
-<<<<<<< HEAD
-  '/components/listgroup/',
-=======
   '/components/collapse/',
->>>>>>> reactstrap/master
+  '/components/listgroup/',
   '/404.html'
 ];
 

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -35,6 +35,7 @@ var paths = [
   '/components/tabs/',
   '/components/jumbotron/',
   '/components/alerts/',
+  '/components/listgroup/',
   '/404.html'
 ];
 


### PR DESCRIPTION
#185  Add ListGroup doc.

**API Change in ListGroupItem component:**
When I write doc, I found that using `color="success"` to set contextual class is not a good idea.

The `color` prop is no longer support, when you want to set a contextual class, just pass the name (one of “success”, “info”, “warning”, “danger”) to the component.

Since this component is not exists in doc yet and just released a few days, I think the change is acceptable.