### PR TITLE
feat(Input): add invalid prop

### DIFF
--- a/docs/lib/Components/FormPage.js
+++ b/docs/lib/Components/FormPage.js
@@ -55,7 +55,8 @@ export default class FormPage extends React.Component {
   size: PropTypes.string,
   bsSize: PropTypes.string,
   state: deprecated(PropTypes.string, 'Please use the prop "valid"'),
-  valid: PropTypes.bool,
+  valid: PropTypes.bool, // applied the is-valid class when true, does nothing when false
+  invalid: PropTypes.bool, // applied the is-invalid class when true, does nothing when false
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   // ref will only get you a reference to the Input component, use innerRef to get a reference to the DOM input (for things like focus management).
   innerRef: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),

--- a/docs/lib/examples/FormFeedback.js
+++ b/docs/lib/examples/FormFeedback.js
@@ -6,14 +6,20 @@ export default class Example extends React.Component {
     return (
       <Form>
         <FormGroup>
-          <Label for="exampleEmail">Input with success</Label>
-          <Input valid />
-          <FormFeedback valid>Oh noes! that name is already taken</FormFeedback>
+          <Label for="exampleEmail">Input wihtout validation</Label>
+          <Input />
+          <FormFeedback>You will not be able to see this</FormFeedback>
           <FormText>Example help text that remains unchanged.</FormText>
         </FormGroup>
         <FormGroup>
-          <Label for="examplePassword">Input with danger</Label>
-          <Input valid={false} />
+          <Label for="exampleEmail">Valid input</Label>
+          <Input valid />
+          <FormFeedback valid>Sweet! that name is available</FormFeedback>
+          <FormText>Example help text that remains unchanged.</FormText>
+        </FormGroup>
+        <FormGroup>
+          <Label for="examplePassword">Invalid input</Label>
+          <Input invalid />
           <FormFeedback>Oh noes! that name is already taken</FormFeedback>
           <FormText>Example help text that remains unchanged.</FormText>
         </FormGroup>

--- a/src/Input.js
+++ b/src/Input.js
@@ -10,8 +10,9 @@ const propTypes = {
   type: PropTypes.string,
   size: PropTypes.string,
   bsSize: PropTypes.string,
-  state: deprecated(PropTypes.string, 'Please use the prop "valid"'),
+  state: deprecated(PropTypes.string, 'Please use the props "valid" and "invalid" to indicate the state.'),
   valid: PropTypes.bool,
+  invalid: PropTypes.bool,
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   innerRef: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   static: deprecated(PropTypes.bool, 'Please use the prop "plaintext"'),
@@ -34,6 +35,7 @@ class Input extends React.Component {
       bsSize,
       state,
       valid,
+      invalid,
       tag,
       addon,
       static: staticInput,
@@ -65,9 +67,9 @@ class Input extends React.Component {
       }
     }
 
-    if (state && typeof valid === 'undefined') {
+    if (state && typeof valid === 'undefined' && typeof invalid === 'undefined') {
       if (state === 'danger') {
-        valid = false;
+        invalid = true;
       } else if (state === 'success') {
         valid = true;
       }
@@ -81,7 +83,7 @@ class Input extends React.Component {
 
     const classes = mapToCssModules(classNames(
       className,
-      valid === false && 'is-invalid',
+      invalid && 'is-invalid',
       valid && 'is-valid',
       bsSize ? `form-control-${bsSize}` : false,
       formControlClass

--- a/src/__tests__/Input.spec.js
+++ b/src/__tests__/Input.spec.js
@@ -82,8 +82,20 @@ describe('Input', () => {
     expect(wrapper.hasClass('is-invalid')).toBe(false);
   });
 
-  it('should render with "is-invalid" class when valid is false', () => {
+  it('should not render with "is-invalid" class when valid is false', () => {
     const wrapper = shallow(<Input valid={false} />);
+
+    expect(wrapper.hasClass('is-invalid')).toBe(false);
+  });
+
+  it('should not render with "is-valid" class when invalid is false', () => {
+    const wrapper = shallow(<Input invalid={false} />);
+
+    expect(wrapper.hasClass('is-valid')).toBe(false);
+  });
+
+  it('should render with "is-invalid" class when invalid is true', () => {
+    const wrapper = shallow(<Input invalid />);
 
     expect(wrapper.hasClass('is-invalid')).toBe(true);
   });


### PR DESCRIPTION
Added invalid prop and modified valid prop to only apply class when true

Breaking Change: the valid prop no longer applies the is-invalid class when false. Use the new invalid prop to apply that class.

Closes #850