### PR TITLE
feat(Popover): closeOnClick property

### DIFF
--- a/docs/lib/examples/Popover.js
+++ b/docs/lib/examples/Popover.js
@@ -24,7 +24,7 @@ export default class Example extends React.Component {
         <Button id="Popover1" onClick={this.toggle}>
           Launch Popover
         </Button>
-        <Popover placement="bottom" isOpen={this.state.popoverOpen} target="Popover1" toggle={this.toggle}>
+        <Popover placement="bottom" isOpen={this.state.popoverOpen} closeOnClick={ true } target="Popover1" toggle={this.toggle}>
           <PopoverTitle>Popover Title</PopoverTitle>
           <PopoverContent>Sed posuere consectetur est at lobortis. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.</PopoverContent>
         </Popover>

--- a/src/Popover.js
+++ b/src/Popover.js
@@ -8,6 +8,8 @@ const propTypes = {
   placement: React.PropTypes.oneOf(tetherAttachements),
   target: PropTypes.string.isRequired,
   isOpen: PropTypes.bool,
+  // close popover when clicking toggler
+  closeOnClick: PropTypes.bool,
   tether: PropTypes.object,
   tetherRef: PropTypes.func,
   className: PropTypes.string,
@@ -17,6 +19,7 @@ const propTypes = {
 
 const defaultProps = {
   isOpen: false,
+  closeOnClick: false,
   placement: 'bottom',
   toggle: () => {}
 };
@@ -70,6 +73,7 @@ class Popover extends React.Component {
         tether={tetherConfig}
         tetherRef={this.props.tetherRef}
         isOpen={this.props.isOpen}
+        closeOnClick={this.props.closeOnClick}
         toggle={this.props.toggle}
       >
         <div {...attributes} className={classes} />

--- a/src/TetherContent.js
+++ b/src/TetherContent.js
@@ -9,6 +9,7 @@ const propTypes = {
   arrow: PropTypes.string,
   disabled: PropTypes.bool,
   isOpen: PropTypes.bool.isRequired,
+  closeOnClick: PropTypes.bool,
   toggle: PropTypes.func.isRequired,
   tether: PropTypes.object.isRequired,
   tetherRef: PropTypes.func,
@@ -18,6 +19,7 @@ const propTypes = {
 
 const defaultProps = {
   isOpen: false,
+  closeOnClick: false,
   tetherRef: function () {}
 };
 
@@ -26,7 +28,10 @@ class TetherContent extends React.Component {
     super(props);
 
     this.handleDocumentClick = this.handleDocumentClick.bind(this);
+    this.checkTogglerTarget = this.checkTogglerTarget.bind(this);
     this.toggle = this.toggle.bind(this);
+
+    this.state = { togglerClicked: false };
   }
 
   componentDidMount() {
@@ -66,15 +71,34 @@ class TetherContent extends React.Component {
     return config;
   }
 
+  checkTogglerTarget(togglerID, clickTarget) {
+    if (clickTarget && clickTarget.id) return clickTarget.id === togglerID.slice(1);
+    return null;
+  }
+
   handleDocumentClick(e) {
     const container = this._element;
+    const togglerIsTarget = this.checkTogglerTarget(this.getTarget(), e.target);
+
     if (e.target === container || !container.contains(e.target)) {
-      this.toggle();
+      if (this.props.closeOnClick) {
+        // toggle only if we click elsewhere, or if the toggler hasn't been clicked already
+        if (!togglerIsTarget || !this.state.togglerClicked) {
+          this.toggle();
+        }
+      } else {
+        this.toggle();
+      }
+    }
+
+    if (this.props.closeOnClick) {
+      this.state.togglerClicked = false;
     }
   }
 
   handleProps() {
     if (this.props.isOpen) {
+      this.state.togglerClicked = true;
       this.show();
     } else {
       this.hide();

--- a/src/__tests__/TetherContent.spec.js
+++ b/src/__tests__/TetherContent.spec.js
@@ -190,6 +190,20 @@ describe('TetherContent', () => {
     });
   });
 
+  // helper function to check whether popover toggler is clicked
+  describe('checkTogglerTarget', () => {
+    it('should be called when the toggler is clicked', () => {
+      state = true;
+      spyOn(TetherContent.prototype, 'checkTogglerTarget').and.callThrough();
+      const wrapper = mount(<TetherContent tether={tetherConfig} isOpen={state} toggle={toggle}><p>Content</p></TetherContent>);
+      const instance = wrapper.instance();
+
+      instance._element.click();
+
+      expect(TetherContent.prototype.checkTogglerTarget.calls.count()).toBe(1);
+    })
+  })
+
   describe('handleProps', () => {
     it('should call .hide when false', () => {
       spyOn(TetherContent.prototype, 'componentDidMount').and.callThrough();


### PR DESCRIPTION
Added closeOnClick property to Popover component:
- closeOnClick affects Popover behavior when toggler is clicked
- if true, Popover closes when toggler is clicked
- old behavior is the default