### PR TITLE
[DO NOT MERGE] Experiment: Use cherry picked lodash modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,10 +48,12 @@
   "homepage": "https://github.com/reactstrap/reactstrap#readme",
   "dependencies": {
     "classnames": "^2.2.3",
+    "lodash-es": "^4.17.4",
     "lodash.isfunction": "^3.0.8",
     "lodash.isobject": "^3.0.2",
     "lodash.omit": "^4.4.1",
     "lodash.tonumber": "^4.0.3",
+    "source-map-explorer": "^1.3.3",
     "tether": "balloob/tether#7e0d48e4ac2162e251dc2b69d7c13e6c29a5667f"
   },
   "peerDependencies": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,6 +6,7 @@ import babili from 'rollup-plugin-babili';
 const config = {
   moduleName: 'ReactStrap',
   entry: 'src/index.js',
+  sourceMap: true,
   exports: 'named',
   plugins: [
     nodeResolve(),

--- a/src/Col.js
+++ b/src/Col.js
@@ -1,4 +1,4 @@
-import isobject from 'lodash.isobject';
+import isObject from 'lodash-es/isObject';
 import React from 'react';
 import classNames from 'classnames';
 import { mapToCssModules } from './utils';
@@ -72,7 +72,7 @@ const Col = (props) => {
     const isXs = !i;
     let colClass;
 
-    if (isobject(columnProp)) {
+    if (isObject(columnProp)) {
       const colSizeInterfix = isXs ? '-' : `-${colWidth}-`;
       colClass = getColumnSizeClass(isXs, colWidth, columnProp.size);
 

--- a/src/Collapse.js
+++ b/src/Collapse.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import classNames from 'classnames';
-import omit from 'lodash.omit';
+import omit from 'lodash-es/omit';
 import { mapToCssModules } from './utils';
 
 const { PropTypes, Component } = React;

--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -4,7 +4,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import classNames from 'classnames';
-import omit from 'lodash.omit';
+import omit from 'lodash-es/omit';
 import { mapToCssModules } from './utils';
 import TetherContent from './TetherContent';
 import DropdownMenu from './DropdownMenu';

--- a/src/Fade.js
+++ b/src/Fade.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import classNames from 'classnames';
-import omit from 'lodash.omit';
+import omit from 'lodash-es/omit';
 import { mapToCssModules } from './utils';
 
 const { PropTypes } = React;

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import classNames from 'classnames';
-import omit from 'lodash.omit';
+import omit from 'lodash-es/omit';
 import TransitionGroup from 'react-addons-transition-group';
 import Fade from './Fade';
 import {

--- a/src/Popover.js
+++ b/src/Popover.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import classNames from 'classnames';
-import omit from 'lodash.omit';
+import omit from 'lodash-es/omit';
 import TetherContent from './TetherContent';
 import { getTetherAttachments, mapToCssModules, tetherAttachements } from './utils';
 

--- a/src/Progress.js
+++ b/src/Progress.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import classNames from 'classnames';
-import toNumber from 'lodash.tonumber';
+import toNumber from 'lodash-es/toNumber';
 import { mapToCssModules } from './utils';
 
 const { PropTypes } = React;

--- a/src/TabContent.js
+++ b/src/TabContent.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import classNames from 'classnames';
-import omit from 'lodash.omit';
+import omit from 'lodash-es/omit';
 import { mapToCssModules } from './utils';
 
 const { PropTypes, Component } = React;

--- a/src/TetherContent.js
+++ b/src/TetherContent.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import isFunction from 'lodash.isfunction';
+import isFunction from 'lodash-es/isFunction';
 import Tether from 'tether';
 
 const { PropTypes } = React;

--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import classNames from 'classnames';
-import omit from 'lodash.omit';
+import omit from 'lodash-es/omit';
 import TetherContent from './TetherContent';
 import { getTetherAttachments, tetherAttachements, mapToCssModules } from './utils';
 


### PR DESCRIPTION
So as a quick experiment to see if I could reduce the bundle size even more, I tried to replace the lodash dependencies with cherry picked functions from the lodash lib. The idea was that we would be able to dedupe overlapping code between the individual lodash packages.

Result: did not reduce bundle size.

Leaving PR here so people can learn from the results.

It is caused because Rollup can't 100% decide if some code is side-effect free. It will caution on the safe side and end up including more then is needed. [See Rollup wiki](https://github.com/rollup/rollup/wiki/Troubleshooting#tree-shaking-doesnt-seem-to-be-working)

| Type | Size |
| -- | -- |
| Current (function per package) | 111kB
| Import from `lodash/func-name` | 127kB
| Import named from `lodash-es/func-name` | 124kB
| Import named from `lodash` | Forgot, but was > 200kB

![screen shot 2017-03-30 at 2 26 48 pm](https://cloud.githubusercontent.com/assets/1444314/24527088/95d41d70-1555-11e7-8c27-3e64e5d2de5f.png)
