### PR TITLE
fix(PaginationLink): handle empty children array

### DIFF
--- a/src/PaginationLink.js
+++ b/src/PaginationLink.js
@@ -51,7 +51,7 @@ const PaginationLink = (props) => {
   if (children && !children.length) {
     children = null;
   }
-  
+
   if (previous || next) {
     children = [
       <span

--- a/src/PaginationLink.js
+++ b/src/PaginationLink.js
@@ -48,6 +48,10 @@ const PaginationLink = (props) => {
   }
 
   let children = props.children;
+  if (children && !children.length) {
+    children = null;
+  }
+  
   if (previous || next) {
     children = [
       <span

--- a/src/__tests__/PaginationLink.spec.js
+++ b/src/__tests__/PaginationLink.spec.js
@@ -37,6 +37,22 @@ describe('PaginationLink', () => {
     expect(wrapper.find('.sr-only').text()).toBe('Next');
   });
 
+  it('should render default previous caret with children as an empty array', () => {
+    const wrapper = shallow(<PaginationLink previous children={[]} />);
+
+    expect(wrapper.prop('aria-label')).toBe('Previous');
+    expect(wrapper.find({ 'aria-hidden': 'true' }).text()).toBe('\u00ab');
+    expect(wrapper.find('.sr-only').text()).toBe('Previous');
+  });
+
+  it('should render default next caret with children as an empty array', () => {
+    const wrapper = shallow(<PaginationLink next children={[]} />);
+
+    expect(wrapper.prop('aria-label')).toBe('Next');
+    expect(wrapper.find({ 'aria-hidden': 'true' }).text()).toBe('\u00bb');
+    expect(wrapper.find('.sr-only').text()).toBe('Next');
+  });
+
   it('should render custom aria label', () => {
     const wrapper = shallow(<PaginationLink next aria-label="Yo" />);
 


### PR DESCRIPTION
Preact defaults to empty array for children, this will check for that and null it out.

This is based on the fix for a similar issue with react-router: https://github.com/ReactTraining/react-router/pull/4423/files

Closes #494