### PR TITLE
Use `h5` for ModalHeader

### DIFF
--- a/src/ModalHeader.js
+++ b/src/ModalHeader.js
@@ -14,7 +14,7 @@ const propTypes = {
 };
 
 const defaultProps = {
-  tag: 'h4',
+  tag: 'h5',
   wrapTag: 'div',
   closeAriaLabel: 'Close',
 };


### PR DESCRIPTION
According to the [Bootstrap docs](https://getbootstrap.com/docs/4.0/components/modal/#modal-components), H5 is the preferred tag. Using H4 results in a misaligned close button on the modal.