### PR TITLE
Pass through unused props in Modal

### DIFF
--- a/src/Modal.js
+++ b/src/Modal.js
@@ -1,6 +1,7 @@
 import React, { PropTypes } from 'react';
 import ReactDOM from 'react-dom';
 import classNames from 'classnames';
+import omit from 'lodash.omit';
 import TransitionGroup from 'react-addons-transition-group';
 import Fade from './Fade';
 import {
@@ -161,9 +162,19 @@ class Modal extends React.Component {
   }
 
   renderChildren() {
+    const {
+      className,
+      cssModule,
+      isOpen,
+      size,
+      backdrop,
+      children,
+      ...attributes
+    } = omit(this.props, ['toggle', 'keyboard', 'onEnter', 'onExit', 'zIndex']);
+
     return (
       <TransitionGroup component="div">
-        {this.props.isOpen && (
+        {isOpen && (
           <Fade
             key="modal-dialog"
             onEnter={this.onEnter}
@@ -178,19 +189,20 @@ class Modal extends React.Component {
             tabIndex="-1"
           >
             <div
-              className={mapToCssModules(classNames('modal-dialog', this.props.className, {
-                [`modal-${this.props.size}`]: this.props.size
-              }), this.props.cssModule)}
+              className={mapToCssModules(classNames('modal-dialog', className, {
+                [`modal-${size}`]: size
+              }), cssModule)}
               role="document"
               ref={(c) => (this._dialog = c)}
+              {...attributes}
             >
               <div className="modal-content">
-                {this.props.children}
+                {children}
               </div>
             </div>
           </Fade>
         )}
-        {this.props.isOpen && this.props.backdrop && (
+        {isOpen && backdrop && (
           <Fade
             key="modal-backdrop"
             transitionAppearTimeout={150}


### PR DESCRIPTION
Currently it's not possible to for example change the size (excluding default Bootstrap sizes) of modals. This change allows users to style the modal dialog.