### PR TITLE
Limit babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,6 @@
 {
-  "presets": ["es2015", "stage-0", "react"]
+  "presets": ["es2015", "react"],
+  "plugins": [
+    "transform-object-rest-spread"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -61,10 +61,10 @@
   "devDependencies": {
     "babel-cli": "^6.14.0",
     "babel-loader": "^6.2.2",
+    "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "babel-preset-es2015": "^6.14.0",
     "babel-preset-react": "^6.11.1",
     "babel-preset-react-app": "^0.2.1",
-    "babel-preset-stage-0": "^6.5.0",
     "bootstrap": "^4.0.0-alpha.6",
     "clean-webpack-plugin": "^0.1.8",
     "conventional-changelog-cli": "^1.1.1",


### PR DESCRIPTION
While working on the Rollup stuff I noticed that Reactstrap uses Babel stage-0 preset but none of the options are in use.

From my experience I can recommend to not use any Babel presets that are still very much in flux like stage-0. The next release of Babel might have different stage-0 features or the stage-0 APIs introduced breaking changes.

By looking at the code I realized that the only non-standard JavaScript feature that is being used is object spread. So this PR removes stage-0 and replaces it with just object-spread.