### PR TITLE
changed react-popper version to  ^0.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "lodash.isobject": "^3.0.2",
     "lodash.tonumber": "^4.0.3",
     "prop-types": "^15.5.8",
-    "react-popper": "0.8.1",
+    "react-popper": "^0.8.2",
     "react-portal": "^4.1.2",
     "react-transition-group": "^2.2.1"
   },


### PR DESCRIPTION
react-popper 0.8.1 not working with browserify, changing to 0.8.2 is good