### PR TITLE
Updated peerDependencies (react, react-dom and react-transition-group…

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,9 +94,9 @@
     "reactstrap-tether": "1.3.4"
   },
   "peerDependencies": {
-    "react": "^0.14.9 || ^15.3.0",
-    "react-dom": "^0.14.9 || ^15.3.0",
-    "react-transition-group": "^1.1.2"
+    "react": "^0.14.9 || ^15.3.0 || ^16.0.0",
+    "react-dom": "^0.14.9 || ^15.3.0 || ^16.0.0",
+    "react-transition-group": "^1.1.2 || ^2.2.0"
   },
   "devDependencies": {
     "babel-cli": "^6.14.0",


### PR DESCRIPTION
…) to support the latest versions

Currently this doesnt work with the create-react-app cli
I did a fresh "create-react-app my-app" then I cd into my-app and do a "npm install --save reactstrap"

It gives me the following output:
npm WARN reactstrap@4.8.0 requires a peer of react@^0.14.9 || ^15.3.0 but none was installed.
npm WARN reactstrap@4.8.0 requires a peer of react-dom@^0.14.9 || ^15.3.0 but none was installed.
npm WARN reactstrap@4.8.0 requires a peer of react-transition-group@^1.1.2 but none was installed.

So i check the peerDependencies in the package.json and saw some old version numbers and thought that I would update them to support the next versions as well(branch 5.0's package.json says ^16.0.0 thats why it says ^16.0.0 and 2.2.0 for the newest react-transition-group which I tested works fine)

Secondly the readme says:
npm install --save reactstrap react-transition-group@^1.1.2 react@^15.3.0 react-dom@^15.3.0

When I run that I get "zsh: no matches found: react-transition-group@^1.1.2" this might be a Mac problem or even my shell zsh specifying a range the "^"? Im running npm 5.0.3. It doesnt work on my end.
I was thinking about to update the readme to say
npm install --save reactstrap react-transition-group react react-dom but I would like to get your feedback on this I guess there is a reason why you have the versions there. 





