### PR TITLE
Update ModalHeader close button

### DIFF
--- a/src/ModalHeader.js
+++ b/src/ModalHeader.js
@@ -35,10 +35,10 @@ const ModalHeader = (props) => {
 
   return (
     <div {...attributes} className={classes}>
-      {closeButton}
       <h4 className={mapToCssModules('modal-title', cssModule)}>
         {children}
       </h4>
+      {closeButton}
     </div>
   );
 };


### PR DESCRIPTION
Recent changes to Bootstrap alpha use flexbox to position ModalHeader
title and close button, which cause the current code to incorrectly
position title and close on the opposite and wrong side.