### PR TITLE
pass in cssModule to Fade in Modal

### DIFF
--- a/src/Modal.js
+++ b/src/Modal.js
@@ -191,6 +191,7 @@ class Modal extends React.Component {
             transitionLeaveTimeout={300}
             onClickCapture={this.handleBackdropClick}
             onKeyUp={this.handleEscape}
+            cssModule={cssModule}
             className={mapToCssModules(classNames('modal', modalClassName), cssModule)}
             style={{ display: 'block' }}
             tabIndex="-1"
@@ -215,6 +216,7 @@ class Modal extends React.Component {
             transitionAppearTimeout={150}
             transitionEnterTimeout={150}
             transitionLeaveTimeout={150}
+            cssModule={cssModule}
             className={mapToCssModules(classNames('modal-backdrop', backdropClassName), cssModule)}
           />
         )}


### PR DESCRIPTION
Modals would not work when a cssModule was passed in because the Fade component's styles wouldn't be pushed through `mapToCssModules` correctly.