### PR TITLE
docs(*): Add innerRef.

### DIFF
--- a/docs/lib/Components/ButtonsPage.js
+++ b/docs/lib/Components/ButtonsPage.js
@@ -40,6 +40,9 @@ export default class ButtonsPage extends React.Component {
   // default: 'button'
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
 
+  // ref will only get you a reference to the Button component, use innerRef to get a reference to the DOM element (for things like focus management).
+  innerRef: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+
   onClick: PropTypes.func,
   size: PropTypes.string
 }`}

--- a/docs/lib/Components/CardPage.js
+++ b/docs/lib/Components/CardPage.js
@@ -110,7 +110,9 @@ CardImgOverlay.propTypes = {
 CardLink.propTypes = {
   // Pass in a Component to override default element
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  className: PropTypes.string
+  className: PropTypes.string,
+  // ref will only get you a reference to the CardLink component, use innerRef to get a reference to the DOM element (for things like focus management).
+  innerRef: PropTypes.oneOfType([PropTypes.func, PropTypes.string])
 };
 
 CardSubtitle.propTypes = {

--- a/docs/lib/Components/NavsPage.js
+++ b/docs/lib/Components/NavsPage.js
@@ -58,8 +58,10 @@ export default class NavssPage extends React.Component {
 {`NavLink.propTypes = {
   disabled: PropTypes.bool,
   active: PropTypes.bool,
-  tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string])
   // pass in custom element to use
+  tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  // ref will only get you a reference to the NavLink component, use innerRef to get a reference to the DOM element (for things like focus management).
+  innerRef: PropTypes.oneOfType([PropTypes.func, PropTypes.string])
 }`}
           </PrismCode>
         </pre>


### PR DESCRIPTION
Add innerRef where it was missing. innerRef is also allowed on Form but
it does not have any propTypes documented yet.