### PR TITLE
Fixes Server Side Rendering, Bump Deps, Now React16 required.

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,12 +94,11 @@
     "lodash.tonumber": "^4.0.3",
     "prop-types": "^15.5.8",
     "react-popper": "^0.8.3",
-    "react-portal": "^4.1.2",
     "react-transition-group": "^2.2.1"
   },
   "peerDependencies": {
-    "react": "^0.14.9 || ^15.3.0 || ^16.0.0",
-    "react-dom": "^0.14.9 || ^15.3.0 || ^16.0.0"
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.14.0",

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -191,8 +191,10 @@ class Modal extends React.Component {
   }
 
   destroy() {
-    document.body.removeChild(this._element);
-    this._element = null;
+    if (this._element) {
+      document.body.removeChild(this._element);
+      this._element = null;
+    }
 
     const modalOpenClassName = mapToCssModules('modal-open', this.props.cssModule);
     // Use regex to prevent matching `modal-open` as part of a different class, e.g. `my-modal-opened`

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Portal } from 'react-portal';
 import classNames from 'classnames';
+import Portal from './Portal';
 import Fade from './Fade';
 import {
   getOriginalBodyPadding,

--- a/src/Portal.js
+++ b/src/Portal.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import PropTypes from 'prop-types';
+import { canUseDOM } from './utils';
+
+const propTypes = {
+  children: PropTypes.node.isRequired,
+  node: PropTypes.any
+};
+
+class Portal extends React.Component {
+  componentWillUnmount() {
+    if (this.defaultNode) {
+      document.body.removeChild(this.defaultNode);
+    }
+    this.defaultNode = null;
+  }
+
+  render() {
+    if (!canUseDOM) {
+      return null;
+    }
+
+    if (!this.props.node && !this.defaultNode) {
+      this.defaultNode = document.createElement('div');
+      document.body.appendChild(this.defaultNode);
+    }
+
+    return ReactDOM.createPortal(
+      this.props.children,
+      this.props.node || this.defaultNode
+    );
+  }
+}
+
+Portal.propTypes = propTypes;
+
+export default Portal;

--- a/src/utils.js
+++ b/src/utils.js
@@ -199,3 +199,9 @@ export const PopperPlacements = [
   'left',
   'left-start',
 ];
+
+export const canUseDOM = !!(
+  typeof window !== 'undefined' &&
+  window.document &&
+  window.document.createElement
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -6659,12 +6659,6 @@ react-popper@^0.8.3:
     popper.js "^1.12.9"
     prop-types "^15.6.0"
 
-react-portal@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/react-portal/-/react-portal-4.1.2.tgz#7f28f3c8c2ed5c541907c0ed0f24e8996acf627f"
-  dependencies:
-    prop-types "^15.5.8"
-
 react-prism@^4.3.2:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/react-prism/-/react-prism-4.3.2.tgz#5c07609539b3ba6f45eb33e7d6a3588df3270c21"


### PR DESCRIPTION
The inclusion of `react-portal` introduced numerous issues including preventing server side rendering from working correctly. This PR fixes that and also reduces the massive increase in size resulting from that dependency. 

Fixes other issues noted in #870 which are currently not fixed in `beta.3`

Also requires React16 now. This has been talked about for awhile and signed off by @TheSharpieOne  and will not pose an issue for most libraries as the transition is seamless.

And lastly, file sizes now back to `beta.0` level
```
169K Mar 20 03:29 reactstrap.cjs.js
265K Mar 20 03:29 reactstrap.cjs.js.map
166K Mar 20 03:29 reactstrap.es.js
264K Mar 20 03:29 reactstrap.es.js.map
284K Mar 20 03:29 reactstrap.full.js
455K Mar 20 03:29 reactstrap.full.js.map
111K Mar 20 03:29 reactstrap.full.min.js
395K Mar 20 03:29 reactstrap.full.min.js.map
168K Mar 20 03:29 reactstrap.js
263K Mar 20 03:29 reactstrap.js.map
 75K Mar 20 03:29 reactstrap.min.js
228K Mar 20 03:29 reactstrap.min.js.map
```