### PR TITLE
feat(CarouselItem): support tag prop on carousel item

### DIFF
--- a/docs/lib/Components/CarouselPage.js
+++ b/docs/lib/Components/CarouselPage.js
@@ -23,7 +23,7 @@ export default class CarouselPage extends React.Component {
           </PrismCode>
         </pre>
 
-        <h3>Properties</h3>
+        <h3>Carousel Properties</h3>
         <pre>
           <PrismCode className="language-jsx">
 {`Carousel.propTypes = {
@@ -56,6 +56,59 @@ export default class CarouselPage extends React.Component {
   // controls whether the slide animation on the Carousel works or not
   slide: PropTypes.bool,
   cssModule: PropTypes.object,
+};`}
+          </PrismCode>
+        </pre>
+
+        <h3>CarouselItem Properties</h3>
+        <pre>
+          <PrismCode className="language-jsx">
+{`CarouselItem.propTypes = {
+  ...Transition.propTypes,
+  tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  in: PropTypes.bool,
+  src: PropTypes.string,
+  altText: PropTypes.string,
+  cssModule: PropTypes.object,
+  children: PropTypes.shape({
+    type: PropTypes.oneOf([CarouselCaption]),
+  }),
+  slide: PropTypes.bool,
+};`}
+          </PrismCode>
+        </pre>
+
+        <h3>CarouselControl Properties</h3>
+        <pre>
+          <PrismCode className="language-jsx">
+{`CarouselControl.propTypes = {
+  direction: PropTypes.oneOf(['prev', 'next']).isRequired,
+  onClickHandler: PropTypes.func.isRequired,
+  cssModule: PropTypes.object,
+  directionText: PropTypes.string
+};`}
+          </PrismCode>
+        </pre>
+
+        <h3>CarouselIndicators Properties</h3>
+        <pre>
+          <PrismCode className="language-jsx">
+{`CarouselIndicators.propTypes = {
+  items: PropTypes.array.isRequired,
+  activeIndex: PropTypes.number.isRequired,
+  cssModule: PropTypes.object,
+  onClickHandler: PropTypes.func.isRequired
+};`}
+          </PrismCode>
+        </pre>
+
+        <h3>CarouselCaption Properties</h3>
+        <pre>
+          <PrismCode className="language-jsx">
+{`CarouselCaption.propTypes = {
+  captionHeader: PropTypes.string,
+  captionText: PropTypes.string.isRequired,
+  cssModule: PropTypes.object
 };`}
           </PrismCode>
         </pre>

--- a/src/CarouselItem.js
+++ b/src/CarouselItem.js
@@ -50,7 +50,7 @@ class CarouselItem extends React.Component {
   }
 
   render() {
-    const { src, altText, in: isIn, children, cssModule, slide, ...transitionProps } = this.props;
+    const { src, altText, in: isIn, children, cssModule, slide, tag: Tag, ...transitionProps } = this.props;
     const imgClasses = mapToCssModules(classNames(
       'd-block',
       'img-fluid'
@@ -85,7 +85,7 @@ class CarouselItem extends React.Component {
 
           return (
             <div className={itemClasses}>
-              <img className={imgClasses} src={src} alt={altText} />
+              <Tag className={imgClasses} src={src} alt={altText} />
               {children}
             </div>
           );
@@ -97,8 +97,9 @@ class CarouselItem extends React.Component {
 
 CarouselItem.propTypes = {
   ...Transition.propTypes,
+  tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   in: PropTypes.bool,
-  src: PropTypes.string.isRequired,
+  src: PropTypes.string,
   altText: PropTypes.string,
   cssModule: PropTypes.object,
   children: PropTypes.shape({
@@ -109,6 +110,7 @@ CarouselItem.propTypes = {
 
 CarouselItem.defaultProps = {
   ...Transition.defaultProps,
+  tag: 'img',
   timeout: TransitionTimeouts.Carousel,
   slide: true,
 };

--- a/src/__tests__/Carousel.spec.js
+++ b/src/__tests__/Carousel.spec.js
@@ -30,9 +30,14 @@ describe('Carousel', () => {
   });
 
   describe('items', () => {
-    it('should render an img tag', () => {
+    it('should render an img tag by default', () => {
       const wrapper = mount(<CarouselItem src={items[0].src} altText={items[0].src} />);
       expect(wrapper.find('img').length).toEqual(1);
+    });
+
+    it('should render custom tag', () => {
+      const wrapper = mount(<CarouselItem tag="image" />);
+      expect(wrapper.find('image').length).toBe(1);
     });
 
     it('should render a caption if one is passed in', () => {


### PR DESCRIPTION
The ```img``` tag is hardcoded in CarouselItem.
This PR fixes it.