### PR TITLE
Fix error when running npm start

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,7 @@
 {
   "presets": ["es2015", "react"],
   "plugins": [
-    "transform-object-rest-spread"
+    "transform-object-rest-spread",
+    "transform-class-properties"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -61,10 +61,11 @@
   "devDependencies": {
     "babel-cli": "^6.14.0",
     "babel-loader": "^6.2.2",
+    "babel-plugin-transform-class-properties": "^6.23.0",
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "babel-preset-es2015": "^6.14.0",
     "babel-preset-react": "^6.11.1",
-    "babel-preset-react-app": "^0.2.1",
+    "babel-preset-react-app": "^2.2.0",
     "bootstrap": "^4.0.0-alpha.6",
     "clean-webpack-plugin": "^0.1.8",
     "conventional-changelog-cli": "^1.1.1",


### PR DESCRIPTION
Webpack was failing to compile when running `npm start`. The error was being caused by an arrow function class property in a component. Class properties are stage-2, so I added `babel-plugin-transform-class-properties` to dev dependencies. 

I also went ahead and upgraded `babel-preset-react-app` which removes the following deprecated warning
```
npm WARN deprecated babel-preset-latest@6.14.0: 💥  preset-latest accomplishes the same task as babel-preset-env. 🙏  Please install it with 'npm install babel-preset-env --save-dev'. '{ "presets": ["latest"] }' to '{ "presets": ["env"] }'. For more info, please check the docs: http://babeljs.io/docs/plugins/preset-env 👌. And let us know how you're liking Babel at @babeljs on 🐦
```