### PR TITLE
Externalize ReactTransitionGroup (fixes big file size)

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "reactstrap",
   "version": "4.6.2",
   "description": "React Bootstrap 4 components",
-  "main": "dist/reactstrap.min.js",
+  "main": "lib/index.js",
   "jsnext:main": "dist/reactstrap.es.js",
   "module": "dist/reactstrap.es.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "reactstrap",
   "version": "4.6.2",
   "description": "React Bootstrap 4 components",
-  "main": "lib/index.js",
+  "main": "dist/reactstrap.min.js",
   "jsnext:main": "dist/reactstrap.es.js",
   "module": "dist/reactstrap.es.js",
   "scripts": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -19,16 +19,12 @@ const config = {
     'react',
     'react-dom',
     'react-transition-group',
-    'react-transition-group/CSSTransitionGroup',
-    'react-transition-group/TransitionGroup'
   ],
   // Used for the UMD bundles
   globals: {
     react: 'React',
     'react-dom': 'ReactDOM',
     'react-transition-group': 'ReactTransitionGroup',
-    'react-transition-group/CSSTransitionGroup': 'ReactTransitionGroup.CSSTransitionGroup',
-    'react-transition-group/TransitionGroup': 'ReactTransitionGroup.TransitionGroup',
   },
   targets: [
     { dest: 'dist/reactstrap.es.js', format: 'es' },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -19,11 +19,16 @@ const config = {
     'react',
     'react-dom',
     'react-transition-group',
+    'react-transition-group/CSSTransitionGroup',
+    'react-transition-group/TransitionGroup'
   ],
   // Used for the UMD bundles
   globals: {
     react: 'React',
     'react-dom': 'ReactDOM',
+    'react-transition-group': 'ReactTransitionGroup',
+    'react-transition-group/CSSTransitionGroup': 'ReactTransitionGroup.CSSTransitionGroup',
+    'react-transition-group/TransitionGroup': 'ReactTransitionGroup.TransitionGroup',
   },
   targets: [
     { dest: 'dist/reactstrap.es.js', format: 'es' },

--- a/src/Alert.js
+++ b/src/Alert.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import CSSTransitionGroup from 'react-transition-group/CSSTransitionGroup';
+import { CSSTransitionGroup } from 'react-transition-group';
 import { mapToCssModules } from './utils';
 
 const FirstChild = ({ children }) => (

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import classNames from 'classnames';
-import TransitionGroup from 'react-transition-group/TransitionGroup';
+import { TransitionGroup } from 'react-transition-group';
 import Fade from './Fade';
 import {
   getOriginalBodyPadding,


### PR DESCRIPTION
Reactstrap bundle size jumped from 95kB to 335kB with the release of v4.6.0 (https://github.com/reactstrap/reactstrap/issues/472).

After observing the bundled output using [`source-map-explorer`](https://www.npmjs.com/package/source-map-explorer) I noticed that React, ReactDOM and React Transition Group all three were part of the bundle! [Visualized bundle](https://sourcemap-nrtnjyylaw.now.sh).

This was introduced when upgrading the React Transition Group package in #399. The imports were updated to point at modules that live under the `react-transition-group` package. For example:

```js
import CSSTransitionGroup from 'react-transition-group/CSSTransitionGroup';
```

By importing a module under the package, Rollup no longer found a matching entry in the list of imports that should be treated as external. This resulted in Rollup including it in the bundle.

This PR fixes it by setting up the correct external entries for the React Transition Group package and the imports that we use. I have also added back the entries to the global list for React Transition Group that were removed in #399 so that UMD builds will work correctly when used together with the UMD builds of React Transition Group. [Visualized bundle after the fix](https://sourcemap-qzasczgqli.now.sh/).

![image](https://user-images.githubusercontent.com/1444314/27455293-b13d87de-5751-11e7-8604-56f2c6a95ead.png)

Fixes #472.

This PR also reverts #433. #433 worked around the wrong bundling by pointing at the `lib` folder. This is wrong because the lib folder contains individually transpiled files. By being individually transpiled, each file will contain a copy of the babel helpers that are used, resulting in each component being bigger than it should be.