### PR TITLE
Return event to toggle function

### DIFF
--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -121,7 +121,7 @@ class Dropdown extends React.Component {
       return;
     }
 
-    this.toggle();
+    this.toggle(e);
   }
 
   handleProps() {
@@ -141,7 +141,7 @@ class Dropdown extends React.Component {
       return e && e.preventDefault();
     }
 
-    return this.props.toggle();
+    return this.props.toggle(e);
   }
 
   renderChildren() {


### PR DESCRIPTION
Return the click event to passed-in toggle function so that state can be updated dynamically. This would allow you to set a property (say href) on the component and update state by the target's attribute.