### PR TITLE
chore(readme): add version to install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Then open [http://localhost:3000/](http://localhost:3000/) to see your app. The 
 Install reactstrap and Bootstrap from NPM. Reactstrap does not include Bootstrap CSS so this needs to be installed as well:
 
 ```
-npm install bootstrap@4.0.0-alpha.6 --save
-npm install --save reactstrap react-transition-group react react-dom
+npm install --save bootstrap@4.0.0-alpha.6
+npm install --save reactstrap react-transition-group@^1.1.2 react@^15.3.0 react-dom@^15.3.0
 ```
 
 Import Bootstrap CSS in the ```src/index.js``` file:


### PR DESCRIPTION
closes #495


Also, when reading the readme, it seems like the information is not 100% correct. It seems to indicate that you have to use create-react-app and that you must include bootstrap from npm. This is not the case. 
While using create-react-app is a good suggestion, especially for starting a new app, it is not required. Perhaps moving `npm install --save reactstrap react-transition-group@^1.1.2 react@^15.3.0 react-dom@^15.3.0` to the top would clarify what needs to be installed to use this app.
Bootstrap itself is not needed, at least from npm. Including a `<link>` to [their CDN](https://www.bootstrapcdn.com/alpha/) (or [bootstrap on cdnjs](https://cdnjs.com/libraries/twitter-bootstrap/)) is probably the most common way. One only needs to include bootstrap from npm if they intend to customize it (and not just override it's styles)