### PR TITLE
 #607 animation on modal mounting

### DIFF
--- a/src/Fade.js
+++ b/src/Fade.js
@@ -57,7 +57,7 @@ function Fade(props) {
   return (
     <Transition {...transitionProps}>
       {(status) => {
-        const isActive = status === 'entering' || status === 'entered';
+        const isActive = status === 'entered';
         const classes = mapToCssModules(classNames(
           className,
           baseClass,


### PR DESCRIPTION
@TheSharpieOne ok so I know this change looks a little ridiculous, but I definitely did a decent amount of investigating and debugging on the timing of when the transition classes are applied, when rendering into subtree is occurs after adding a new div to the document.body, other ways to re-draw the transition after rendering the first time, the list goes on.

Oddly enough, this fix seems to work where adding the `fade show` class only when `status === 'entered'`, allows `Transition` to work correctly with the fade in.  I guess react-transition-group's `'exiting'` to `'entering'` event transition doesn't play well with React 16.

Let me know your thoughts / test it on your machine, it seems to work on my environment.  Sorry, I know it might seem kind of weird that it came to this one line change, but it seems to work and I like to try to keep PRs as simple as possible. 