### PR TITLE
fix(CardTitle): default tag to h5

### DIFF
--- a/src/CardTitle.js
+++ b/src/CardTitle.js
@@ -10,7 +10,7 @@ const propTypes = {
 };
 
 const defaultProps = {
-  tag: 'h4'
+  tag: 'h5'
 };
 
 const CardTitle = (props) => {

--- a/src/__tests__/CardTitle.spec.js
+++ b/src/__tests__/CardTitle.spec.js
@@ -24,4 +24,10 @@ describe('CardTitle', () => {
     expect(wrapper.hasClass('card-title')).toBe(true);
     expect(wrapper.find('h1').length).toBe(1);
   });
+
+  it('should render a "h5" tag by default', () => {
+    const wrapper = shallow(<CardTitle>Yo!</CardTitle>);
+
+    expect(wrapper.find('h5').length).toBe(1);
+  });
 });


### PR DESCRIPTION
 Bootstrap used "h5" tag in the docs by default. According to [documentation].(https://getbootstrap.com/docs/4.0/components/card/#titles-text-and-links)
This PR fixes it.