### PR TITLE
fix(Nav): update valid properties

### DIFF
--- a/docs/lib/Components/NavsPage.js
+++ b/docs/lib/Components/NavsPage.js
@@ -4,8 +4,8 @@ import { PrismCode } from 'react-prism';
 import Helmet from 'react-helmet';
 import NavsExample from '../examples/Navs';
 const NavsExampleSource = require('!!raw!../examples/Navs');
-import NavInlineExample from '../examples/NavInline';
-const NavInlineExampleSource = require('!!raw!../examples/NavInline');
+import NavVerticalExample from '../examples/NavVertical';
+const NavVerticalExampleSource = require('!!raw!../examples/NavVertical');
 import NavTabsExample from '../examples/NavTabs';
 const NavTabsExampleSource = require('!!raw!../examples/NavTabs');
 import NavPillsExample from '../examples/NavPills';
@@ -29,11 +29,9 @@ export default class NavssPage extends React.Component {
         <pre>
           <PrismCode className="language-jsx">
 {`Nav.propTypes = {
-  inline: PropTypes.bool,
-  disabled: PropTypes.bool,
   tabs: PropTypes.bool,
   pills: PropTypes.bool,
-  stacked: PropTypes.bool,
+  vertical: PropTypes.bool,
   navbar: PropTypes.bool,
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string])
   // pass in custom element to use
@@ -74,13 +72,13 @@ export default class NavssPage extends React.Component {
 };`}
           </PrismCode>
         </pre>
-        <h3>Inline</h3>
+        <h3>Vertical</h3>
         <div className="docs-example">
-          <NavInlineExample />
+          <NavVerticalExample />
         </div>
         <pre>
           <PrismCode className="language-jsx">
-            {NavInlineExampleSource}
+            {NavVerticalExampleSource}
           </PrismCode>
         </pre>
         <h3>Tabs</h3>

--- a/docs/lib/examples/NavVertical.js
+++ b/docs/lib/examples/NavVertical.js
@@ -6,7 +6,7 @@ export default class Example extends React.Component {
     return (
       <div>
         <p>List Based</p>
-        <Nav inline>
+        <Nav vertical>
           <NavItem>
             <NavLink href="#">Link</NavLink>
           </NavItem>
@@ -22,7 +22,7 @@ export default class Example extends React.Component {
         </Nav>
         <hr />
         <p>Link based</p>
-        <Nav inline>
+        <Nav vertical>
           <NavLink href="#">Link</NavLink> <NavLink href="#">Link</NavLink> <NavLink href="#">Another Link</NavLink> <NavLink disabled href="#">Disabled Link</NavLink>
         </Nav>
       </div>

--- a/src/Nav.js
+++ b/src/Nav.js
@@ -3,11 +3,9 @@ import classNames from 'classnames';
 import { mapToCssModules } from './utils';
 
 const propTypes = {
-  inline: PropTypes.bool,
-  disabled: PropTypes.bool,
   tabs: PropTypes.bool,
   pills: PropTypes.bool,
-  stacked: PropTypes.bool,
+  vertical: PropTypes.bool,
   navbar: PropTypes.bool,
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   className: PropTypes.string,
@@ -24,8 +22,7 @@ const Nav = (props) => {
     cssModule,
     tabs,
     pills,
-    inline,
-    stacked,
+    vertical,
     navbar,
     tag: Tag,
     ...attributes
@@ -37,9 +34,7 @@ const Nav = (props) => {
     {
       'nav-tabs': tabs,
       'nav-pills': pills,
-      'nav-inline': inline,
-      'nav-stacked': stacked,
-      disabled: attributes.disabled
+      'flex-column': vertical
     }
   ), cssModule);
 


### PR DESCRIPTION
Looking at the doc of Bootstrap v4 alpha.6, `Nav` needed some adjustments:

- Remove properties `inline`, `stacked` and `disabled` (they don't exist in either `nav` or `navbar`)
- Add property `vertical`
- Update doc accordingly
- Fix #295 

<img width="231" alt="screen shot 2017-02-22 at 21 36 53" src="https://cloud.githubusercontent.com/assets/4401230/23246341/a87d46f6-f947-11e6-999a-b15544242b84.png">
