### PR TITLE
Col - fix disabled width props from being passed to div

### DIFF
--- a/src/Col.js
+++ b/src/Col.js
@@ -29,7 +29,7 @@ const propTypes = {
 };
 
 const defaultProps = {
-    xs: true
+  xs: true
 };
 
 const getColumnSizeClass = (isXs, colWidth, colSize) => {

--- a/src/Col.js
+++ b/src/Col.js
@@ -79,7 +79,7 @@ const Col = (props) => {
   });
 
   if (attributes['xs']) {
-      delete attributes['xs'];
+    delete attributes['xs'];
   }
 
   const classes = mapToCssModules(classNames(

--- a/src/Col.js
+++ b/src/Col.js
@@ -53,14 +53,14 @@ const Col = (props) => {
   colWidths.forEach(colWidth => {
     const columnProp = props[colWidth];
 
+    delete attributes[colWidth];
+
     if (!columnProp) {
       return;
     }
 
     const isXs = colWidth === 'xs';
     let colClass;
-
-    delete attributes[colWidth];
 
     if (isobject(columnProp)) {
       const colSizeInterfix = isXs ? '-' : `-${colWidth}-`;
@@ -77,10 +77,6 @@ const Col = (props) => {
       colClasses.push(colClass);
     }
   });
-
-  if (attributes['xs']) {
-    delete attributes['xs'];
-  }
 
   const classes = mapToCssModules(classNames(
     className,

--- a/src/Col.js
+++ b/src/Col.js
@@ -28,6 +28,10 @@ const propTypes = {
   cssModule: PropTypes.object,
 };
 
+const defaultProps = {
+    xs: true
+};
+
 const getColumnSizeClass = (isXs, colWidth, colSize) => {
   if (colSize === true || colSize === '') {
     return isXs ? 'col' : `col-${colWidth}`;
@@ -74,6 +78,10 @@ const Col = (props) => {
     }
   });
 
+  if (attributes['xs']) {
+      delete attributes['xs'];
+  }
+
   const classes = mapToCssModules(classNames(
     className,
     colClasses
@@ -85,5 +93,6 @@ const Col = (props) => {
 };
 
 Col.propTypes = propTypes;
+Col.defaultProps = defaultProps;
 
 export default Col;

--- a/src/Col.js
+++ b/src/Col.js
@@ -28,10 +28,6 @@ const propTypes = {
   cssModule: PropTypes.object,
 };
 
-const defaultProps = {
-  xs: true
-};
-
 const getColumnSizeClass = (isXs, colWidth, colSize) => {
   if (colSize === true || colSize === '') {
     return isXs ? 'col' : `col-${colWidth}`;

--- a/src/Col.js
+++ b/src/Col.js
@@ -85,6 +85,5 @@ const Col = (props) => {
 };
 
 Col.propTypes = propTypes;
-Col.defaultProps = defaultProps;
 
 export default Col;


### PR DESCRIPTION
Sometimes you don't want the `col` class by default, and setting xs={false} works but i got this error

`
Unknown prop 'xs' on <div> tag. Remove this prop from the element.
`

This prop is not removed from attributes.

https://github.com/reactstrap/reactstrap/blob/master/src/Col.js#L63