### PR TITLE
fix(Modal): Add class form-control-label to Label components

### DIFF
--- a/src/Label.js
+++ b/src/Label.js
@@ -79,7 +79,8 @@ const Label = (props) => {
     check && inline && disabled ? 'disabled' : false,
     size ? `col-form-label-${size}` : false,
     colClasses,
-    colClasses.length ? 'col-form-label' : false
+    colClasses.length ? 'col-form-label' : false,
+    !check && !colClasses.length ? 'form-control-label' : false
   ), cssModule);
 
   return (

--- a/src/__tests__/Label.spec.js
+++ b/src/__tests__/Label.spec.js
@@ -21,6 +21,30 @@ describe('Label', () => {
     expect(wrapper.hasClass('extra')).toBe(true);
   });
 
+  it('should render with "form-control-label" class', () => {
+    const wrapper = shallow(<Label>Yo!</Label>);
+
+    expect(wrapper.hasClass('form-control-label')).toBe(true);
+  });
+
+  it('should render with "form-control-label" class when inline prop is truthy', () => {
+    const wrapper = shallow(<Label inline>Yo!</Label>);
+
+    expect(wrapper.hasClass('form-control-label')).toBe(true);
+  });
+
+  it('should not render with "form-control-label" class when a col is provided', () => {
+    const wrapper = shallow(<Label sm="6">Yo!</Label>);
+
+    expect(wrapper.hasClass('form-control-label')).toBe(false);
+  });
+
+  it('should not render with "form-control-label" class when check prop is truthy', () => {
+    const wrapper = shallow(<Label check>Yo!</Label>);
+
+    expect(wrapper.hasClass('form-control-label')).toBe(false);
+  });
+
   it('should render with "col-form-label" class when a col is provided', () => {
     const wrapper = shallow(<Label sm="6">Yo!</Label>);
 


### PR DESCRIPTION
Adds the `form-control-label` class to the `Label` component when the component is not used with a `check` or column prop. This class will be added in plain `Label` components and also `inline` `Label` components.

I might also suggest keeping an eye on https://github.com/twbs/bootstrap/issues/22173 moving forward in case further clarification on the distinction between `col-form-label` and `form-control-label` is provided

This resolves #451.