### PR TITLE
chore(docs): button group spacing

### DIFF
--- a/docs/lib/examples/ButtonGroup.js
+++ b/docs/lib/examples/ButtonGroup.js
@@ -5,8 +5,8 @@ export default class Example extends React.Component {
   render() {
     return (
       <ButtonGroup>
-        <Button>Left</Button>{' '}
-        <Button>Middle</Button>{' '}
+        <Button>Left</Button>
+        <Button>Middle</Button>
         <Button>Right</Button>
       </ButtonGroup>
     );


### PR DESCRIPTION
This removes `{' '}` which was added to the doc in #186, but has no effects on `Button`s inside `ButtonGroup`.

In PR[#186](https://github.com/reactstrap/reactstrap/pull/186), `{' '}` was used to make actual spaces. It did works in `Button`, but seems to have no effects in [ButtonGroup](https://reactstrap.github.io/components/button-group/). In this case, I think it's better to remove it, so that developers won't be confused by it.