### PR TITLE
move to external react-transition-group dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Install reactstrap and Bootstrap from NPM. Reactstrap does not include Bootstrap
 
 ```
 npm install bootstrap@4.0.0-alpha.6 --save
-npm install --save reactstrap react-addons-transition-group react-addons-css-transition-group react react-dom
+npm install --save reactstrap react-transition-group react react-dom
 ```
 
 Import Bootstrap CSS in the ```src/index.js``` file:

--- a/docs/lib/Home/index.js
+++ b/docs/lib/Home/index.js
@@ -36,7 +36,7 @@ export default () => {
             <h3 className="mt-5">NPM</h3>
             <p>Install reactstrap and peer dependencies via NPM</p>
             <pre>
-              <PrismCode className="language-bash">npm install --save reactstrap react-addons-transition-group react-addons-css-transition-group react react-dom</PrismCode>
+              <PrismCode className="language-bash">npm install --save reactstrap react-transition-group react react-dom</PrismCode>
             </pre>
             <p>Import the components you need</p>
             <div className="docs-example">

--- a/package.json
+++ b/package.json
@@ -95,9 +95,8 @@
   },
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0",
-    "react-addons-css-transition-group": "^0.14.0 || ^15.0.0",
-    "react-addons-transition-group": "^0.14.0 || ^15.0.0",
-    "react-dom": "^0.14.0 || ^15.0.0"
+    "react-dom": "^0.14.0 || ^15.0.0",
+    "react-transition-group": "^1.1.2"
   },
   "devDependencies": {
     "babel-cli": "^6.14.0",
@@ -128,14 +127,13 @@
     "json-loader": "^0.5.4",
     "raw-loader": "^0.5.1",
     "react": "^15.3.0",
-    "react-addons-css-transition-group": "^15.3.2",
     "react-addons-test-utils": "^15.3.0",
-    "react-addons-transition-group": "^15.3.0",
     "react-dom": "^15.3.0",
     "react-helmet": "^3.0.1",
     "react-prism": "4.0.0",
     "react-router": "^2.6.1",
     "react-scripts": "^0.7.0",
+    "react-transition-group": "^1.1.2",
     "rollup": "^0.41.5",
     "rollup-plugin-babel": "^2.7.1",
     "rollup-plugin-babili": "^2.0.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -17,15 +17,12 @@ const config = {
   external: [
     'react',
     'react-dom',
-    'react-addons-css-transition-group',
-    'react-addons-transition-group',
+    'react-transition-group',
   ],
   // Used for the UMD bundles
   globals: {
     react: 'React',
     'react-dom': 'ReactDOM',
-    'react-addons-css-transition-group': 'React.addons.CSSTransitionGroup',
-    'react-addons-transition-group': 'React.addons.TransitionGroup',
   },
   targets: [
     { dest: 'dist/reactstrap.es.js', format: 'es' },

--- a/src/Alert.js
+++ b/src/Alert.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import classNames from 'classnames';
-import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
+import CSSTransitionGroup from 'react-transition-group/CSSTransitionGroup';
 import { mapToCssModules } from './utils';
 
 const { PropTypes } = React;
@@ -64,7 +64,7 @@ const Alert = (props) => {
   );
 
   return (
-    <ReactCSSTransitionGroup
+    <CSSTransitionGroup
       component={FirstChild}
       transitionName={{
         appear: 'fade',
@@ -82,7 +82,7 @@ const Alert = (props) => {
       transitionLeaveTimeout={transitionLeaveTimeout}
     >
       {isOpen ? alert : null}
-    </ReactCSSTransitionGroup>
+    </CSSTransitionGroup>
   );
 };
 

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import classNames from 'classnames';
 import omit from 'lodash.omit';
-import TransitionGroup from 'react-addons-transition-group';
+import TransitionGroup from 'react-transition-group/TransitionGroup';
 import Fade from './Fade';
 import {
   getOriginalBodyPadding,

--- a/src/__tests__/Fade.spec.js
+++ b/src/__tests__/Fade.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import TransitionGroup from 'react-addons-transition-group';
+import TransitionGroup from 'react-transition-group/TransitionGroup';
 import { Fade } from '../';
 
 class Helper extends React.Component {

--- a/webpack.base.config.js
+++ b/webpack.base.config.js
@@ -57,11 +57,10 @@ module.exports = function (env) {
         }
       },
       {
-        'react-addons-transition-group': {
-          commonjs: 'react-addons-transition-group',
-          commonjs2: 'react-addons-transition-group',
-          amd: 'react-addons-transition-group',
-          root: ['React', 'addons', 'TransitionGroup']
+        'react-transition-group': {
+          commonjs: 'react-transition-group',
+          commonjs2: 'react-transition-group',
+          amd: 'react-transition-group',
         }
       }
     ],


### PR DESCRIPTION
Per https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html:

> react-addons-css-transition-group - Use react-transition-group/CSSTransitionGroup instead. Version 1.1.1 provides a drop-in replacement.

Please review the webpack.base.config.js changes whether it needs changes.