### PR TITLE
Support valid feedback messages.

### DIFF
--- a/docs/lib/examples/FormFeedback.js
+++ b/docs/lib/examples/FormFeedback.js
@@ -8,6 +8,7 @@ export default class Example extends React.Component {
         <FormGroup>
           <Label for="exampleEmail">Input with success</Label>
           <Input valid />
+          <FormFeedback valid>Oh noes! that name is already taken</FormFeedback>
           <FormText>Example help text that remains unchanged.</FormText>
         </FormGroup>
         <FormGroup>

--- a/src/FormFeedback.js
+++ b/src/FormFeedback.js
@@ -27,8 +27,7 @@ const FormFeedback = (props) => {
 
   const classes = mapToCssModules(classNames(
     className,
-    !valid && 'invalid-feedback',
-    valid && 'valid-feedback'
+    valid ? 'valid-feedback' : 'invalid-feedback'
   ), cssModule);
 
   return (

--- a/src/FormFeedback.js
+++ b/src/FormFeedback.js
@@ -8,23 +8,27 @@ const propTypes = {
   tag: PropTypes.string,
   className: PropTypes.string,
   cssModule: PropTypes.object,
+  valid: PropTypes.bool
 };
 
 const defaultProps = {
   tag: 'div',
+  valid: undefined
 };
 
 const FormFeedback = (props) => {
   const {
     className,
     cssModule,
+    valid,
     tag: Tag,
     ...attributes
   } = props;
 
   const classes = mapToCssModules(classNames(
     className,
-    'invalid-feedback'
+    !valid && 'invalid-feedback',
+    valid && 'valid-feedback'
   ), cssModule);
 
   return (

--- a/src/__tests__/FormFeedback.spec.js
+++ b/src/__tests__/FormFeedback.spec.js
@@ -21,6 +21,12 @@ describe('FormFeedback', () => {
     expect(wrapper.hasClass('invalid-feedback')).toBe(true);
   });
 
+  it('should render with "valid-feedback" class', () => {
+    const wrapper = shallow(<FormFeedback valid>Yo!</FormFeedback>);
+
+    expect(wrapper.hasClass('valid-feedback')).toBe(true);
+  });
+
   it('should render additional classes', () => {
     const wrapper = shallow(<FormFeedback className="other">Yo!</FormFeedback>);
 


### PR DESCRIPTION
Bootstrap supports form-validation success feedback messages: https://getbootstrap.com/docs/4.0/components/forms/

I added the possibility to provide a valid prop to the render method to add the `.feedback-valid` class instead of `.feedback-invalid`. It might be nicer if we would instead explicitly specify `invalid` or `valid={false}` but that would break the current behaviour. Any thoughts?