### PR TITLE
Remove UMD-only options from rollup config

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,9 +4,7 @@ import babel from 'rollup-plugin-babel';
 import babili from 'rollup-plugin-babili';
 
 const config = {
-  moduleName: 'ReactStrap',
   entry: 'src/index.js',
-  exports: 'named',
   plugins: [
     nodeResolve(),
     commonjs(),
@@ -20,13 +18,6 @@ const config = {
     'react-addons-css-transition-group',
     'react-addons-transition-group',
   ],
-  // Used for the UMD bundles
-  globals: {
-    react: 'React',
-    'react-dom': 'ReactDOM',
-    'react-addons-css-transition-group': 'CSSTransitionGroup',
-    'react-addons-transition-group': 'TransitionGroup',
-  },
   targets: [
     { dest: 'dist/reactstrap.cjs.js', format: 'cjs' },
     { dest: 'dist/reactstrap.es.js', format: 'es' },


### PR DESCRIPTION
When I removed UMD output for Rollup, I forgot to remove the UMD-only options in the rollup config.