### PR TITLE
docs(DropdownItem): add DropItem props section (#632)

### DIFF
--- a/docs/lib/Components/DropdownsPage.js
+++ b/docs/lib/Components/DropdownsPage.js
@@ -82,6 +82,19 @@ DropdownMenu.propTypes = {
   flip: PropTypes.bool, // default: true,
   className: PropTypes.string,
   cssModule: PropTypes.object,
+};
+
+DropdownItem.propTypes = {
+  children: PropTypes.node,
+  active: PropTypes.bool,
+  disabled: PropTypes.bool,
+  divider: PropTypes.bool,
+  tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  header: PropTypes.bool,
+  onClick: PropTypes.func,
+  className: PropTypes.string,
+  cssModule: PropTypes.object,
+  toggle: PropTypes.bool // default: true
 };`}
           </PrismCode>
         </pre>


### PR DESCRIPTION
Added a list of `DropdownItem` props inside the "Properties" section of [DropdownsPage.js](https://github.com/reactstrap/reactstrap/blob/master/docs/lib/Components/DropdownsPage.js), according to #632.