### PR TITLE
Fix error on `CarouselIndicators` class name when using `cssModule`

### DIFF
--- a/src/CarouselIndicators.js
+++ b/src/CarouselIndicators.js
@@ -6,7 +6,7 @@ import { mapToCssModules } from './utils';
 const CarouselIndicators = (props) => {
   const { items, activeIndex, cssModule, onClickHandler, className } = props;
 
-  const listClasses = mapToCssModules(classNames(className, 'carousel-indicators', cssModule));
+  const listClasses = mapToCssModules(classNames(className, 'carousel-indicators'), cssModule);
   const indicators = items.map((item, idx) => {
     const indicatorClasses = mapToCssModules(classNames(
       { active: activeIndex === idx }


### PR DESCRIPTION
Fix error in the `CarouselIndicators` component that set all the items passed in the `cssModule` prop as its class name.