### PR TITLE
Fix typo in layout example

### DIFF
--- a/docs/lib/examples/Layout.js
+++ b/docs/lib/examples/Layout.js
@@ -16,7 +16,7 @@ export default class Example extends React.Component {
         </Row>
         <Row>
           <Col xs="3">.col-3</Col>
-          <Col xs="auto">.col-auto - variabe width content</Col>
+          <Col xs="auto">.col-auto - variable width content</Col>
           <Col xs="3">.col-3</Col>
         </Row>
         <Row>


### PR DESCRIPTION
Hi all! I'm new to Reactstrap (I'm using it for a small side-project), 
but I noticed there was a small typo in one of the examples, so 
I figured I'd open a pull request to fix it rather just opening an
issue on such a small change. I read through the docs, so
hopefully everything is up to your standards, but if anything
looks out of place, I'll be sure to change it!