### PR TITLE
fix(Modal): Do not trigger toggle when transitioning out

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
   "homepage": "https://github.com/reactstrap/reactstrap#readme",
   "dependencies": {
     "classnames": "^2.2.3",
+    "lodash.debounce": "^4.0.8",
     "lodash.isfunction": "^3.0.8",
     "lodash.isobject": "^3.0.2",
     "lodash.tonumber": "^4.0.3",

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -1,3 +1,4 @@
+import debounce from 'lodash.debounce';
 import React from 'react';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
@@ -78,6 +79,7 @@ class Modal extends React.Component {
     this.togglePortal = this.togglePortal.bind(this);
     this.handleBackdropClick = this.handleBackdropClick.bind(this);
     this.handleEscape = this.handleEscape.bind(this);
+    this.handleEscapeDebounced = debounce(this.handleEscape, 250, { leading: true, trailing: false });
     this.destroy = this.destroy.bind(this);
     this.onOpened = this.onOpened.bind(this);
     this.onClosed = this.onClosed.bind(this);
@@ -122,6 +124,10 @@ class Modal extends React.Component {
   }
 
   handleEscape(e) {
+    // If the modal should not be open, but the listener is alive,
+    // we're already transitioning to close the modal.
+    if (this.props.isOpen !== true) return;
+
     if (this.props.keyboard && e.keyCode === 27 && this.props.toggle) {
       this.props.toggle();
     }
@@ -129,6 +135,9 @@ class Modal extends React.Component {
 
   handleBackdropClick(e) {
     if (this.props.backdrop !== true) return;
+    // If the modal should not be open, but we can click the backdrop,
+    // we're already transitioning to close the modal.
+    if (this.props.isOpen !== true) return;
 
     const container = this._dialog;
 
@@ -241,7 +250,7 @@ class Modal extends React.Component {
 
     const modalAttributes = {
       onClickCapture: this.handleBackdropClick,
-      onKeyUp: this.handleEscape,
+      onKeyUp: this.handleEscapeDebounced,
       style: { display: 'block' },
       'aria-labelledby': labelledBy,
       role,


### PR DESCRIPTION
I'm not sure, if the approach here is suitable. Using debounce will likely have some corner cases (such as the toggle callback taking a very long time to decide whether or not to close the modal). 

However, using "isOpen" seems to be the best way to check, if we're transitioning out. If you can suggest a better way, I'm happy to change the PR.