### PR TITLE
feat(Collapse): Add onOpened and onClosed events (#277)

### DIFF
--- a/docs/lib/Components/CollapsePage.js
+++ b/docs/lib/Components/CollapsePage.js
@@ -43,6 +43,7 @@ export default class CollapsePage extends React.Component {
         </pre>
 
         <h3>Events</h3>
+        <p>Use the onOpened and onClosed props for callbacks when the Collapse has finished opening or closing.</p>
         <div className="docs-example">
           <CollapseEventsExample />
         </div>

--- a/docs/lib/Components/CollapsePage.js
+++ b/docs/lib/Components/CollapsePage.js
@@ -6,6 +6,9 @@ import Helmet from 'react-helmet';
 import CollapseExample from '../examples/Collapse';
 const CollapseExampleSource = require('!!raw!../examples/Collapse');
 
+import CollapseEventsExample from '../examples/CollapseEvents';
+const CollapseEventsExampleSource = require('!!raw!../examples/CollapseEvents');
+
 export default class CollapsePage extends React.Component {
   render() {
     return (
@@ -32,9 +35,20 @@ export default class CollapsePage extends React.Component {
   delay: PropTypes.oneOfType([
     PropTypes.shape({ show: PropTypes.number, hide: PropTypes.number }),
     PropTypes.number
-  ]),
-  // optionally override show/hide delays - default { show: 350, hide: 350 }
+  ]), // optionally override show/hide delays - default { show: 350, hide: 350 }
+  onOpened: PropTypes.func,
+  onClosed: PropTypes.func,
 }`}
+          </PrismCode>
+        </pre>
+
+        <h3>Events</h3>
+        <div className="docs-example">
+          <CollapseEventsExample />
+        </div>
+        <pre>
+          <PrismCode className="language-jsx">
+            {CollapseEventsExampleSource}
           </PrismCode>
         </pre>
       </div>

--- a/docs/lib/examples/CollapseEvents.js
+++ b/docs/lib/examples/CollapseEvents.js
@@ -1,0 +1,46 @@
+import React, { Component } from 'react';
+import { Collapse, Button, CardBlock, Card } from 'reactstrap';
+
+class Example extends Component {
+  constructor(props) {
+    super(props);
+    this.onOpened = this.onOpened.bind(this);
+    this.onClosed = this.onClosed.bind(this);
+    this.toggle = this.toggle.bind(this);
+    this.state = { collapse: false, status: 'Closed' };
+  }
+
+  onOpened() {
+    this.setState({ ...this.state, status: 'Opened' });
+  }
+
+  onClosed() {
+    this.setState({ ...this.state, status: 'Closed' });
+  }
+
+  toggle() {
+    const status = !this.state.collapse ? 'Opening...' : 'Closing...';
+    this.setState({ collapse: !this.state.collapse, status });
+  }
+
+  render() {
+    return (
+      <div>
+        <Button color="primary" onClick={this.toggle} style={{ marginBottom: '1rem' }}>Toggle</Button>
+        <h5>Current state: {this.state.status}</h5>
+        <Collapse isOpen={this.state.collapse} onOpened={this.onOpened} onClosed={this.onClosed}>
+          <Card>
+            <CardBlock>
+            Anim pariatur cliche reprehenderit,
+             enim eiusmod high life accusamus terry richardson ad squid. Nihil
+             anim keffiyeh helvetica, craft beer labore wes anderson cred
+             nesciunt sapiente ea proident.
+            </CardBlock>
+          </Card>
+        </Collapse>
+      </div>
+    );
+  }
+}
+
+export default Example;

--- a/src/Collapse.js
+++ b/src/Collapse.js
@@ -31,14 +31,13 @@ const defaultProps = {
   isOpen: false,
   tag: 'div',
   delay: DEFAULT_DELAYS,
+  onOpened: () => {},
+  onClosed: () => {},
 };
 
 class Collapse extends Component {
   constructor(props) {
     super(props);
-
-    this.onOpened = this.onOpened.bind(this);
-    this.onClosed = this.onClosed.bind(this);
 
     this.state = {
       collapse: props.isOpen ? SHOWN : HIDDEN,
@@ -88,30 +87,18 @@ class Collapse extends Component {
     if (this.state.collapse === SHOWN &&
         prevState &&
         prevState.collapse !== SHOWN) {
-      this.onOpened();
+      this.props.onOpened();
     }
 
     if (this.state.collapse === HIDDEN &&
         prevState &&
         prevState.collapse !== HIDDEN) {
-      this.onClosed();
+      this.props.onClosed();
     }
   }
 
   componentWillUnmount() {
     clearTimeout(this.transitionTag);
-  }
-
-  onOpened() {
-    if (this.props.onOpened) {
-      this.props.onOpened();
-    }
-  }
-
-  onClosed() {
-    if (this.props.onClosed) {
-      this.props.onClosed();
-    }
   }
 
   getDelay(key) {

--- a/src/Collapse.js
+++ b/src/Collapse.js
@@ -18,6 +18,8 @@ const propTypes = {
     PropTypes.shape({ show: PropTypes.number, hide: PropTypes.number }),
     PropTypes.number,
   ]),
+  onOpened: PropTypes.func,
+  onClosed: PropTypes.func,
 };
 
 const DEFAULT_DELAYS = {
@@ -34,6 +36,10 @@ const defaultProps = {
 class Collapse extends Component {
   constructor(props) {
     super(props);
+
+    this.onOpened = this.onOpened.bind(this);
+    this.onClosed = this.onClosed.bind(this);
+
     this.state = {
       collapse: props.isOpen ? SHOWN : HIDDEN,
       height: null
@@ -78,8 +84,34 @@ class Collapse extends Component {
     // else: do nothing.
   }
 
+  componentDidUpdate(prevProps, prevState) {
+    if (this.state.collapse === SHOWN &&
+        prevState &&
+        prevState.collapse !== SHOWN) {
+      this.onOpened();
+    }
+
+    if (this.state.collapse === HIDDEN &&
+        prevState &&
+        prevState.collapse !== HIDDEN) {
+      this.onClosed();
+    }
+  }
+
   componentWillUnmount() {
     clearTimeout(this.transitionTag);
+  }
+
+  onOpened() {
+    if (this.props.onOpened) {
+      this.props.onOpened();
+    }
+  }
+
+  onClosed() {
+    if (this.props.onClosed) {
+      this.props.onClosed();
+    }
   }
 
   getDelay(key) {
@@ -101,7 +133,7 @@ class Collapse extends Component {
       cssModule,
       tag: Tag,
       ...attributes
-    } = omit(this.props, ['isOpen', 'delay']);
+    } = omit(this.props, ['isOpen', 'delay', 'onOpened', 'onClosed']);
     const { collapse, height } = this.state;
     let collapseClass;
     switch (collapse) {

--- a/src/__tests__/Collapse.spec.js
+++ b/src/__tests__/Collapse.spec.js
@@ -162,34 +162,26 @@ describe('Collapse', () => {
   });
 
   it('should call onOpened after opening', () => {
-    spyOn(Collapse.prototype, 'onOpened').and.callThrough();
-    spyOn(Collapse.prototype, 'onClosed').and.callThrough();
     const onOpened = jasmine.createSpy('onOpenedSpy');
     const onClosed = jasmine.createSpy('onClosedSpy');
     const wrapper = mount(<Collapse isOpen={isOpen} onOpened={onOpened} onClosed={onClosed} />);
 
     jasmine.clock().tick(300);
     expect(isOpen).toBe(false);
-    expect(Collapse.prototype.onOpened).not.toHaveBeenCalled();
     expect(onOpened).not.toHaveBeenCalled();
-    expect(Collapse.prototype.onClosed).not.toHaveBeenCalled();
     expect(onClosed).not.toHaveBeenCalled();
 
     toggle();
     wrapper.setProps({ isOpen });
     jasmine.clock().tick(380);
     expect(isOpen).toBe(true);
-    expect(Collapse.prototype.onOpened).toHaveBeenCalled();
     expect(onOpened).toHaveBeenCalled();
-    expect(Collapse.prototype.onClosed).not.toHaveBeenCalled();
     expect(onClosed).not.toHaveBeenCalled();
 
     wrapper.unmount();
   });
 
   it('should call onClosed after closing', () => {
-    spyOn(Collapse.prototype, 'onOpened').and.callThrough();
-    spyOn(Collapse.prototype, 'onClosed').and.callThrough();
     const onOpened = jasmine.createSpy('onOpenedSpy');
     const onClosed = jasmine.createSpy('onClosedSpy');
     toggle();
@@ -197,18 +189,14 @@ describe('Collapse', () => {
 
     jasmine.clock().tick(380);
     expect(isOpen).toBe(true);
-    expect(Collapse.prototype.onOpened).not.toHaveBeenCalled();
     expect(onOpened).not.toHaveBeenCalled();
-    expect(Collapse.prototype.onClosed).not.toHaveBeenCalled();
     expect(onClosed).not.toHaveBeenCalled();
 
     toggle();
     wrapper.setProps({ isOpen });
     jasmine.clock().tick(380);
     expect(isOpen).toBe(false);
-    expect(Collapse.prototype.onOpened).not.toHaveBeenCalled();
     expect(onOpened).not.toHaveBeenCalled();
-    expect(Collapse.prototype.onClosed).toHaveBeenCalled();
     expect(onClosed).toHaveBeenCalled();
 
     wrapper.unmount();

--- a/src/__tests__/Collapse.spec.js
+++ b/src/__tests__/Collapse.spec.js
@@ -187,7 +187,7 @@ describe('Collapse', () => {
     wrapper.unmount();
   });
 
-  it('should call onClosed after after closing', () => {
+  it('should call onClosed after closing', () => {
     spyOn(Collapse.prototype, 'onOpened').and.callThrough();
     spyOn(Collapse.prototype, 'onClosed').and.callThrough();
     const onOpened = jasmine.createSpy('onOpenedSpy');

--- a/src/__tests__/Collapse.spec.js
+++ b/src/__tests__/Collapse.spec.js
@@ -160,4 +160,57 @@ describe('Collapse', () => {
     wrapper.unmount();
     expect(Collapse.prototype.componentWillUnmount).toHaveBeenCalled();
   });
+
+  it('should call onOpened after opening', () => {
+    spyOn(Collapse.prototype, 'onOpened').and.callThrough();
+    spyOn(Collapse.prototype, 'onClosed').and.callThrough();
+    const onOpened = jasmine.createSpy('onOpenedSpy');
+    const onClosed = jasmine.createSpy('onClosedSpy');
+    const wrapper = mount(<Collapse isOpen={isOpen} onOpened={onOpened} onClosed={onClosed} />);
+
+    jasmine.clock().tick(300);
+    expect(isOpen).toBe(false);
+    expect(Collapse.prototype.onOpened).not.toHaveBeenCalled();
+    expect(onOpened).not.toHaveBeenCalled();
+    expect(Collapse.prototype.onClosed).not.toHaveBeenCalled();
+    expect(onClosed).not.toHaveBeenCalled();
+
+    toggle();
+    wrapper.setProps({ isOpen });
+    jasmine.clock().tick(380);
+    expect(isOpen).toBe(true);
+    expect(Collapse.prototype.onOpened).toHaveBeenCalled();
+    expect(onOpened).toHaveBeenCalled();
+    expect(Collapse.prototype.onClosed).not.toHaveBeenCalled();
+    expect(onClosed).not.toHaveBeenCalled();
+
+    wrapper.unmount();
+  });
+
+  it('should call onClosed after after closing', () => {
+    spyOn(Collapse.prototype, 'onOpened').and.callThrough();
+    spyOn(Collapse.prototype, 'onClosed').and.callThrough();
+    const onOpened = jasmine.createSpy('onOpenedSpy');
+    const onClosed = jasmine.createSpy('onClosedSpy');
+    toggle();
+    const wrapper = mount(<Collapse isOpen={isOpen} onOpened={onOpened} onClosed={onClosed} />);
+
+    jasmine.clock().tick(380);
+    expect(isOpen).toBe(true);
+    expect(Collapse.prototype.onOpened).not.toHaveBeenCalled();
+    expect(onOpened).not.toHaveBeenCalled();
+    expect(Collapse.prototype.onClosed).not.toHaveBeenCalled();
+    expect(onClosed).not.toHaveBeenCalled();
+
+    toggle();
+    wrapper.setProps({ isOpen });
+    jasmine.clock().tick(380);
+    expect(isOpen).toBe(false);
+    expect(Collapse.prototype.onOpened).not.toHaveBeenCalled();
+    expect(onOpened).not.toHaveBeenCalled();
+    expect(Collapse.prototype.onClosed).toHaveBeenCalled();
+    expect(onClosed).toHaveBeenCalled();
+
+    wrapper.unmount();
+  });
 });


### PR DESCRIPTION
Allow passing in onOpened and onClosed props as functions that are triggered after the Collapse component has finished opening or closing. Useful for performing an action that relies on the new height of the page after a Collapse component has opened or closed (such as scrolling).