### PR TITLE
Fix fancy syntax in docs example

### DIFF
--- a/docs/lib/examples/AlertDismiss.js
+++ b/docs/lib/examples/AlertDismiss.js
@@ -7,10 +7,12 @@ class AlertExample extends React.Component {
 
     this.state = {
       visible: true
-    }
+    };
+
+    this.onDismiss = this.onDismiss.bind(this);
   }
 
-  onDismiss = () => {
+  onDismiss() {
     this.setState({ visible: false });
   }
 


### PR DESCRIPTION
When I reduced the babel stages, I didn't test the docs. Looks like 1 example broke. Sorry about that.

This PR fixes it.