### PR TITLE
fix Collapse component height & navbar class

### DIFF
--- a/src/Collapse.js
+++ b/src/Collapse.js
@@ -107,7 +107,7 @@ class Collapse extends Component {
     const classes = mapToCssModules(classNames(
       className,
       collapseClass,
-      { navbar }
+      navbar && 'navbar-collapse'
     ), cssModule);
     const style = height === null ? null : { height };
     return (

--- a/src/Collapse.js
+++ b/src/Collapse.js
@@ -26,7 +26,7 @@ class Collapse extends Component {
     super(props);
     this.state = {
       collapse: props.isOpen ? SHOWN : HIDDEN,
-      height: props.isOpen ? null : 0
+      height: null
     };
     this.element = null;
   }

--- a/src/__tests__/Collapse.spec.js
+++ b/src/__tests__/Collapse.spec.js
@@ -35,7 +35,7 @@ describe('Collapse', () => {
 
   it('should render with class "navbar"', () => {
     const wrapper = shallow(<Collapse navbar />);
-    expect(wrapper.hasClass('navbar')).toEqual(true);
+    expect(wrapper.hasClass('navbar-collapse')).toEqual(true);
   });
 
   it('should render with class "show" when isOpen is true', () => {

--- a/src/__tests__/Collapse.spec.js
+++ b/src/__tests__/Collapse.spec.js
@@ -49,9 +49,9 @@ describe('Collapse', () => {
     expect(wrapper.state('height')).toBe(null);
   });
 
-  it('should set height to 0 when isOpen is false', () => {
+  it('should not set height when isOpen is false', () => {
     const wrapper = shallow(<Collapse isOpen={isOpen} />);
-    expect(wrapper.state('height')).toBe(0);
+    expect(wrapper.state('height')).toBe(null);
   });
 
   it('should render with class "collapse" with default collapse state', () => {


### PR DESCRIPTION
Collapse component was rendering with `height: 0` when isOpen was set to false. This caused issues when used inside the Navbar.

Also, updates the proper navbar class, navbar-collapse.