### PR TITLE
feat(Navbar): Added dark prop

### DIFF
--- a/docs/lib/Components/NavbarPage.js
+++ b/docs/lib/Components/NavbarPage.js
@@ -28,6 +28,7 @@ export default class NavsPage extends React.Component {
           <PrismCode className="language-jsx">
 {`Navbar.propTypes = {
   light: PropTypes.bool,
+  dark: PropTypes.bool,
   inverse: PropTypes.bool,
   full: PropTypes.bool,
   fixed: PropTypes.string,

--- a/src/Navbar.js
+++ b/src/Navbar.js
@@ -5,6 +5,7 @@ import { mapToCssModules } from './utils';
 
 const propTypes = {
   light: PropTypes.bool,
+  dark: PropTypes.bool,
   inverse: PropTypes.bool,
   full: PropTypes.bool,
   fixed: PropTypes.string,
@@ -38,6 +39,7 @@ const Navbar = (props) => {
     className,
     cssModule,
     light,
+    dark,
     inverse,
     full,
     fixed,
@@ -53,6 +55,7 @@ const Navbar = (props) => {
     getToggleableClass(toggleable),
     {
       'navbar-light': light,
+      'navbar-dark': dark,
       'navbar-inverse': inverse,
       [`bg-${color}`]: color,
       'navbar-full': full,

--- a/src/__tests__/Navbar.spec.js
+++ b/src/__tests__/Navbar.spec.js
@@ -47,12 +47,13 @@ describe('Navbar', () => {
   });
 
   it('should render prop based classes', () => {
-    const wrapper = shallow(<Navbar light inverse toggleable="sm" color="success" full sticky="top" fixed="top" />);
+    const wrapper = shallow(<Navbar dark light inverse toggleable="sm" color="success" full sticky="top" fixed="top" />);
 
     expect(wrapper.hasClass('bg-success')).toBe(true);
     expect(wrapper.hasClass('navbar')).toBe(true);
     expect(wrapper.hasClass('navbar-toggleable-sm')).toBe(true);
     expect(wrapper.hasClass('navbar-light')).toBe(true);
+    expect(wrapper.hasClass('navbar-dark')).toBe(true);
     expect(wrapper.hasClass('navbar-inverse')).toBe(true);
     expect(wrapper.hasClass('fixed-top')).toBe(true);
     expect(wrapper.hasClass('sticky-top')).toBe(true);


### PR DESCRIPTION
If there is a `light` prop to add the `navbar-light` class, then to keep consistency there should also be a `dark` prop to add the `navbar-dark` class.
This PR adds the `dark` prop which will add the aforementioned class when set. With a test and the prop entry in the comments.