### PR TITLE
Fix import/export not getting transpiled in lib dir

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -7,6 +7,9 @@
     "transform-object-rest-spread"
   ],
   "env": {
+    "dist-dir": {
+      "plugins": ["transform-es2015-modules-commonjs"]
+    },
     "webpack": {
       "plugins": ["transform-es2015-modules-commonjs"]
     },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "start": "BABEL_ENV=webpack webpack-dev-server --config ./webpack.dev.config.js --watch",
     "build-docs": "cross-env WEBPACK_BUILD=production webpack --config ./webpack.dev.config.js --progress --colors",
     "build": "cross-env NODE_ENV=production rollup -c",
-    "prebuild": "babel src --out-dir lib --ignore src/__tests__/",
+    "prebuild": "BABEL_ENV=dist-dir babel src --out-dir lib --ignore src/__tests__/",
     "create-release": "npm test && sh ./scripts/release",
     "publish-release": "npm test && sh ./scripts/publish",
     "lint": "eslint src"


### PR DESCRIPTION
Rollup conversion introduced a bug where Babel wouldn't transpile import/export to CommonJS syntax in the lib dir. This PR fixes it.

Report: https://github.com/reactstrap/reactstrap/pull/359#issuecomment-290928268