### PR TITLE
feature(Modal): add accessibility props

### DIFF
--- a/docs/lib/Components/ModalsPage.js
+++ b/docs/lib/Components/ModalsPage.js
@@ -51,6 +51,9 @@ export default class ModalsPage extends React.Component {
   size: PropTypes.string,
   // callback for toggling isOpen in the controlling component
   toggle:  PropTypes.func,
+  role: PropTypes.string, // defaults to "dialog"
+  // used to reference the ID of the title element in the modal
+  labelledBy: PropTypes.string,
   keyboard: PropTypes.bool,
   // control backdrop, see http://v4-alpha.getbootstrap.com/components/modal/#options
   backdrop: PropTypes.oneOfType([

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -18,6 +18,8 @@ const propTypes = {
   size: PropTypes.string,
   toggle: PropTypes.func,
   keyboard: PropTypes.bool,
+  role: PropTypes.string,
+  labelledBy: PropTypes.string,
   backdrop: PropTypes.oneOfType([
     PropTypes.bool,
     PropTypes.oneOf(['static'])
@@ -53,6 +55,7 @@ const propsToOmit = Object.keys(propTypes);
 const defaultProps = {
   isOpen: false,
   autoFocus: true,
+  role: 'dialog',
   backdrop: true,
   keyboard: true,
   zIndex: 1050,
@@ -239,13 +242,17 @@ class Modal extends React.Component {
       isOpen,
       backdrop,
       modalTransitionTimeout,
-      backdropTransitionTimeout
+      backdropTransitionTimeout,
+      role,
+      labelledBy
     } = this.props;
 
     const modalAttributes = {
       onClickCapture: this.handleBackdropClick,
       onKeyUp: this.handleEscape,
       style: { display: 'block' },
+      'aria-labelledby': labelledBy,
+      role,
       tabIndex: '-1'
     };
 

--- a/src/__tests__/Modal.spec.js
+++ b/src/__tests__/Modal.spec.js
@@ -239,6 +239,48 @@ describe('Modal', () => {
     wrapper.unmount();
   });
 
+  it('should render modal with default role of "dialog"', () => {
+    isOpen = true;
+    const wrapper = mount(
+      <Modal isOpen={isOpen} toggle={toggle}>
+        Yo!
+      </Modal>
+    );
+
+    jasmine.clock().tick(300);
+    expect(wrapper.children().length).toBe(0);
+    expect(document.getElementsByClassName('modal')[0].getAttribute('role')).toBe('dialog');
+    wrapper.unmount();
+  });
+
+  it('should render modal with provided role', () => {
+    isOpen = true;
+    const wrapper = mount(
+      <Modal isOpen={isOpen} toggle={toggle} role="alert">
+        Yo!
+      </Modal>
+    );
+
+    jasmine.clock().tick(300);
+    expect(wrapper.children().length).toBe(0);
+    expect(document.getElementsByClassName('modal')[0].getAttribute('role')).toBe('alert');
+    wrapper.unmount();
+  });
+
+  it('should render modal with aria-labelledby provided labelledBy', () => {
+    isOpen = true;
+    const wrapper = mount(
+      <Modal isOpen={isOpen} toggle={toggle} labelledBy="myModalTitle">
+        Yo!
+      </Modal>
+    );
+
+    jasmine.clock().tick(300);
+    expect(wrapper.children().length).toBe(0);
+    expect(document.getElementsByClassName('modal')[0].getAttribute('aria-labelledby')).toBe('myModalTitle');
+    wrapper.unmount();
+  });
+
   it('should not render modal when isOpen is false', () => {
     const wrapper = mount(
       <Modal isOpen={isOpen} toggle={toggle}>


### PR DESCRIPTION
Add role props which defaults to dialog to the Modal component
Add labelledBy props which will output to aria-labelledby. This prop should be used by the develop to tie a title to the modal.

Closes #518