### PR TITLE
Update docs to install bootstrap using --save-exact

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Then open [http://localhost:3000/](http://localhost:3000/) to see your app. The 
 Install reactstrap and Bootstrap from NPM. Reactstrap does not include Bootstrap CSS so this needs to be installed as well:
 
 ```
-npm install --save bootstrap@4.0.0-beta.2
+npm install --save-exact bootstrap@4.0.0-beta.2
 npm install --save reactstrap@next react@^16.0.0 react-dom@^16.0.0
 ```
 

--- a/docs/lib/Home/index.js
+++ b/docs/lib/Home/index.js
@@ -66,7 +66,7 @@ npm start`}
             <p>Install reactstrap and Bootstrap from NPM. Reactstrap does not include Bootstrap CSS so this needs to be installed as well:</p>
             <pre>
               <PrismCode className="language-bash">
-  {`npm install bootstrap@4.0.0-beta.2 --save
+  {`npm install bootstrap@4.0.0-beta.2 --save-exact
 npm install --save reactstrap@next react react-dom`}
               </PrismCode>
             </pre>


### PR DESCRIPTION
As the newly released `bootstrap@4.0.0-beta.3` is semantically compatible with `bootstrap@4.0.0-beta.2` users needs to install using `--save-exact`, to avoid the breaking changes from beta.3.