### PR TITLE
feat(Popover/Tooltip): add ability to hide arrow (#814)

### DIFF
--- a/docs/lib/Components/PopoversPage.js
+++ b/docs/lib/Components/PopoversPage.js
@@ -41,6 +41,7 @@ export default class PopoversPage extends React.Component {
   // Apply class to the inner-popover
   innerClassName: PropTypes.string,
   disabled: PropTypes.bool,
+  hideArrow: PropTypes.bool,
   placementPrefix: PropTypes.string,
   delay: PropTypes.oneOfType([
     PropTypes.shape({ show: PropTypes.number, hide: PropTypes.number }),

--- a/docs/lib/Components/TooltipsPage.js
+++ b/docs/lib/Components/TooltipsPage.js
@@ -32,6 +32,7 @@ export default class TooltipsPage extends React.Component {
 {`Tooltip.propTypes = {
   // boolean to control the state of the tooltip
   isOpen: PropTypes.bool,
+  hideArrow: PropTypes.bool,
   // callback for toggling isOpen in the controlling component
   toggle: PropTypes.func,
   // target element or element ID, popover is attached to this element

--- a/src/Popover.js
+++ b/src/Popover.js
@@ -18,6 +18,7 @@ const propTypes = {
   ]),
   isOpen: PropTypes.bool,
   disabled: PropTypes.bool,
+  hideArrow: PropTypes.bool,
   className: PropTypes.string,
   innerClassName: PropTypes.string,
   placementPrefix: PropTypes.string,
@@ -37,6 +38,7 @@ const DEFAULT_DELAYS = {
 
 const defaultProps = {
   isOpen: false,
+  hideArrow: false,
   placement: 'right',
   placementPrefix: 'bs-popover',
   delay: DEFAULT_DELAYS,
@@ -173,6 +175,7 @@ class Popover extends React.Component {
         className={popperClasses}
         target={this.props.target}
         isOpen={this.props.isOpen}
+        hideArrow={this.props.hideArrow}
         placement={this.props.placement}
         placementPrefix={this.props.placementPrefix}
         container={this.props.container}

--- a/src/PopperContent.js
+++ b/src/PopperContent.js
@@ -10,6 +10,7 @@ const propTypes = {
   className: PropTypes.string,
   placement: PropTypes.string,
   placementPrefix: PropTypes.string,
+  hideArrow: PropTypes.bool,
   tag: PropTypes.string,
   isOpen: PropTypes.bool.isRequired,
   cssModule: PropTypes.object,
@@ -23,6 +24,7 @@ const propTypes = {
 
 const defaultProps = {
   placement: 'auto',
+  hideArrow: false,
   isOpen: false,
   offset: 0,
   fallbackPlacement: 'flip',
@@ -135,6 +137,7 @@ class PopperContent extends React.Component {
       offset,
       fallbackPlacement,
       placementPrefix,
+      hideArrow,
       className,
       tag,
       container,
@@ -162,7 +165,7 @@ class PopperContent extends React.Component {
     return (
       <ReactPopper modifiers={extendedModifiers} {...attrs} component={tag} className={popperClassName}>
         {children}
-        <Arrow className={arrowClassName} />
+        {hideArrow ? null : <Arrow className={arrowClassName} />}
       </ReactPopper>
     );
   }

--- a/src/PopperContent.js
+++ b/src/PopperContent.js
@@ -165,7 +165,7 @@ class PopperContent extends React.Component {
     return (
       <ReactPopper modifiers={extendedModifiers} {...attrs} component={tag} className={popperClassName}>
         {children}
-        {hideArrow ? null : <Arrow className={arrowClassName} />}
+        {!hideArrow && <Arrow className={arrowClassName} />}
       </ReactPopper>
     );
   }

--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -18,6 +18,7 @@ const propTypes = {
   ]),
   isOpen: PropTypes.bool,
   disabled: PropTypes.bool,
+  hideArrow: PropTypes.bool,
   className: PropTypes.string,
   innerClassName: PropTypes.string,
   cssModule: PropTypes.object,
@@ -38,6 +39,7 @@ const DEFAULT_DELAYS = {
 
 const defaultProps = {
   isOpen: false,
+  hideArrow: false,
   placement: 'top',
   placementPrefix: 'bs-tooltip',
   delay: DEFAULT_DELAYS,
@@ -193,6 +195,7 @@ class Tooltip extends React.Component {
         className={popperClasses}
         target={this.props.target}
         isOpen={this.props.isOpen}
+        hideArrow={this.props.hideArrow}
         placement={this.props.placement}
         placementPrefix={this.props.placementPrefix}
         container={this.props.container}

--- a/src/__tests__/Popover.spec.js
+++ b/src/__tests__/Popover.spec.js
@@ -33,6 +33,32 @@ describe('Popover', () => {
     element = null;
   });
 
+  it('should render with "hideArrow" false by default', () => {
+    isOpen = true;
+    const wrapper = mount(
+      <Popover isOpen={isOpen} toggle={toggle} placement={placement} target="innerTarget">
+        <PopoverHeader>Title</PopoverHeader>
+        <PopoverBody>Content</PopoverBody>
+      </Popover>
+    );
+
+    expect(wrapper.prop('hideArrow')).toBe(false);
+    wrapper.unmount();
+  });
+
+  it('should render with "hideArrow" true when "hideArrow" prop is truthy', () => {
+    isOpen = true;
+    const wrapper = mount(
+      <Popover isOpen={isOpen} toggle={toggle} placement={placement} target="innerTarget" hideArrow>
+        <PopoverHeader>Title</PopoverHeader>
+        <PopoverBody>Content</PopoverBody>
+      </Popover>
+    );
+
+    expect(wrapper.prop('hideArrow')).toBe(true);
+    wrapper.unmount();
+  });
+
   it('should render inner popper when isOpen', () => {
     isOpen = true;
     const wrapper = mount(

--- a/src/__tests__/PopperContent.spec.js
+++ b/src/__tests__/PopperContent.spec.js
@@ -48,6 +48,24 @@ describe('PopperContent', () => {
     expect(wrapper.containsMatchingElement(<Arrow />)).toBe(true);
   });
 
+  it('should NOT render an Arrow in the Popper when "hideArrow" is truthy', () => {
+    const wrapper = mount(<PopperContent target="target" isOpen container="inline" hideArrow>Yo!</PopperContent>);
+
+    expect(wrapper.containsMatchingElement(<Arrow />)).toBe(false);
+  });
+
+  it('should render with "hideArrow" false by default', () => {
+    const wrapper = mount(<PopperContent target="target">Yo!</PopperContent>);
+
+    expect(wrapper.prop('hideArrow')).toBe(false);
+  });
+
+  it('should render with "hideArrow" true when "hideArrow" prop is truthy', () => {
+    const wrapper = mount(<PopperContent target="target" hideArrow>Yo!</PopperContent>);
+
+    expect(wrapper.prop('hideArrow')).toBe(true);
+  });
+
   it('should not render children', () => {
     const wrapper = shallow(<PopperContent target="target">Yo!</PopperContent>);
 

--- a/src/__tests__/Tooltip.spec.js
+++ b/src/__tests__/Tooltip.spec.js
@@ -36,6 +36,24 @@ describe('Tooltip', () => {
     innerTarget = null;
   });
 
+  it('should render with "hideArrow" false by default', () => {
+    const wrapper = mount(
+      <Tooltip target="target" isOpen={isOpen} toggle={toggle}>
+        Tooltip Content
+      </Tooltip>);
+
+    expect(wrapper.prop('hideArrow')).toBe(false);
+  });
+
+  it('should render with "hideArrow" true when "hideArrow" prop is truthy', () => {
+    const wrapper = mount(
+      <Tooltip target="target" isOpen={isOpen} toggle={toggle} hideArrow>
+        Tooltip Content
+      </Tooltip>);
+
+    expect(wrapper.prop('hideArrow')).toBe(true);
+  });
+
   it('should not render children if isOpen is false', () => {
     const wrapper = mount(
       <Tooltip target="target" isOpen={isOpen} toggle={toggle}>


### PR DESCRIPTION
Added `hideArrow` prop to Popover, Tooltip and PopperContent according to #814  .