### PR TITLE
chore(dist): fix release

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "reactstrap",
   "version": "4.6.1",
   "description": "React Bootstrap 4 components",
-  "main": "dist/reactstrap.min.js",
+  "main": "lib/index.js",
   "jsnext:main": "dist/reactstrap.es.js",
   "module": "dist/reactstrap.es.js",
   "scripts": {


### PR DESCRIPTION
fixes #430 and #432. This uses the generated lib files when requiring/importing from npm module (not not using treeshaking (webpack1)). **This does NOT fix the dist/ files (such as the UMD build) being generated incorrectly.**