### PR TITLE
fix(Modal): fix bug where closing modal removed wrong modal-open string in class

### DIFF
--- a/src/Modal.js
+++ b/src/Modal.js
@@ -122,7 +122,8 @@ class Modal extends React.Component {
       this._element = null;
     }
 
-    const classes = document.body.className.replace('modal-open', '');
+    // Use regex to prevent matching `modal-open` as part of a different class, e.g. `my-modal-opened`
+    const classes = document.body.className.replace(/(^| )modal-open( |$)/, ' ');
     document.body.className = mapToCssModules(classNames(classes).trim(), this.props.cssModule);
     setScrollbarWidth(this.originalBodyPadding);
   }

--- a/src/__tests__/Modal.spec.js
+++ b/src/__tests__/Modal.spec.js
@@ -482,4 +482,47 @@ describe('Modal', () => {
     expect(document.getElementsByClassName('modal-dialog').length).toBe(0);
     expect(document.body.className).toBe('');
   });
+
+  it('should remove exactly modal-open class from body', () => {
+    // set a body class which includes modal-open
+    document.body.className = 'my-modal-opened';
+
+    const wrapper = mount(
+      <Modal isOpen={isOpen} toggle={toggle}>
+        Yo!
+      </Modal>
+    );
+
+    // assert that the modal is closed and the body class is what was set initially
+    jasmine.clock().tick(300);
+    expect(isOpen).toBe(false);
+    expect(document.body.className).toBe('my-modal-opened');
+
+    toggle();
+    wrapper.setProps({
+      isOpen: isOpen
+    });
+
+    // assert that the modal is open and the body class is what was set initially + modal-open
+    jasmine.clock().tick(300);
+    expect(isOpen).toBe(true);
+    expect(document.body.className).toBe('my-modal-opened modal-open');
+
+    // append another body class which includes modal-open
+    // using this to test if replace will leave a space when removing modal-open
+    document.body.className += ' modal-opened';
+    expect(document.body.className).toBe('my-modal-opened modal-open modal-opened');
+
+    toggle();
+    wrapper.setProps({
+      isOpen: isOpen
+    });
+
+    // assert that the modal is closed and the body class is what was set initially
+    jasmine.clock().tick(300);
+    expect(isOpen).toBe(false);
+    expect(document.body.className).toBe('my-modal-opened modal-opened');
+
+    wrapper.unmount();
+  });
 });


### PR DESCRIPTION
Initially, I wanted to just report the issue, but while writing it, I found out that it was an easy fix so I did it myself.
Here is what I wanted to report:


### Issue description

- version: tested on`#4.5.0` but this issue can be found in the master branch
- components: `Modal`

### Steps to reproduce issue

1. add a class to the body which contains`modal-open`, e.g.: `my-modal-opened`
2. add a [Modal](https://reactstrap.github.io/components/modals/) element
3. show the modal, which will add the `modal-open` class to the body, the body class property is now `my-modal-opened modal-open`
4. hide the modal, expecting to return body class to `my-modal-opened`, but instead, the class is now `my-ed modal-open`

Demo: http://codepen.io/anon/pen/pPWVyP
