### PR TITLE
Replace pull/push with order

### DIFF
--- a/docs/lib/Components/LayoutPage.js
+++ b/docs/lib/Components/LayoutPage.js
@@ -50,8 +50,7 @@ const columnProps = PropTypes.oneOfType([
     // 12 || "12" => col-12 or col-\`width\`-12
     // auto => col-auto or col-\`width\`-auto
     // true => col or col-\`width\`
-    push: stringOrNumberProp,
-    pull: stringOrNumberProp,
+    order: stringOrNumberProp,
     offset: stringOrNumberProp
   })
 ]);

--- a/docs/lib/Components/index.js
+++ b/docs/lib/Components/index.js
@@ -133,7 +133,7 @@ class Components extends React.Component {
     return (
       <Container className="content">
         <Row>
-          <Col md={3} className="order-md-12">
+          <Col md={{ size: 3, order: 2 }}>
             <div className="docs-sidebar mb-3">
               <h5>Components</h5>
               <Nav className="flex-column">
@@ -146,7 +146,7 @@ class Components extends React.Component {
               </Nav>
             </div>
           </Col>
-          <Col md={9} className="order-md-1">
+          <Col md={{ size: 9, order: 1 }}>
             {this.props.children}
           </Col>
         </Row>

--- a/docs/lib/Utilities/index.js
+++ b/docs/lib/Utilities/index.js
@@ -37,7 +37,7 @@ class Utilities extends React.Component {
     return (
       <Container className="content">
         <Row>
-          <Col md={{ size: 3, push: 9 }}>
+          <Col md={{ size: 3, order: 2 }}>
             <div className="docs-sidebar mb-3">
               <h5>Utilities</h5>
               <Nav className="flex-column">
@@ -47,7 +47,7 @@ class Utilities extends React.Component {
               </Nav>
             </div>
           </Col>
-          <Col md={{ size: 9, pull: 3 }}>
+          <Col md={{ size: 9, order: 1 }}>
             {this.props.children}
           </Col>
         </Row>

--- a/docs/lib/examples/Layout.js
+++ b/docs/lib/examples/Layout.js
@@ -29,7 +29,7 @@ export default class Example extends React.Component {
           <Col sm="4">.col .col-sm-4</Col>
         </Row>
         <Row>
-          <Col sm={{ size: 6, push: 2, pull: 2, offset: 1 }}>.col .col-sm-6 .col-sm-push-2 .col-sm-pull-2 .col-sm-offset-2</Col>
+          <Col sm={{ size: 6, order: 2, offset: 1 }}>.col .col-sm-6 .col-sm-order-2 .col-sm-offset-2</Col>
         </Row>
         <Row>
           <Col sm="12" md={{ size: 8, offset: 2 }}>.col .col-sm-12 .col-md-6 .col-md-offset-3</Col>

--- a/src/Col.js
+++ b/src/Col.js
@@ -2,7 +2,7 @@ import isobject from 'lodash.isobject';
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { mapToCssModules } from './utils';
+import { mapToCssModules, deprecated } from './utils';
 
 const colWidths = ['xs', 'sm', 'md', 'lg', 'xl'];
 const stringOrNumberProp = PropTypes.oneOfType([PropTypes.number, PropTypes.string]);
@@ -13,8 +13,9 @@ const columnProps = PropTypes.oneOfType([
   PropTypes.string,
   PropTypes.shape({
     size: PropTypes.oneOfType([PropTypes.bool, PropTypes.number, PropTypes.string]),
-    push: stringOrNumberProp,
-    pull: stringOrNumberProp,
+    push: deprecated(stringOrNumberProp, 'Please use the prop "order"'),
+    pull: deprecated(stringOrNumberProp, 'Please use the prop "order"'),
+    order: stringOrNumberProp,
     offset: stringOrNumberProp
   })
 ]);
@@ -78,8 +79,7 @@ const Col = (props) => {
 
       colClasses.push(mapToCssModules(classNames({
         [colClass]: columnProp.size || columnProp.size === '',
-        [`push${colSizeInterfix}${columnProp.push}`]: columnProp.push || columnProp.push === 0,
-        [`pull${colSizeInterfix}${columnProp.pull}`]: columnProp.pull || columnProp.pull === 0,
+        [`order${colSizeInterfix}${columnProp.order}`]: columnProp.order || columnProp.order === 0,
         [`offset${colSizeInterfix}${columnProp.offset}`]: columnProp.offset || columnProp.offset === 0
       })), cssModule);
     } else {

--- a/src/Label.js
+++ b/src/Label.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import isobject from 'lodash.isobject';
-import { mapToCssModules } from './utils';
+import { mapToCssModules, deprecated } from './utils';
 
 const colWidths = ['xs', 'sm', 'md', 'lg', 'xl'];
 
@@ -13,8 +13,9 @@ const columnProps = PropTypes.oneOfType([
   PropTypes.number,
   PropTypes.shape({
     size: stringOrNumberProp,
-    push: stringOrNumberProp,
-    pull: stringOrNumberProp,
+    push: deprecated(stringOrNumberProp, 'Please use the prop "order"'),
+    pull: deprecated(stringOrNumberProp, 'Please use the prop "order"'),
+    order: stringOrNumberProp,
     offset: stringOrNumberProp,
   }),
 ]);
@@ -84,8 +85,7 @@ const Label = (props) => {
 
       colClasses.push(mapToCssModules(classNames({
         [colClass]: columnProp.size || columnProp.size === '',
-        [`push${colSizeInterfix}${columnProp.push}`]: columnProp.push || columnProp.push === 0,
-        [`pull${colSizeInterfix}${columnProp.pull}`]: columnProp.pull || columnProp.pull === 0,
+        [`order${colSizeInterfix}${columnProp.order}`]: columnProp.order || columnProp.order === 0,
         [`offset${colSizeInterfix}${columnProp.offset}`]: columnProp.offset || columnProp.offset === 0
       })), cssModule);
     } else {

--- a/src/__tests__/Col.spec.js
+++ b/src/__tests__/Col.spec.js
@@ -30,11 +30,10 @@ describe('Col', () => {
   });
 
   it('should allow custom columns to be defined with objects', () => {
-    const wrapper = shallow(<Col widths={['base', 'jumbo', 'wtf']} wtf={{ size: 1, push: 2, pull: 3, offset: 4 }} />);
+    const wrapper = shallow(<Col widths={['base', 'jumbo', 'wtf']} wtf={{ size: 1, order: 2, offset: 4 }} />);
 
     expect(wrapper.hasClass('col-wtf-1')).toBe(true);
-    expect(wrapper.hasClass('push-wtf-2')).toBe(true);
-    expect(wrapper.hasClass('pull-wtf-3')).toBe(true);
+    expect(wrapper.hasClass('order-wtf-2')).toBe(true);
     expect(wrapper.hasClass('offset-wtf-4')).toBe(true);
     expect(wrapper.hasClass('col')).toBe(true);
   });
@@ -61,28 +60,26 @@ describe('Col', () => {
   });
 
   it('should pass col size specific classes via Objects', () => {
-    const wrapper = shallow(<Col sm={{ size: 6, push: 2, pull: 2, offset: 2 }} />);
+    const wrapper = shallow(<Col sm={{ size: 6, order: 2, offset: 2 }} />);
 
     expect(wrapper.hasClass('col-sm-6')).toBe(true);
     expect(wrapper.hasClass('col')).toBe(true);
-    expect(wrapper.hasClass('push-sm-2')).toBe(true);
-    expect(wrapper.hasClass('pull-sm-2')).toBe(true);
+    expect(wrapper.hasClass('order-sm-2')).toBe(true);
     expect(wrapper.hasClass('offset-sm-2')).toBe(true);
   });
 
   it('should pass col size specific classes via Objects including 0', () => {
-    const wrapper = shallow(<Col sm={{ size: 6, push: 0, pull: 0, offset: 0 }} />);
+    const wrapper = shallow(<Col sm={{ size: 6, order: 0, offset: 0 }} />);
 
     expect(wrapper.hasClass('col-sm-6')).toBe(true);
     expect(wrapper.hasClass('col')).toBe(true);
-    expect(wrapper.hasClass('push-sm-0')).toBe(true);
-    expect(wrapper.hasClass('pull-sm-0')).toBe(true);
+    expect(wrapper.hasClass('order-sm-0')).toBe(true);
     expect(wrapper.hasClass('offset-sm-0')).toBe(true);
   });
 
   it('should pass col size when passing via object with size "auto"', () => {
     const wrapper = shallow(<Col
-      sm={{ size: 'auto', push: 2, pull: 2, offset: 2 }}
+      sm={{ size: 'auto', offset: 2 }}
     />);
 
     expect(wrapper.hasClass('col-sm-auto')).toBe(true);

--- a/src/__tests__/Label.spec.js
+++ b/src/__tests__/Label.spec.js
@@ -130,37 +130,32 @@ describe('Label', () => {
   });
 
   it('should pass col size specific classes via Objects', () => {
-    const wrapper = shallow(<Label sm={{ size: 6, push: 2, pull: 2, offset: 2 }}>Yo!</Label>);
+    const wrapper = shallow(<Label sm={{ size: 6, order: 2, offset: 2 }}>Yo!</Label>);
 
     expect(wrapper.hasClass('col-sm-6')).toBe(true);
-    expect(wrapper.hasClass('push-sm-2')).toBe(true);
-    expect(wrapper.hasClass('pull-sm-2')).toBe(true);
+    expect(wrapper.hasClass('order-sm-2')).toBe(true);
     expect(wrapper.hasClass('offset-sm-2')).toBe(true);
   });
 
   it('should pass col size specific classes via Objects (xs)', () => {
-    const wrapper = shallow(<Label xs={{ size: 6, push: 2, pull: 2, offset: 2 }}>Yo!</Label>);
+    const wrapper = shallow(<Label xs={{ size: 6, order: 2, offset: 2 }}>Yo!</Label>);
 
     expect(wrapper.hasClass('col-6')).toBe(true);
-    expect(wrapper.hasClass('push-2')).toBe(true);
-    expect(wrapper.hasClass('pull-2')).toBe(true);
+    expect(wrapper.hasClass('order-2')).toBe(true);
     expect(wrapper.hasClass('offset-2')).toBe(true);
   });
 
   it('should pass multiple col size specific classes via Objects', () => {
-    const wrapper = shallow(<Label xs={{ size: 4, push: 3, pull: 3, offset: 3 }} sm={{ size: 6, push: 2, pull: 2, offset: 2 }} md={{ size: 7, push: 1, pull: 1, offset: 1 }}>Yo!</Label>);
+    const wrapper = shallow(<Label xs={{ size: 4, order: 3, offset: 3 }} sm={{ size: 6, order: 2, offset: 2 }} md={{ size: 7, order: 1, offset: 1 }}>Yo!</Label>);
 
     expect(wrapper.hasClass('col-4')).toBe(true);
-    expect(wrapper.hasClass('push-3')).toBe(true);
-    expect(wrapper.hasClass('pull-3')).toBe(true);
+    expect(wrapper.hasClass('order-3')).toBe(true);
     expect(wrapper.hasClass('offset-3')).toBe(true);
     expect(wrapper.hasClass('col-sm-6')).toBe(true);
-    expect(wrapper.hasClass('push-sm-2')).toBe(true);
-    expect(wrapper.hasClass('pull-sm-2')).toBe(true);
+    expect(wrapper.hasClass('order-sm-2')).toBe(true);
     expect(wrapper.hasClass('offset-sm-2')).toBe(true);
     expect(wrapper.hasClass('col-md-7')).toBe(true);
-    expect(wrapper.hasClass('push-md-1')).toBe(true);
-    expect(wrapper.hasClass('pull-md-1')).toBe(true);
+    expect(wrapper.hasClass('order-md-1')).toBe(true);
     expect(wrapper.hasClass('offset-md-1')).toBe(true);
   });
 


### PR DESCRIPTION
Removed `pull`/`push` from `columnProps` and added `order` (in `Col` and `Label`). I deprecated the props but they won't work at all now; too complex to convert to `order`.

https://github.com/reactstrap/reactstrap/issues/575#issuecomment-338847760