### PR TITLE
Support for Custom Form Inputs

### DIFF
--- a/docs/lib/Components/FormPage.js
+++ b/docs/lib/Components/FormPage.js
@@ -27,6 +27,9 @@ const InputGridSizingExampleSource = require('!!raw!../examples/InputGridSizing'
 import LabelHiddenExample from '../examples/LabelHidden';
 const LabelHiddenExampleSource = require('!!raw!../examples/LabelHidden');
 
+import CustomControlExample from '../examples/CustomControl';
+const CustomControlExampleSource = require('!!raw!../examples/CustomControl');
+
 export default class FormPage extends React.Component {
   render() {
     return (
@@ -109,6 +112,16 @@ export default class FormPage extends React.Component {
         <pre>
           <PrismCode className="language-jsx">
             {LabelHiddenExampleSource}
+          </PrismCode>
+        </pre>
+
+        <h3>Custom Controls</h3>
+        <div className="docs-example">
+          <CustomControlExample />
+        </div>
+        <pre>
+          <PrismCode className="language-jsx">
+            {CustomControlExampleSource}
           </PrismCode>
         </pre>
       </div>

--- a/docs/lib/examples/CustomControl.js
+++ b/docs/lib/examples/CustomControl.js
@@ -1,0 +1,73 @@
+import React from 'react';
+import { Button, Form, FormGroup, Label, Input, FormText, CustomControl } from 'reactstrap';
+
+export default class Example extends React.Component {
+  render() {
+    return (
+      <Form>
+        <FormGroup>
+          <Label for="exampleCheckbox">Checkboxes</Label>
+          <div>
+            <CustomControl id="exampleCheckbox" type="checkbox" description="Check this custom checkbox" />
+          </div>
+        </FormGroup>
+        <FormGroup>
+          <Label for="exampleRadio">Radios</Label>
+          <div>
+            <CustomControl id="exampleRadio" type="radio" description="Toggle this custom radio" />
+            <CustomControl id="exampleRadio" type="radio" description="Or toggle this other custom radio" />
+          </div>
+        </FormGroup>
+        <FormGroup>
+          <Label for="exampleRadioStacked">Radios Stacked</Label>
+          <CustomControl id="exampleRadioStacked" type="stacked">
+            <CustomControl type="radio" description="Toggle this custom radio" name="radio-stacked" />
+            <CustomControl type="radio" description="Or toggle this other custom radio" name="radio-stacked" />
+          </CustomControl>
+        </FormGroup>
+        <FormGroup>
+          <Label for="exampleCustomInputDisabled">Disabled Custom Input</Label>
+          <div>
+            <CustomControl id="exampleCustomInputDisabled" type="checkbox" description="Check this custom checkbox" disabled />
+            <CustomControl id="exampleCustomInputDisabled" type="radio" description="Toggle this custom radio" disabled />
+          </div>
+        </FormGroup>
+        <FormGroup>
+          <Label for="exampleSelect">Select</Label>
+          <div>
+            <CustomControl id="exampleSelect" type="select">
+              <option defaultValue>Open this select menu</option>
+              <option value="1">One</option>
+              <option value="2">Two</option>
+              <option value="3">Three</option>
+            </CustomControl>
+          </div>
+        </FormGroup>
+        <FormGroup>
+          <Label for="exampleSelectDisabled">Disabled Select</Label>
+          <div>
+            <CustomControl id="exampleSelectDisabled" type="select" disabled>
+              <option defaultValue>Open this select menu</option>
+              <option value="1">One</option>
+              <option value="2">Two</option>
+              <option value="3">Three</option>
+            </CustomControl>
+          </div>
+        </FormGroup>
+        <FormGroup>
+          <Label for="exampleFile">File browser</Label>
+          <div>
+            <CustomControl id="exampleFile" type="file"/>
+          </div>
+        </FormGroup>
+        <FormGroup>
+          <Label for="exampleFileDisabled">Disabled File</Label>
+          <div>
+            <CustomControl id="exampleFileDisabled" type="file" disabled/>
+          </div>
+        </FormGroup>
+
+      </Form>
+    );
+  }
+}

--- a/src/CustomControl.js
+++ b/src/CustomControl.js
@@ -1,0 +1,63 @@
+/* eslint react/prefer-stateless-function: 0 */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import { Checkbox, Radio, Stacked, Select, File } from './CustomControlStack';
+import { mapToCssModules, tagMapper } from './utils';
+
+const propTypes = {
+  children: PropTypes.node,
+  type: PropTypes.string,
+  getRef: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  className: PropTypes.string,
+  cssModule: PropTypes.object,
+};
+
+const defaultProps = {
+  type: 'stacked',
+};
+
+const getTagType = tagMapper({
+  checkbox: Checkbox,
+  radio: Radio,
+  select: Select,
+  stacked: Stacked,
+  file: File,
+});
+
+class CustomControl extends React.Component {
+  render() {
+    const {
+      className,
+      cssModule,
+      type,
+      getRef,
+      ...attributes
+    } = this.props;
+
+    let Tag = getTagType(type);
+
+    let customControlClass = 'custom';
+
+    if (['radio', 'checkbox'].indexOf(type) > -1) {
+      customControlClass = `${customControlClass}-control custom-${type}`;
+    }else if ('radio-stacked' === type) {
+      customControlClass = `${customControlClass}-controls-${type}`;
+    } else {
+      customControlClass = `${customControlClass}-${type}`;
+    }
+
+    const classes = mapToCssModules(classNames(
+      className,
+      customControlClass
+    ), cssModule);
+
+    return (<Tag {...attributes} ref={getRef} className={classes} />);
+  }
+}
+
+CustomControl.propTypes = propTypes;
+CustomControl.defaultProps = defaultProps;
+
+export default CustomControl;

--- a/src/CustomControlStack.js
+++ b/src/CustomControlStack.js
@@ -1,0 +1,149 @@
+/* eslint react/prefer-stateless-function: 0 */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+export const Checkbox = (props) => {
+  const {
+    className,
+    name,
+    description,
+    getRef,
+    disabled,
+    ...attributes,
+  } = props;
+
+  return (
+    <label className={className}>
+      <input {...attributes} type="checkbox" className="custom-control-input" name={name} ref={getRef} disabled={disabled} />
+      <span className="custom-control-indicator"></span>
+      {description && (<span className="custom-control-description">{description}</span>)}
+    </label>
+  );
+}
+
+Checkbox.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+  name: PropTypes.string,
+  description: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
+  getRef: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  disabled: PropTypes.bool,
+};
+
+Checkbox.defaultProps = {
+  description: false
+};
+
+
+export const Radio = (props) => {
+  const {
+    className,
+    name,
+    description,
+    getRef,
+    disabled,
+    ...attributes,
+  } = props;
+
+  return (
+    <label className={className}>
+      <input {...attributes} type="radio" className="custom-control-input" name={name} ref={getRef} disabled={disabled} />
+      <span className="custom-control-indicator"></span>
+      {description && (<span className="custom-control-description">{description}</span>)}
+    </label>
+  );
+}
+
+Radio.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+  name: PropTypes.string,
+  description: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
+  getRef: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  disabled: PropTypes.bool,
+};
+
+Radio.defaultProps = {
+  description: false
+};
+
+export const Stacked = (props) => {
+  const {
+    children,
+    className,
+    ...attributes,
+  } = props;
+
+  return (
+    <div className="custom-controls-stacked">
+      {children}
+    </div>
+  );
+}
+
+Stacked.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+};
+
+Stacked.defaultProps = {};
+
+export const Select = (props) => {
+  const {
+    children,
+    className,
+    getRef,
+    disabled,
+    ...attributes,
+  } = props;
+
+  return (
+    <select {...attributes} className={className} ref={getRef} disabled={disabled} >
+      {children}
+    </select>
+  );
+}
+
+Select.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+  getRef: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  disabled: PropTypes.bool,
+};
+
+Select.defaultProps = {
+  disabled: false
+};
+
+export const File = (props) => {
+  const {
+    children,
+    className,
+    getRef,
+    disabled,
+    lang,
+    ...attributes,
+  } = props;
+
+  return (
+    <label className={className}>
+      <input {...attributes} type="file" className="custom-file-input" disabled={disabled} />
+      <span className="custom-file-control" lang={lang}></span>
+    </label>
+  );
+}
+
+File.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+  getRef: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  disabled: PropTypes.bool,
+  lang: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
+};
+
+File.defaultProps = {
+  lang: 'en',
+  disabled: false,
+};

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ import Button from './Button';
 import ButtonDropdown from './ButtonDropdown';
 import ButtonGroup from './ButtonGroup';
 import ButtonToolbar from './ButtonToolbar';
+import CustomControl from './CustomControl';
 import Dropdown from './Dropdown';
 import DropdownItem from './DropdownItem';
 import DropdownMenu from './DropdownMenu';
@@ -137,6 +138,7 @@ export {
   FormFeedback,
   FormGroup,
   FormText,
+  CustomControl,
   Input,
   InputGroup,
   InputGroupAddon,

--- a/src/utils.js
+++ b/src/utils.js
@@ -167,3 +167,9 @@ export function omit(obj, omitKeys) {
   });
   return result;
 }
+
+export function tagMapper(elements) {
+  return function(tag) {
+    return elements && elements[tag] ? elements[tag] : (() => null);
+  };
+}


### PR DESCRIPTION
feat (Custom Form Inputs #534): add support for custom inputs

+ created tagMapper - map type to element
+ expose CustomControl object (src/index.js)
+ CustomControlStack (Checkbox, Radio, Select, File) inputs
+ create example for (Checkbox, Radio, Select, File) inputs

- Unit test pending initial review.

github issue: https://github.com/reactstrap/reactstrap/issues/534