### PR TITLE
chore(docs): upgrade to bootstrap 4.0.0 (final)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Then open [http://localhost:3000/](http://localhost:3000/) to see your app. The 
 Install reactstrap and Bootstrap from NPM. Reactstrap does not include Bootstrap CSS so this needs to be installed as well:
 
 ```
-npm install --save bootstrap@4.0.0-beta.3
+npm install --save bootstrap@4.0.0
 npm install --save reactstrap@next react@^16.0.0 react-dom@^16.0.0
 ```
 
@@ -43,7 +43,7 @@ Import required reactstrap components within ```src/App.js``` file or your custo
 import { Button } from 'reactstrap';
 ```
 
-Now you are ready to use the imported reactstrap components within your component hierarchy defined in the render 
+Now you are ready to use the imported reactstrap components within your component hierarchy defined in the render
 method. Here is an example [`App.js`](https://gist.github.com/Thomas-Smyth/006fd507a7295f17a8473451938f9935) redone
 using reactstrap.
 
@@ -52,7 +52,7 @@ using reactstrap.
 ##### Required Peer Dependencies
 
 These libraries are not bundled with Reactstrap and required at runtime:
- 
+
   * [**react**](https://www.npmjs.com/package/react)
   * [**react-dom**](https://www.npmjs.com/package/react-dom)
 
@@ -62,13 +62,13 @@ These libraries are not included in the main distribution file `reactstrap.min.j
 included when using components that require transitions or popover effects (e.g. Tooltip, Modal, etc).
 
   * [**react-transition-group**](https://www.npmjs.com/package/react-transition-group)
-  * [**react-popper**](https://www.npmjs.com/package/react-popper) 
+  * [**react-popper**](https://www.npmjs.com/package/react-popper)
 
 
 ### CDN
 
 If you prefer to include Reactstrap globally by marking `reactstrap` as external in your application, the
-`reactstrap` library provides various single-file distributions, which are hosted on the following CDNs: 
+`reactstrap` library provides various single-file distributions, which are hosted on the following CDNs:
 
 * [**cdnjs**](https://cdnjs.com/libraries/reactstrap)
 ```html
@@ -92,29 +92,29 @@ If you prefer to include Reactstrap globally by marking `reactstrap` as external
 
 #### Versions
 
-Reactstrap has two primary distribution versions:  
+Reactstrap has two primary distribution versions:
 
 1) `reactstrap.min.js`
 
-    This file **excludes** the optional dependencies – `react-popper` and `react-transition-group`. 
-    This is the recommended approach (similar approach in Bootstrap's JavaScript components) for including 
+    This file **excludes** the optional dependencies – `react-popper` and `react-transition-group`.
+    This is the recommended approach (similar approach in Bootstrap's JavaScript components) for including
     Reactstrap as it reduces the filesize and gives more flexibility in configuring needed dependencies.
-    
+
     **Recommended use cases:**
-    
+
       * Small, medium, or large applications
       * Applications that do not use any transitions or popper components
       * Applications that directly use `react-popper` or `react-transition-group` – Reactstrap and your application
         will use the single global version included
 
  2) `reactstrap.full.min.js`
-     
+
     This file **includes** the optional dependencies – `react-popper` and `react-transition-group`
-     
+
     **Recommended use cases:**
 
       * Small applications
-           
+
 
 #### Example
 

--- a/docs/lib/Home/index.js
+++ b/docs/lib/Home/index.js
@@ -66,7 +66,7 @@ npm start`}
             <p>Install reactstrap and Bootstrap from NPM. Reactstrap does not include Bootstrap CSS so this needs to be installed as well:</p>
             <pre>
               <PrismCode className="language-bash">
-  {`npm install bootstrap@4.0.0-beta.3 --save
+  {`npm install bootstrap --save
 npm install --save reactstrap@next react react-dom`}
               </PrismCode>
             </pre>

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "babel-preset-es2015-rollup": "^3.0.0",
     "babel-preset-react": "^6.11.1",
     "babel-preset-react-app": "^0.2.1",
-    "bootstrap": "4.0.0-beta.3",
+    "bootstrap": "^4.0.0",
     "clean-webpack-plugin": "^0.1.8",
     "conventional-changelog-cli": "^1.1.1",
     "conventional-recommended-bump": "^0.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1439,9 +1439,9 @@ boom@5.x.x:
   dependencies:
     hoek "4.x.x"
 
-bootstrap@4.0.0-beta.3:
-  version "4.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.0.0-beta.3.tgz#60f0660bc3d121176514b361f6f83201c7ff8874"
+bootstrap@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.0.0.tgz#ceb03842c145fcc1b9b4e15da2a05656ba68469a"
 
 boxen@^0.6.0:
   version "0.6.0"


### PR DESCRIPTION
No breaking changes, just bug fixes and minor features. http://blog.getbootstrap.com/2018/01/18/bootstrap-4/

supersedes #760 