### PR TITLE
docs(install): Use the minified version of Bootstrap CSS

### DIFF
--- a/docs/lib/Home/index.js
+++ b/docs/lib/Home/index.js
@@ -72,7 +72,7 @@ npm install --save reactstrap@next react react-dom`}
             </pre>
             <p>Import Bootstrap CSS in the <code>src/index.js</code> file:</p>
             <pre>
-              <PrismCode className="language-bash">import 'bootstrap/dist/css/bootstrap.css';</PrismCode>
+              <PrismCode className="language-bash">import 'bootstrap/dist/css/bootstrap.min.css';</PrismCode>
             </pre>
             <p>Import required reactstrap components within <code>src/App.js</code> file or your custom component files:</p>
             <pre>


### PR DESCRIPTION
For smaller build sizes (given most people won't run a CSS minifier as part of the build) and consistency with upstream Bootstrap docs:
https://getbootstrap.com/docs/4.0/getting-started/webpack/#importing-compiled-css

Fixes #879.