### PR TITLE
Add UMD builds to Rollup

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "reactstrap",
   "version": "4.4.0",
   "description": "React Bootstrap 4 components",
-  "main": "dist/reactstrap.cjs.js",
+  "main": "dist/reactstrap.min.js",
   "jsnext:main": "dist/reactstrap.es.js",
   "module": "dist/reactstrap.es.js",
   "scripts": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,6 +4,7 @@ import babel from 'rollup-plugin-babel';
 import babili from 'rollup-plugin-babili';
 
 const config = {
+  moduleName: 'Reactstrap',
   entry: 'src/index.js',
   plugins: [
     nodeResolve(),
@@ -12,15 +13,23 @@ const config = {
       plugins: ['external-helpers'],
     }),
   ],
+  sourceMap: true,
   external: [
     'react',
     'react-dom',
     'react-addons-css-transition-group',
     'react-addons-transition-group',
   ],
+  // Used for the UMD bundles
+  globals: {
+    react: 'React',
+    'react-dom': 'ReactDOM',
+    'react-addons-css-transition-group': 'React.addons.CSSTransitionGroup',
+    'react-addons-transition-group': 'React.addons.TransitionGroup',
+  },
   targets: [
-    { dest: 'dist/reactstrap.cjs.js', format: 'cjs' },
     { dest: 'dist/reactstrap.es.js', format: 'es' },
+    { dest: 'dist/reactstrap.min.js', format: 'umd' },
   ],
 };
 


### PR DESCRIPTION
I incorrectly assumed that Webpack was exporting CommonJS syntax. Instead, it was exporting UMD format (which is CommonJS compatible).

So, this updates the Rollup config, also making it backwards compatible with Reactstrap 4.3.0 to address https://github.com/reactstrap/reactstrap/pull/359#issuecomment-290926692.

As extra bonus, the UMD bundles are able to be minified to 95kB! Looking at the source code, it seems like minifiers can do a better job minifying since everything is inside a function.

Changes:

 - Dropped `reactstrap.cjs.js` output
 - Added UMD bundle `reactstrap.min.js` (compatible with CommonJS and equivalent to output in Reactstrap 4.3)
 - Added source maps back

![image](https://cloud.githubusercontent.com/assets/1444314/24591371/894997b8-17b4-11e7-9bd8-731135615592.png)

### Testing changes

Point all the test files at the UMD bundle:

```bash
sed -i "" "s/\.\.\/\'/\.\.\/\.\.\/dist\/reactstrap.min'/" src/__tests__/*.spec.js
```

Run tests as usual: `npm test`.