### PR TITLE
feat(Progress): enhance multiple progress bars

### DIFF
--- a/docs/lib/Components/ProgressPage.js
+++ b/docs/lib/Components/ProgressPage.js
@@ -7,10 +7,14 @@ import ProgressExample from '../examples/Progress';
 const ProgressExampleSource = require('!!raw!../examples/Progress');
 import ProgressColorExample from '../examples/ProgressColor';
 const ProgressColorExampleSource = require('!!raw!../examples/ProgressColor');
+import ProgressLabelsExample from '../examples/ProgressLabels';
+const ProgressLabelsExampleSource = require('!!raw!../examples/ProgressLabels');
 import ProgressAnimatedExample from '../examples/ProgressAnimated';
 const ProgressAnimatedExampleSource = require('!!raw!../examples/ProgressAnimated');
 import ProgressStripedExample from '../examples/ProgressStriped';
 const ProgressStripedExampleSource = require('!!raw!../examples/ProgressStriped');
+import ProgressMultiExample from '../examples/ProgressMulti';
+const ProgressMultiExampleSource = require('!!raw!../examples/ProgressMulti');
 import ProgressMaxExample from '../examples/ProgressMax';
 const ProgressMaxExampleSource = require('!!raw!../examples/ProgressMax');
 
@@ -32,6 +36,8 @@ export default class ProgressPage extends React.Component {
         <pre>
           <PrismCode className="language-jsx">
 {`Progress.propTypes = {
+  multi: PropTypes.bool,
+  bar: PropTypes.bool, // used in combination with multi
   tag: PropTypes.string,
   value: PropTypes.oneOfType([
     PropTypes.string,
@@ -67,6 +73,18 @@ Progress.defaultProps = {
           </PrismCode>
         </pre>
 
+        <h3>Labels</h3>
+        <div className="docs-example">
+          <div>
+            <ProgressLabelsExample />
+          </div>
+        </div>
+        <pre>
+          <PrismCode className="language-jsx">
+            {ProgressLabelsExampleSource}
+          </PrismCode>
+        </pre>
+
         <h3>Striped</h3>
         <div className="docs-example">
           <div>
@@ -91,6 +109,18 @@ Progress.defaultProps = {
         <pre>
           <PrismCode className="language-jsx">
             {ProgressAnimatedExampleSource}
+          </PrismCode>
+        </pre>
+
+        <h3>Multiple bars / Stacked</h3>
+        <div className="docs-example">
+          <div>
+            <ProgressMultiExample />
+          </div>
+        </div>
+        <pre>
+          <PrismCode className="language-jsx">
+            {ProgressMultiExampleSource}
           </PrismCode>
         </pre>
 

--- a/docs/lib/examples/Progress.js
+++ b/docs/lib/examples/Progress.js
@@ -15,12 +15,12 @@ const Example = (props) => {
       <div className="text-center">100%</div>
       <Progress value="100" />
       <div className="text-center">Multiple bars</div>
-      <Progress>
-        <Progress value="15" />
-        <Progress color="success" value="30" />
-        <Progress color="info" value="25" />
-        <Progress color="warning" value="20" />
-        <Progress color="danger" value="5" />
+      <Progress multi>
+        <Progress bar value="15" />
+        <Progress bar color="success" value="30" />
+        <Progress bar color="info" value="25" />
+        <Progress bar color="warning" value="20" />
+        <Progress bar color="danger" value="5" />
       </Progress>
     </div>
   );

--- a/docs/lib/examples/ProgressAnimated.js
+++ b/docs/lib/examples/ProgressAnimated.js
@@ -9,6 +9,12 @@ const Example = (props) => {
       <Progress animated color="info" value={50} />
       <Progress animated color="warning" value={75} />
       <Progress animated color="danger" value="100" />
+      <Progress multi>
+        <Progress animated bar value="10" />
+        <Progress animated bar color="success" value="30" />
+        <Progress animated bar color="warning" value="20" />
+        <Progress animated bar color="danger" value="20" />
+      </Progress>
     </div>
   );
 };

--- a/docs/lib/examples/ProgressLabels.js
+++ b/docs/lib/examples/ProgressLabels.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Progress } from 'reactstrap';
+
+const Example = (props) => {
+  return (
+    <div>
+      <Progress value="25">25%</Progress>
+      <Progress value={50}>1/2</Progress>
+      <Progress value={75}>You're almost there!</Progress>
+      <Progress color="success" value="100">You did it!</Progress>
+      <Progress multi>
+        <Progress bar value="15">Meh</Progress>
+        <Progress bar color="success" value="30">Wow!</Progress>
+        <Progress bar color="info" value="25">Cool</Progress>
+        <Progress bar color="warning" value="20">20%</Progress>
+        <Progress bar color="danger" value="5">!!</Progress>
+      </Progress>
+    </div>
+  );
+};
+
+export default Example;

--- a/docs/lib/examples/ProgressMax.js
+++ b/docs/lib/examples/ProgressMax.js
@@ -12,6 +12,14 @@ const Example = (props) => {
       <Progress value={75} max={111} />
       <div className="text-center">463 of 500</div>
       <Progress value="463" max={500} />
+
+      <div className="text-center">Various (40) of 55</div>
+      <Progress multi>
+        <Progress bar value="5" max={55}>5</Progress>
+        <Progress bar color="success" value="15" max={55}>15</Progress>
+        <Progress bar color="warning" value="10" max={55}>10</Progress>
+        <Progress bar color="danger" value="10" max={55}>10</Progress>
+      </Progress>
     </div>
   );
 };

--- a/docs/lib/examples/ProgressMulti.js
+++ b/docs/lib/examples/ProgressMulti.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Progress } from 'reactstrap';
+
+const Example = (props) => {
+  return (
+    <div>
+      <div className="text-center">Plain</div>
+      <Progress multi>
+        <Progress bar value="15" />
+        <Progress bar color="success" value="20" />
+        <Progress bar color="info" value="25" />
+        <Progress bar color="warning" value="20" />
+        <Progress bar color="danger" value="15" />
+      </Progress>
+      <div className="text-center">With Labels</div>
+      <Progress multi>
+        <Progress bar value="15">Meh</Progress>
+        <Progress bar color="success" value="35">Wow!</Progress>
+        <Progress bar color="warning" value="25">25%</Progress>
+        <Progress bar color="danger" value="25">LOOK OUT!!</Progress>
+      </Progress>
+      <div className="text-center">Stripes and Animations</div>
+      <Progress multi>
+        <Progress bar striped value="15">Stripes</Progress>
+        <Progress bar animated color="success" value="30">Animated Stripes</Progress>
+        <Progress bar color="info" value="25">Plain</Progress>
+      </Progress>
+    </div>
+  );
+};
+
+export default Example;

--- a/docs/lib/examples/ProgressStriped.js
+++ b/docs/lib/examples/ProgressStriped.js
@@ -9,6 +9,12 @@ const Example = (props) => {
       <Progress striped color="info" value={50} />
       <Progress striped color="warning" value={75} />
       <Progress striped color="danger" value="100" />
+      <Progress multi>
+        <Progress striped bar value="10" />
+        <Progress striped bar color="success" value="30" />
+        <Progress striped bar color="warning" value="20" />
+        <Progress striped bar color="danger" value="20" />
+      </Progress>
     </div>
   );
 };

--- a/src/Progress.js
+++ b/src/Progress.js
@@ -6,6 +6,7 @@ import { mapToCssModules } from './utils';
 const propTypes = {
   children: PropTypes.node,
   bar: PropTypes.bool,
+  multi: PropTypes.bool,
   tag: PropTypes.string,
   value: PropTypes.oneOfType([
     PropTypes.string,
@@ -39,6 +40,7 @@ const Progress = (props) => {
     striped,
     color,
     bar,
+    multi,
     tag: Tag,
     ...attributes
   } = props;
@@ -57,18 +59,7 @@ const Progress = (props) => {
     striped || animated ? 'progress-bar-striped' : null
   ), cssModule);
 
-  if (children) {
-    const childrenWithProps = React.Children.map(children, el => {
-      return React.cloneElement(el, {
-        bar: true
-      });
-    });
-    return (
-      <Tag {...attributes} className={progressClasses} children={childrenWithProps} />
-    );
-  }
-
-  const ProgressBar = (
+  const ProgressBar = multi ? children : (
     <div
       className={progressBarClasses}
       style={{ width: `${percent}%` }}
@@ -76,6 +67,7 @@ const Progress = (props) => {
       aria-valuenow={value}
       aria-valuemin="0"
       aria-valuemax={max}
+      children={children}
     />
   );
 

--- a/src/__tests__/Progress.spec.js
+++ b/src/__tests__/Progress.spec.js
@@ -83,6 +83,13 @@ describe('Progress', () => {
     expect(wrapper.type()).toBe('main');
   });
 
+  it('should render only the .progress when "multi" is passed', () => {
+    const wrapper = shallow(<Progress multi />);
+
+    expect(wrapper.type()).toBe('div');
+    expect(wrapper.hasClass('progress')).toBe(true);
+  });
+
   it('should render only the .progress-bar when "bar" is passed', () => {
     const wrapper = shallow(<Progress bar />);
 
@@ -90,14 +97,34 @@ describe('Progress', () => {
     expect(wrapper.hasClass('progress-bar')).toBe(true);
   });
 
+  it('should render the children (label)', () => {
+    const wrapper = shallow(<Progress>0%</Progress>);
+
+    expect(wrapper.text()).toBe('0%');
+  });
+
+  it('should render the children (label) (multi)', () => {
+    const wrapper = mount(
+      <Progress multi>
+        <Progress bar value="15">15%</Progress>
+        <Progress bar color="success" value="30">30%</Progress>
+        <Progress bar color="info" value="25">25%</Progress>
+        <Progress bar color="warning" value="20">20%</Progress>
+        <Progress bar color="danger" value="5">5%</Progress>
+      </Progress>
+    );
+
+    expect(wrapper.text()).toBe('15%30%25%20%5%');
+  });
+
   it('should render nested progress bars', () => {
     const wrapper = mount(
-      <Progress>
-        <Progress value="15" />
-        <Progress color="success" value="30" />
-        <Progress color="info" value="25" />
-        <Progress color="warning" value="20" />
-        <Progress color="danger" value="5" />
+      <Progress multi>
+        <Progress bar value="15" />
+        <Progress bar color="success" value="30" />
+        <Progress bar color="info" value="25" />
+        <Progress bar color="warning" value="20" />
+        <Progress bar color="danger" value="5" />
       </Progress>
     );
 


### PR DESCRIPTION
Re worked progress a little more. Removed the cloneElement in favor of user/dev adding props `multi` and `bar`.
Progress bars can now have labels
Enhanced docs to add more various examples multiple progress bars and labels.
Added tests for the new props and labels.