### PR TITLE
Remove lodash.omit

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
     "classnames": "^2.2.3",
     "lodash.isfunction": "^3.0.8",
     "lodash.isobject": "^3.0.2",
-    "lodash.omit": "^4.4.1",
     "lodash.tonumber": "^4.0.3",
     "prop-types": "^15.5.8",
     "reactstrap-tether": "1.3.4"

--- a/src/Collapse.js
+++ b/src/Collapse.js
@@ -1,8 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { omit } from './utils';
-import { mapToCssModules } from './utils';
+import { mapToCssModules, omit } from './utils';
 
 const SHOW = 'SHOW';
 const SHOWN = 'SHOWN';

--- a/src/Collapse.js
+++ b/src/Collapse.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import omit from 'lodash.omit';
+import { omit } from './utils';
 import { mapToCssModules } from './utils';
 
 const SHOW = 'SHOW';

--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -5,8 +5,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import classNames from 'classnames';
-import { omit } from './utils';
-import { mapToCssModules } from './utils';
+import { mapToCssModules, omit } from './utils';
 import TetherContent from './TetherContent';
 import DropdownMenu from './DropdownMenu';
 

--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -5,7 +5,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import classNames from 'classnames';
-import omit from 'lodash.omit';
+import { omit } from './utils';
 import { mapToCssModules } from './utils';
 import TetherContent from './TetherContent';
 import DropdownMenu from './DropdownMenu';

--- a/src/DropdownItem.js
+++ b/src/DropdownItem.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import omit from 'lodash.omit';
 import classNames from 'classnames';
+import { omit } from './utils';
 import { mapToCssModules } from './utils';
 
 const propTypes = {

--- a/src/DropdownItem.js
+++ b/src/DropdownItem.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { omit } from './utils';
-import { mapToCssModules } from './utils';
+import { mapToCssModules, omit } from './utils';
 
 const propTypes = {
   children: PropTypes.node,

--- a/src/Fade.js
+++ b/src/Fade.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import omit from 'lodash.omit';
+import { omit } from './utils';
 import { mapToCssModules } from './utils';
 
 const propTypes = {

--- a/src/Fade.js
+++ b/src/Fade.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { omit } from './utils';
-import { mapToCssModules } from './utils';
+import { mapToCssModules, omit } from './utils';
 
 const propTypes = {
   baseClass: PropTypes.string,

--- a/src/Popover.js
+++ b/src/Popover.js
@@ -1,9 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { omit } from './utils';
 import TetherContent from './TetherContent';
-import { getTetherAttachments, mapToCssModules, tetherAttachements } from './utils';
+import { getTetherAttachments, mapToCssModules, omit, tetherAttachements } from './utils';
 
 const propTypes = {
   placement: PropTypes.oneOf(tetherAttachements),

--- a/src/Popover.js
+++ b/src/Popover.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import omit from 'lodash.omit';
+import { omit } from './utils';
 import TetherContent from './TetherContent';
 import { getTetherAttachments, mapToCssModules, tetherAttachements } from './utils';
 

--- a/src/TabContent.js
+++ b/src/TabContent.js
@@ -1,8 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { omit } from './utils';
-import { mapToCssModules } from './utils';
+import { mapToCssModules, omit } from './utils';
 
 const propTypes = {
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),

--- a/src/TabContent.js
+++ b/src/TabContent.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import omit from 'lodash.omit';
+import { omit } from './utils';
 import { mapToCssModules } from './utils';
 
 const propTypes = {

--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -1,9 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { omit } from './utils';
 import TetherContent from './TetherContent';
-import { getTetherAttachments, tetherAttachements, mapToCssModules } from './utils';
+import { getTetherAttachments, mapToCssModules, omit, tetherAttachements } from './utils';
 
 const propTypes = {
   placement: PropTypes.oneOf(tetherAttachements),

--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import omit from 'lodash.omit';
+import { omit } from './utils';
 import TetherContent from './TetherContent';
 import { getTetherAttachments, tetherAttachements, mapToCssModules } from './utils';
 

--- a/src/__tests__/utils.spec.js
+++ b/src/__tests__/utils.spec.js
@@ -157,39 +157,39 @@ describe('Utils', () => {
   describe('omit', () => {
     it('should omit keys', () => {
       const input = {
-        'hello': 'world',
-        'speed': 'fast',
-        'size': 'small'
+        hello: 'world',
+        speed: 'fast',
+        size: 'small'
       };
-      expect(Utils.omit(input, ['hello'])).toEqual({ 'speed': 'fast', 'size': 'small' });
+      expect(Utils.omit(input, ['hello'])).toEqual({ speed: 'fast', size: 'small' });
     });
 
     it('should not alter source object', () => {
       const input = {
-        'hello': 'world',
-        'speed': 'fast',
-        'size': 'small'
+        hello: 'world',
+        speed: 'fast',
+        size: 'small'
       };
-      expect(Utils.omit(input, ['hello'])).toEqual({ 'speed': 'fast', 'size': 'small' });
+      expect(Utils.omit(input, ['hello'])).toEqual({ speed: 'fast', size: 'small' });
       expect(input).toEqual({
-        'hello': 'world',
-        'speed': 'fast',
-        'size': 'small'
+        hello: 'world',
+        speed: 'fast',
+        size: 'small'
       });
     });
 
     it('should ignore non-existing keys', () => {
       const input = {
-        'hello': 'world',
-        'speed': 'fast',
-        'size': 'small'
+        hello: 'world',
+        speed: 'fast',
+        size: 'small'
       };
-      expect(Utils.omit(input, ['non-existing', 'hello'])).toEqual({ 'speed': 'fast', 'size': 'small' });
+      expect(Utils.omit(input, ['non-existing', 'hello'])).toEqual({ speed: 'fast', size: 'small' });
     });
 
     it('should return a new object', () => {
       const input = {
-        'hello': 'world'
+        hello: 'world'
       };
       // toBe tests equality using `===` and so will test if it's not the same object.
       expect(Utils.omit(input, [])).not.toBe(input);

--- a/src/__tests__/utils.spec.js
+++ b/src/__tests__/utils.spec.js
@@ -154,6 +154,48 @@ describe('Utils', () => {
     });
   });
 
+  describe('omit', () => {
+    it('should omit keys', () => {
+      const input = {
+        'hello': 'world',
+        'speed': 'fast',
+        'size': 'small'
+      };
+      expect(Utils.omit(input, ['hello'])).toEqual({ 'speed': 'fast', 'size': 'small' });
+    });
+
+    it('should not alter source object', () => {
+      const input = {
+        'hello': 'world',
+        'speed': 'fast',
+        'size': 'small'
+      };
+      expect(Utils.omit(input, ['hello'])).toEqual({ 'speed': 'fast', 'size': 'small' });
+      expect(input).toEqual({
+        'hello': 'world',
+        'speed': 'fast',
+        'size': 'small'
+      });
+    });
+
+    it('should ignore non-existing keys', () => {
+      const input = {
+        'hello': 'world',
+        'speed': 'fast',
+        'size': 'small'
+      };
+      expect(Utils.omit(input, ['non-existing', 'hello'])).toEqual({ 'speed': 'fast', 'size': 'small' });
+    });
+
+    it('should return a new object', () => {
+      const input = {
+        'hello': 'world'
+      };
+      // toBe tests equality using `===` and so will test if it's not the same object.
+      expect(Utils.omit(input, [])).not.toBe(input);
+    });
+  });
+
   // TODO
   // describe('getScrollbarWidth', () => {
   //   // jsdom workaround https://github.com/tmpvar/jsdom/issues/135#issuecomment-68191941

--- a/src/utils.js
+++ b/src/utils.js
@@ -154,3 +154,16 @@ export function mapToCssModules(className, cssModule) {
   if (!cssModule) return className;
   return className.split(' ').map(c => cssModule[c] || c).join(' ');
 }
+
+/**
+ * Returns a new object with the key/value pairs from `obj` that are not in the array `omitKeys`.
+ */
+export function omit(obj, omitKeys) {
+  const result = {};
+  Object.keys(obj).forEach(key => {
+    if (omitKeys.indexOf(key) === -1) {
+      result[key] = obj[key];
+    }
+  });
+  return result;
+}


### PR DESCRIPTION
When I was analyzing [the source map](https://sourcemap-qzasczgqli.now.sh/) for #474 I noticed that the package `lodash.omit` takes up 9.29kB!

[Looking at the source](https://unpkg.com/lodash.omit@4.5.0/index.js), we can see that it pulls in a lot of dependent lodash functions.

I've added our own omit function to `utils.js`, which minifies to 105 bytes, and works with the use cases that we provide to it:

```js
export function omit(obj, omitKeys) {
  const result = {};
  Object.keys(obj).forEach(key => {
    if (omitKeys.indexOf(key) === -1) {
      result[key] = obj[key];
    }
  });
  return result;
}
```

This saves the user ~9kB.