### PR TITLE
chore(lint): fix linter error

### DIFF
--- a/src/Form.js
+++ b/src/Form.js
@@ -23,7 +23,7 @@ const Form = (props) => {
     inline,
     tag: Tag,
     getRef,
-    ...attributes,
+    ...attributes
   } = props;
 
   const classes = mapToCssModules(classNames(

--- a/src/FormFeedback.js
+++ b/src/FormFeedback.js
@@ -19,7 +19,7 @@ const FormFeedback = (props) => {
     className,
     cssModule,
     tag: Tag,
-    ...attributes,
+    ...attributes
   } = props;
 
   const classes = mapToCssModules(classNames(

--- a/src/FormGroup.js
+++ b/src/FormGroup.js
@@ -27,7 +27,7 @@ const FormGroup = (props) => {
     color,
     check,
     tag: Tag,
-    ...attributes,
+    ...attributes
   } = props;
 
   const classes = mapToCssModules(classNames(

--- a/src/FormText.js
+++ b/src/FormText.js
@@ -23,7 +23,7 @@ const FormText = (props) => {
     inline,
     color,
     tag: Tag,
-    ...attributes,
+    ...attributes
   } = props;
 
   const classes = mapToCssModules(classNames(

--- a/src/Input.js
+++ b/src/Input.js
@@ -35,7 +35,7 @@ class Input extends React.Component {
       addon,
       static: staticInput,
       getRef,
-      ...attributes,
+      ...attributes
     } = this.props;
 
     const checkInput = ['radio', 'checkbox'].indexOf(type) > -1;

--- a/src/Label.js
+++ b/src/Label.js
@@ -51,7 +51,7 @@ const Label = (props) => {
     disabled,
     size,
     for: htmlFor,
-    ...attributes,
+    ...attributes
   } = props;
 
   const colClasses = [];

--- a/src/Media.js
+++ b/src/Media.js
@@ -33,7 +33,7 @@ const Media = (props) => {
     right,
     tag,
     top,
-    ...attributes,
+    ...attributes
   } = props;
 
   let defaultTag;

--- a/src/Pagination.js
+++ b/src/Pagination.js
@@ -21,7 +21,7 @@ const Pagination = (props) => {
     cssModule,
     size,
     tag: Tag,
-    ...attributes,
+    ...attributes
   } = props;
 
   const classes = mapToCssModules(classNames(

--- a/src/PaginationItem.js
+++ b/src/PaginationItem.js
@@ -23,7 +23,7 @@ const PaginationItem = (props) => {
     cssModule,
     disabled,
     tag: Tag,
-    ...attributes,
+    ...attributes
   } = props;
 
   const classes = mapToCssModules(classNames(

--- a/src/PaginationLink.js
+++ b/src/PaginationLink.js
@@ -24,7 +24,7 @@ const PaginationLink = (props) => {
     next,
     previous,
     tag: Tag,
-    ...attributes,
+    ...attributes
   } = props;
 
   const classes = mapToCssModules(classNames(

--- a/src/Row.js
+++ b/src/Row.js
@@ -20,7 +20,7 @@ const Row = (props) => {
     cssModule,
     noGutters,
     tag: Tag,
-    ...attributes,
+    ...attributes
   } = props;
 
   const classes = mapToCssModules(classNames(


### PR DESCRIPTION
A new linter rule lines up with new browser spec prohibits a trailing comma after the rest syntax.
Since there can be no variables defined after the rest, it is pointless to have a comma dangle there.