### PR TITLE
feat(getTarget): throw when string not in DOM

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -120,6 +120,9 @@ export function getTarget(target) {
     if (selection === null) {
       return document.querySelector(`#${target}`);
     }
+    if (selection === null) {
+      throw new Error(`The target '${target}' could not be identified in the dom, tip: check spelling`);
+    }
     return selection;
   }
 


### PR DESCRIPTION
Previously it when a string target was not found in the DOM via querySelector, it would just return the `null` and bomb elswhere
Now an error is thrown to help the developer track down the issue.

Closes #620