### PR TITLE
Add ESLint configuration file for docs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -41,6 +41,7 @@ var rules = {
 };
 
 module.exports = {
+  "root": true,
   'extends': 'airbnb',
   'env': {
     'browser': true,

--- a/docs/.eslintrc.js
+++ b/docs/.eslintrc.js
@@ -1,0 +1,7 @@
+var rules = {
+    'import/no-extraneous-dependencies': 0,
+};
+
+module.exports = {
+    rules: rules,
+};


### PR DESCRIPTION
The reasoning for this change is to get rid of ESLint errors shown in the IDEs
that use ESLint plugins (e.g. VSCode) because the ESLint default rules for importing
extraneus modules are not observed in docs app - it uses the modules that are not
listed in main content dependencies section.

Thanks!