### PR TITLE
chore(UncontrolledNavDropdown): simplify logic

### DIFF
--- a/src/UncontrolledNavDropdown.js
+++ b/src/UncontrolledNavDropdown.js
@@ -1,22 +1,11 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { warnOnce } from './utils';
-import NavDropdown from './NavDropdown';
+import UncontrolledDropdown from './UncontrolledDropdown';
 
-export default class UncontrolledNavDropdown extends Component {
-  constructor(props) {
-    super(props);
+const UncontrolledNavDropdown = () => {
+  warnOnce('The "UncontrolledNavDropdown" component has been deprecated.\nPlease use component "UncontrolledDropdown" with nav prop.');
 
-    this.state = { isOpen: false };
-    this.toggle = this.toggle.bind(this);
-  }
+  return <UncontrolledDropdown nav {...this.props} />;
+};
 
-  toggle() {
-    this.setState({ isOpen: !this.state.isOpen });
-  }
-
-  render() {
-    warnOnce('The "UncontrolledNavDropdown" component has been deprecated.\nPlease use component "UncontrolledDropdown" with nav prop.');
-
-    return <NavDropdown isOpen={this.state.isOpen} toggle={this.toggle} {...this.props} />;
-  }
-}
+export default UncontrolledNavDropdown;


### PR DESCRIPTION
This simplifies the deprecated component to just return the preferred component (UncontrolledDropdown) with the nav prop
This removes the logic from the deprecated component.