### PR TITLE
fix(DropdownToggle): Fixes #461 (reverting bad PR#402) which ensures

### DIFF
--- a/src/DropdownToggle.js
+++ b/src/DropdownToggle.js
@@ -6,7 +6,6 @@ import Button from './Button';
 
 const propTypes = {
   caret: PropTypes.bool,
-  color: PropTypes.string,
   children: PropTypes.node,
   className: PropTypes.string,
   cssModule: PropTypes.object,
@@ -22,7 +21,6 @@ const propTypes = {
 const defaultProps = {
   'data-toggle': 'dropdown',
   'aria-haspopup': true,
-  color: 'secondary',
 };
 
 const contextTypes = {

--- a/src/DropdownToggle.js
+++ b/src/DropdownToggle.js
@@ -6,6 +6,7 @@ import Button from './Button';
 
 const propTypes = {
   caret: PropTypes.bool,
+  color: PropTypes.string,
   children: PropTypes.node,
   className: PropTypes.string,
   cssModule: PropTypes.object,
@@ -21,6 +22,7 @@ const propTypes = {
 const defaultProps = {
   'data-toggle': 'dropdown',
   'aria-haspopup': true,
+  color: 'secondary',
 };
 
 const contextTypes = {
@@ -53,7 +55,7 @@ class DropdownToggle extends React.Component {
   }
 
   render() {
-    const { className, cssModule, caret, split, nav, tag, ...props } = this.props;
+    const { className, color, cssModule, caret, split, nav, tag, ...props } = this.props;
     const ariaLabel = props['aria-label'] || 'Toggle Dropdown';
     const classes = mapToCssModules(classNames(
       className,
@@ -73,6 +75,7 @@ class DropdownToggle extends React.Component {
       props.href = '#';
     } else if (!tag) {
       Tag = Button;
+      props.color = color;
     } else {
       Tag = tag;
     }

--- a/src/__tests__/DropdownToggle.spec.js
+++ b/src/__tests__/DropdownToggle.spec.js
@@ -100,7 +100,7 @@ describe('DropdownToggle', () => {
       expect(wrapper.find('button').length).toBe(1);
       expect(wrapper.find('button').hasClass('btn-secondary')).toBe(true);
     });
-  
+
     it('should render the dropdown as a BUTTON element with explicit color success', () => {
       const wrapper = mount(
         <DropdownToggle color="success" />,
@@ -115,7 +115,7 @@ describe('DropdownToggle', () => {
       expect(wrapper.find('button').length).toBe(1);
       expect(wrapper.find('button').hasClass('btn-success')).toBe(true);
     });
-    
+
     it('should render the dropdown as an A element with no color attribute', () => {
       const wrapper = mount(
         <DropdownToggle tag="a" />,
@@ -130,7 +130,7 @@ describe('DropdownToggle', () => {
       expect(wrapper.find('a').length).toBe(1);
       expect(wrapper.find('a[color]').length).toBe(0);
     });
-    
+
     it('should render the dropdown as a DIV element with no color attribute', () => {
       const wrapper = mount(
         <DropdownToggle tag="div" color="success"/>,
@@ -146,7 +146,7 @@ describe('DropdownToggle', () => {
       expect(wrapper.find('div[color]').length).toBe(0);
     });
   });
-   
+
   it('should render a split', () => {
     const wrapper = mount(
       <DropdownToggle split>Ello world</DropdownToggle>,

--- a/src/__tests__/DropdownToggle.spec.js
+++ b/src/__tests__/DropdownToggle.spec.js
@@ -133,7 +133,7 @@ describe('DropdownToggle', () => {
 
     it('should render the dropdown as a DIV element with no color attribute', () => {
       const wrapper = mount(
-        <DropdownToggle tag="div" color="success"/>,
+        <DropdownToggle tag="div" color="success" />,
         {
           context: {
             isOpen: isOpen,

--- a/src/__tests__/DropdownToggle.spec.js
+++ b/src/__tests__/DropdownToggle.spec.js
@@ -85,6 +85,68 @@ describe('DropdownToggle', () => {
     expect(wrapper.find('[data-toggle="dropdown"]').hasClass('dropdown-toggle')).toBe(true);
   });
 
+  describe('color', () => {
+    it('should render the dropdown as a BUTTON element with default color secondary', () => {
+      const wrapper = mount(
+        <DropdownToggle />,
+        {
+          context: {
+            isOpen: isOpen,
+            toggle: toggle
+          }
+        }
+      );
+
+      expect(wrapper.find('button').length).toBe(1);
+      expect(wrapper.find('button').hasClass('btn-secondary')).toBe(true);
+    });
+  
+    it('should render the dropdown as a BUTTON element with explicit color success', () => {
+      const wrapper = mount(
+        <DropdownToggle color="success" />,
+        {
+          context: {
+            isOpen: isOpen,
+            toggle: toggle
+          }
+        }
+      );
+
+      expect(wrapper.find('button').length).toBe(1);
+      expect(wrapper.find('button').hasClass('btn-success')).toBe(true);
+    });
+    
+    it('should render the dropdown as an A element with no color attribute', () => {
+      const wrapper = mount(
+        <DropdownToggle tag="a" />,
+        {
+          context: {
+            isOpen: isOpen,
+            toggle: toggle
+          }
+        }
+      );
+
+      expect(wrapper.find('a').length).toBe(1);
+      expect(wrapper.find('a[color]').length).toBe(0);
+    });
+    
+    it('should render the dropdown as a DIV element with no color attribute', () => {
+      const wrapper = mount(
+        <DropdownToggle tag="div" color="success"/>,
+        {
+          context: {
+            isOpen: isOpen,
+            toggle: toggle
+          }
+        }
+      );
+
+      expect(wrapper.find('div').length).toBe(1);
+      expect(wrapper.find('div[color]').length).toBe(0);
+    });
+  });
+   
   it('should render a split', () => {
     const wrapper = mount(
       <DropdownToggle split>Ello world</DropdownToggle>,


### PR DESCRIPTION
color attribute is NOT leaked. The color attribute was added into props because it originally existed as a defaultProp (but not in the prop types) as result from a copy/paste error. The correct solution is to remove from both as it's not used in stylizing the DropdownToggle in any fashion which results in the attribute leaking as an html prop which causes HTML5 validation to error.