### PR TITLE
Optimize CommonJS and module build

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -7,7 +7,7 @@
     "transform-object-rest-spread"
   ],
   "env": {
-    "dist-dir": {
+    "lib-dir": {
       "plugins": ["transform-es2015-modules-commonjs"]
     },
     "webpack": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "start": "BABEL_ENV=webpack webpack-dev-server --config ./webpack.dev.config.js --watch",
     "build-docs": "cross-env WEBPACK_BUILD=production webpack --config ./webpack.dev.config.js --progress --colors",
     "build": "rollup -c",
-    "prebuild": "BABEL_ENV=dist-dir babel src --out-dir lib --ignore src/__tests__/",
+    "prebuild": "BABEL_ENV=lib-dir babel src --out-dir lib --ignore src/__tests__/",
     "create-release": "npm test && sh ./scripts/release",
     "publish-release": "npm test && sh ./scripts/publish",
     "lint": "eslint src"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "reactstrap",
   "version": "4.7.0",
   "description": "React Bootstrap 4 components",
-  "main": "lib/index.js",
+  "main": "dist/reactstrap.cjs.js",
   "jsnext:main": "dist/reactstrap.es.js",
   "module": "dist/reactstrap.es.js",
   "scripts": {
@@ -11,7 +11,7 @@
     "cover": "npm test -- --coverage",
     "start": "BABEL_ENV=webpack webpack-dev-server --config ./webpack.dev.config.js --watch",
     "build-docs": "cross-env WEBPACK_BUILD=production webpack --config ./webpack.dev.config.js --progress --colors",
-    "build": "cross-env NODE_ENV=production rollup -c",
+    "build": "rollup -c",
     "prebuild": "BABEL_ENV=dist-dir babel src --out-dir lib --ignore src/__tests__/",
     "create-release": "npm test && sh ./scripts/release",
     "publish-release": "npm test && sh ./scripts/publish",
@@ -95,8 +95,8 @@
   },
   "peerDependencies": {
     "react": "^0.14.9 || ^15.3.0",
-    "react-transition-group": "^1.1.2",
-    "react-dom": "^0.14.9 || ^15.3.0"
+    "react-dom": "^0.14.9 || ^15.3.0",
+    "react-transition-group": "^1.1.2"
   },
   "devDependencies": {
     "babel-cli": "^6.14.0",
@@ -135,9 +135,9 @@
     "react-scripts": "^0.9.5",
     "react-test-renderer": "^15.5.4",
     "react-transition-group": "^1.1.2",
-    "rollup": "^0.41.5",
+    "rollup": "^0.43.0",
     "rollup-plugin-babel": "^2.7.1",
-    "rollup-plugin-babili": "^3.0.0",
+    "rollup-plugin-babili": "^3.1.0",
     "rollup-plugin-commonjs": "^8.0.2",
     "rollup-plugin-node-resolve": "^3.0.0",
     "rollup-plugin-replace": "^1.1.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,39 +4,75 @@ import babel from 'rollup-plugin-babel';
 import babili from 'rollup-plugin-babili';
 import replace from 'rollup-plugin-replace';
 
-const config = {
-  moduleName: 'Reactstrap',
-  entry: 'src/index.js',
-  plugins: [
-    nodeResolve(),
-    commonjs(),
-    babel({
-      plugins: ['external-helpers'],
-    }),
-  ],
-  sourceMap: true,
-  external: [
-    'react',
-    'react-dom',
-    'react-transition-group',
-  ],
-  // Used for the UMD bundles
-  globals: {
-    react: 'React',
-    'react-dom': 'ReactDOM',
-    'react-transition-group': 'ReactTransitionGroup',
-  },
-  targets: [
-    { dest: 'dist/reactstrap.es.js', format: 'es' },
-    { dest: 'dist/reactstrap.min.js', format: 'umd' },
-  ],
-};
+// Require understands JSON files.
+const packageJson = require('./package.json');
+const peerDependencies = Object.keys(packageJson.peerDependencies);
+const dependencies = Object.keys(packageJson.dependencies);
 
-if (process.env.NODE_ENV === 'production') {
-  config.plugins.push(babili({ comments: false }));
-  config.plugins.push(replace({
-    'process.env.NODE_ENV': JSON.stringify('production'),
-  }));
+function baseConfig() {
+  return {
+    moduleName: 'Reactstrap',
+    entry: 'src/index.js',
+    plugins: [
+      nodeResolve(),
+      commonjs(),
+      babel({
+        plugins: ['external-helpers'],
+      }),
+    ],
+    sourceMap: true,
+  };
 }
 
-export default config;
+/*
+  COMMONJS / MODULE CONFIG
+  ------------------------
+
+  Goal of this configuration is to generate bundles to be consumed by bundlers.
+  This configuration is not minimized and will import all dependencies.
+*/
+const libConfig = baseConfig();
+// Do not include any of the dependencies
+libConfig.external = peerDependencies.concat(dependencies);
+libConfig.targets = [
+  { dest: 'dist/reactstrap.cjs.js', format: 'cjs' },
+  { dest: 'dist/reactstrap.es.js', format: 'es' },
+];
+
+/*
+  UMD CONFIG
+  ----------
+
+  Goal of this configuration is to be directly included on web pages.
+  This configuration is minimized and will include dependencies that are not
+  marked as peer dependencies.
+
+  Defining this config will also check that all peer dependencies are set up
+  correctly in the globals entry.
+*/
+const umdConfig = baseConfig();
+umdConfig.external = peerDependencies;
+umdConfig.plugins.push(replace({
+  'process.env.NODE_ENV': JSON.stringify('production'),
+}));
+umdConfig.plugins.push(babili({ comments: false }));
+umdConfig.targets = [
+  { dest: 'dist/reactstrap.min.js', format: 'umd' },
+];
+umdConfig.globals = {
+  react: 'React',
+  'react-dom': 'ReactDOM',
+  'react-transition-group': 'ReactTransitionGroup',
+};
+const missingGlobals = peerDependencies.filter(dep => !(dep in umdConfig.globals));
+if (missingGlobals.length) {
+  console.error('All peer dependencies need to be mentioned in globals, please update rollup.config.js.');
+  console.error('Missing: ' + missingGlobals.join(', '));
+  console.error('Aborting build.');
+  process.exit(1);
+}
+
+export default [
+  libConfig,
+  umdConfig,
+];

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -19,8 +19,6 @@ const config = {
     'react',
     'react-dom',
     'react-transition-group',
-    'react-transition-group/CSSTransitionGroup',
-    'react-transition-group/TransitionGroup'
   ],
   // Used for the UMD bundles
   globals: {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -19,6 +19,8 @@ const config = {
     'react',
     'react-dom',
     'react-transition-group',
+    'react-transition-group/CSSTransitionGroup',
+    'react-transition-group/TransitionGroup'
   ],
   // Used for the UMD bundles
   globals: {


### PR DESCRIPTION
This PR will split our Rollup config in two: one for the CJS/ES build and one for UMD. This is a backwards compatible change. It will also address the minimized name issue that people experienced in Storybook.

Bundled output (names link to the actual output):

 - `lib` - babelified source, stays the same
 - [`dist/reactstrap.cjs.js`](https://gist.github.com/balloob/79cb8c9d930dae9ab5a0c4cf8900e823#file-reactstrap-cjs-js) - unminified CommonJS build, pointed at from `package.main`
 - [`dist/reactstrap.es.js`](https://gist.github.com/balloob/79cb8c9d930dae9ab5a0c4cf8900e823#file-reactstrap-es-js) - unminified Module build, pointed at from `package.module`
 - [`dist/reactstrap.min.js`](https://gist.github.com/balloob/79cb8c9d930dae9ab5a0c4cf8900e823#file-reactstrap-min-js) - minified UMD build, to be included by users directly

![image](https://user-images.githubusercontent.com/1444314/27559052-08995e2a-5a74-11e7-909a-4827d741a66e.png)

The CJS/ES builds will not include any dependency and will not be minimized. These builds are going to be consumed by other bundlers and thus will be minimized when bundled for production (if the user chooses so). These bundles will be returned when `require('reactstrap')` or `import Reactstrap from 'reactstrap';`.

If you want to cherry pick only specific components:

With CommonJS: `const Card = require('reactstrap/lib/Card');`
With modules: `import { Card } from 'reactstrap';`

The UMD build is meant to be included directly on a webpage and will include the dependencies but not the peer dependencies. I've added a check so that when people add a peer dependency but not add it to the UMD globals object, it will fail the build.

This PR includes #474 as it was needed to generate correct builds.

CC @TheSharpieOne 

### Testing

To update source to run tests against the CommonJS build:

```
sed -i "" "s/\.\.\/\'/\.\.\/\.\.\/dist\/reactstrap.cjs'/" src/__tests__/*.spec.js
```

To update source to run tests against the module build:

```
sed -i "" "s/\.\.\/\'/\.\.\/\.\.\/dist\/reactstrap.es'/" src/__tests__/*.spec.js
```

To update source to run tests against the UMD build:

```
sed -i "" "s/\.\.\/\'/\.\.\/\.\.\/dist\/reactstrap.min'/" src/__tests__/*.spec.js
```
