### PR TITLE
fix(build): inform rollup of react-popper exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "lodash.isobject": "^3.0.2",
     "lodash.tonumber": "^4.0.3",
     "prop-types": "^15.5.8",
-    "react-popper": "0.8.1",
+    "react-popper": "^0.8.2",
     "react-portal": "^4.1.2",
     "react-transition-group": "^2.2.1"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -16,7 +16,8 @@ function baseConfig() {
     plugins: [
       nodeResolve(),
       commonjs({
-        include: 'node_modules/**'
+        include: 'node_modules/**',
+        namedExports: { 'node_modules/react-popper/lib/react-popper.js': ['Manager', 'Target', 'Popper', 'Arrow'] },
       }),
       babel({
         plugins: ['external-helpers'],

--- a/yarn.lock
+++ b/yarn.lock
@@ -6652,9 +6652,9 @@ react-helmet@^5.0.3:
     prop-types "^15.5.4"
     react-side-effect "^1.1.0"
 
-react-popper@0.8.1:
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-0.8.1.tgz#a5e1cf10581598709f8f220eb3631d6c8c8716af"
+react-popper@0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-0.8.2.tgz#092095ff13933211d3856d9f325511ec3a42f12c"
   dependencies:
     popper.js "^1.12.9"
     prop-types "^15.6.0"


### PR DESCRIPTION
This brings react-popper back to ^0.8.2, but adds some rollup config to allow the build to deal with how react-popper is defining the exports.

CC @supergibbs