### PR TITLE
fix(getTarget): do not return null; throw

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -116,9 +116,9 @@ export function getTarget(target) {
   }
 
   if (typeof target === 'string' && document) {
-    const selection = document.querySelector(target);
+    let selection = document.querySelector(target);
     if (selection === null) {
-      return document.querySelector(`#${target}`);
+      selection = document.querySelector(`#${target}`);
     }
     if (selection === null) {
       throw new Error(`The target '${target}' could not be identified in the dom, tip: check spelling`);


### PR DESCRIPTION
If it returns as it did does, it would be able to return null as it would immediately return and not go into the null check with throws.