### PR TITLE
fix(PaginationLink): handle empty children array correctly

### DIFF
--- a/src/PaginationLink.js
+++ b/src/PaginationLink.js
@@ -48,7 +48,7 @@ const PaginationLink = (props) => {
   }
 
   let children = props.children;
-  if (children && !children.length) {
+  if (children && Array.isArray(children) && children.length === 0) {
     children = null;
   }
 

--- a/src/__tests__/PaginationLink.spec.js
+++ b/src/__tests__/PaginationLink.spec.js
@@ -60,8 +60,14 @@ describe('PaginationLink', () => {
     expect(wrapper.find('.sr-only').text()).toBe('Yo');
   });
 
-  it('should render custom caret', () => {
+  it('should render custom caret specified as a string', () => {
     const wrapper = shallow(<PaginationLink next>Yo</PaginationLink>);
+
+    expect(wrapper.find({ 'aria-hidden': 'true' }).text()).toBe('Yo');
+  });
+
+  it('should render custom caret specified as a component', () => {
+    const wrapper = shallow(<PaginationLink next><span>Yo</span></PaginationLink>);
 
     expect(wrapper.find({ 'aria-hidden': 'true' }).text()).toBe('Yo');
   });


### PR DESCRIPTION
The fix on #511 broke PaginationLink for any children that does not contain a `length` property.

This PR fixes it.