### PR TITLE
chore(docs): upgrade to bootstrap 4.0.0-beta.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Then open [http://localhost:3000/](http://localhost:3000/) to see your app. The 
 Install reactstrap and Bootstrap from NPM. Reactstrap does not include Bootstrap CSS so this needs to be installed as well:
 
 ```
-npm install --save bootstrap@4.0.0-beta.2
+npm install --save bootstrap@4.0.0-beta.3
 npm install --save reactstrap@next react@^16.0.0 react-dom@^16.0.0
 ```
 

--- a/docs/lib/Home/index.js
+++ b/docs/lib/Home/index.js
@@ -66,7 +66,7 @@ npm start`}
             <p>Install reactstrap and Bootstrap from NPM. Reactstrap does not include Bootstrap CSS so this needs to be installed as well:</p>
             <pre>
               <PrismCode className="language-bash">
-  {`npm install bootstrap@4.0.0-beta.2 --save
+  {`npm install bootstrap@4.0.0-beta.3 --save
 npm install --save reactstrap@next react react-dom`}
               </PrismCode>
             </pre>

--- a/docs/lib/examples/FormGrid.js
+++ b/docs/lib/examples/FormGrid.js
@@ -46,7 +46,7 @@ export default class Example extends React.Component {
           </Col>
         </FormGroup>
         <FormGroup tag="fieldset" row>
-          <legend className="col-form-legend col-sm-2">Radio Buttons</legend>
+          <legend className="col-form-label col-sm-2">Radio Buttons</legend>
           <Col sm={10}>
             <FormGroup check>
               <Label check>

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "babel-preset-es2015-rollup": "^3.0.0",
     "babel-preset-react": "^6.11.1",
     "babel-preset-react-app": "^0.2.1",
-    "bootstrap": "4.0.0-beta.2",
+    "bootstrap": "4.0.0-beta.3",
     "clean-webpack-plugin": "^0.1.8",
     "conventional-changelog-cli": "^1.1.1",
     "conventional-recommended-bump": "^0.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1439,9 +1439,9 @@ boom@5.x.x:
   dependencies:
     hoek "4.x.x"
 
-bootstrap@4.0.0-beta.2:
-  version "4.0.0-beta.2"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.0.0-beta.2.tgz#4d67d2aa2219f062cd90bc1247e6747b9e8fd051"
+bootstrap@4.0.0-beta.3:
+  version "4.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.0.0-beta.3.tgz#60f0660bc3d121176514b361f6f83201c7ff8874"
 
 boxen@^0.6.0:
   version "0.6.0"


### PR DESCRIPTION
Also changes `col-form-legend` to `col-form-label` in examples