### PR TITLE
Fixed event name typo

### DIFF
--- a/src/CarouselItem.js
+++ b/src/CarouselItem.js
@@ -61,7 +61,7 @@ class CarouselItem extends React.Component {
     this.setState({
       animation: []
     });
-    this.slide.dispatchEvent(new CustomEvent('slid.bs.carousel'));
+    this.slide.dispatchEvent(new CustomEvent('slide.bs.carousel'));
   }
 
 


### PR DESCRIPTION
However, there is already an event fired on `componentWillLeave` with the same name so perhaps one of these should be removed or renamed.