### PR TITLE
fix(Tooltip): match BS default values

### DIFF
--- a/docs/lib/Components/TooltipsPage.js
+++ b/docs/lib/Components/TooltipsPage.js
@@ -43,11 +43,13 @@ export default class TooltipsPage extends React.Component {
   // optionally overide tether config http://tether.io/#options
   tetherRef: PropType.function,
   // function which is passed a reference to the instance of tether for manually \`position()\`ing
+  animation: PropTypes.bool, // defaults true; controls fade animation.
+  animationDuration: PropTypes.number, // default 150; controls how long the animation takes before removing the tooltip
   delay: PropTypes.oneOfType([
     PropTypes.shape({ show: PropTypes.number, hide: PropTypes.number }),
     PropTypes.number
   ]),
-  // optionally override show/hide delays - default { show: 0, hide: 250 }
+  // optionally override show/hide delays - default { show: 0, hide: 0 }
   autohide: PropTypes.bool,
   // optionally hide tooltip when hovering over tooltip content - default true
   placement: PropTypes.oneOf([

--- a/src/TetherContent.js
+++ b/src/TetherContent.js
@@ -38,6 +38,9 @@ class TetherContent extends React.Component {
     if (this.props.isOpen !== prevProps.isOpen) {
       this.handleProps();
     } else if (this._element) {
+      if (this.props.className !== prevProps.className) {
+        this._element.className = this._element.className.replace(prevProps.className, this.props.className);
+      }
       // rerender
       this.renderIntoSubtree();
     }

--- a/src/__tests__/Tooltip.spec.js
+++ b/src/__tests__/Tooltip.spec.js
@@ -226,7 +226,7 @@ describe('Tooltip', () => {
 
       instance.onMouseLeaveTooltip();
       expect(isOpen).toBe(true);
-      jasmine.clock().tick(200);
+      jasmine.clock().tick(350); // delay + animation time
       expect(isOpen).toBe(false);
     });
 
@@ -242,7 +242,7 @@ describe('Tooltip', () => {
 
       instance.onMouseLeaveTooltip();
       expect(isOpen).toBe(true);
-      jasmine.clock().tick(200);
+      jasmine.clock().tick(350); // delay + animation time
       expect(isOpen).toBe(false);
     });
 
@@ -258,7 +258,57 @@ describe('Tooltip', () => {
 
       instance.onMouseLeaveTooltip();
       expect(isOpen).toBe(true);
-      jasmine.clock().tick(250);  // Default hide value: 250
+      jasmine.clock().tick(150);  // Default animationTime value: 150
+      expect(isOpen).toBe(false);
+    });
+  });
+
+  describe('animation', () => {
+    it('should be enabled by default', () => {
+      isOpen = true;
+      const wrapper = mount(
+        <Tooltip target="target" isOpen={isOpen} toggle={toggle}>
+          Tooltip Content
+        </Tooltip>,
+        { attachTo: container }
+      );
+      const instance = wrapper.instance();
+
+      instance.onMouseLeaveTooltip();
+      expect(isOpen).toBe(true);
+      jasmine.clock().tick(150);
+      expect(isOpen).toBe(false);
+    });
+
+    it('bre able to be disabled', () => {
+      isOpen = true;
+      const wrapper = mount(
+        <Tooltip target="target" isOpen={isOpen} toggle={toggle} animation={false}>
+          Tooltip Content
+        </Tooltip>,
+        { attachTo: container }
+      );
+      const instance = wrapper.instance();
+
+      instance.onMouseLeaveTooltip();
+      expect(isOpen).toBe(true);
+      jasmine.clock().tick(0);
+      expect(isOpen).toBe(false);
+    });
+
+    it('should be able to set the animation duration', () => {
+      isOpen = true;
+      const wrapper = mount(
+        <Tooltip target="target" isOpen={isOpen} toggle={toggle} animationDuration={1000}>
+          Tooltip Content
+        </Tooltip>,
+        { attachTo: container }
+      );
+      const instance = wrapper.instance();
+
+      instance.onMouseLeaveTooltip();
+      expect(isOpen).toBe(true);
+      jasmine.clock().tick(1000);
       expect(isOpen).toBe(false);
     });
   });
@@ -362,7 +412,7 @@ describe('Tooltip', () => {
       expect(Tooltip.prototype.toggle).not.toHaveBeenCalled();
 
       instance.onMouseOverTooltip();
-      jasmine.clock().tick(200);
+      jasmine.clock().tick(350); // delay + animation time
 
       expect(Tooltip.prototype.toggle).toHaveBeenCalled();
 
@@ -408,7 +458,7 @@ describe('Tooltip', () => {
       expect(Tooltip.prototype.toggle).not.toHaveBeenCalled();
 
       instance.onMouseLeaveTooltip();
-      jasmine.clock().tick(200);
+      jasmine.clock().tick(350); // delay + animation time
 
       expect(Tooltip.prototype.toggle).toHaveBeenCalled();
 
@@ -454,7 +504,7 @@ describe('Tooltip', () => {
       instance.onMouseLeaveTooltipContent();
       jasmine.clock().tick(100);
       expect(Tooltip.prototype.toggle).not.toHaveBeenCalled();
-      jasmine.clock().tick(200);
+      jasmine.clock().tick(350);  // delay + animation time
       expect(Tooltip.prototype.toggle).toHaveBeenCalled();
 
       wrapper.detach();
@@ -516,7 +566,7 @@ describe('Tooltip', () => {
       instance.onMouseLeaveTooltip();
       jasmine.clock().tick(100);
       instance.onMouseOverTooltipContent();
-      jasmine.clock().tick(200);
+      jasmine.clock().tick(350); // delay + animation time
       expect(Tooltip.prototype.toggle).toHaveBeenCalled();
       instance.onMouseLeaveTooltipContent();
       expect(instance._hideTimeout).toBeFalsy();


### PR DESCRIPTION
Default tooltip hide delay to 0 to match bootstrap
Add animation prop defaults to true to control animation
Add animationDuration prop defaults to 250 to allow animation duration to be overriden
Adjust TetherContent to allow classNames to change and rerender

Closes: #484

Breaks Tooltip: Tooltip's default hide delay is now 0 (previously 250) and now has fade animation with a duration of 250. This was done to better match bootstrap's default. If you like the previous defaults, you can set `delay={hide:0}` and `animation={false}`

Demo: (left: current; right: proposed)
![tooltip-animation](https://user-images.githubusercontent.com/664714/28735813-038e15ec-73b5-11e7-9318-b256fe46b43c.gif)
