### PR TITLE
docs(NavbarExampleSource): aligns the dropdown menu in nav bar to the right

### DIFF
--- a/docs/lib/examples/Navbar.js
+++ b/docs/lib/examples/Navbar.js
@@ -44,7 +44,7 @@ export default class Example extends React.Component {
                 <DropdownToggle nav caret>
                   Options
                 </DropdownToggle>
-                <DropdownMenu >
+                <DropdownMenu right>
                   <DropdownItem>
                     Option 1
                   </DropdownItem>


### PR DESCRIPTION
This improves the documentation by aligning the "Options" DropdownMenu correctly to the right.

Previously: 
![screen shot 2018-03-22 at 8 57 39 am](https://user-images.githubusercontent.com/2195815/37739717-205790d6-2daf-11e8-9403-9e512479adaf.png)

This fix:
![screen shot 2018-03-22 at 8 57 24 am](https://user-images.githubusercontent.com/2195815/37739724-279b48b0-2daf-11e8-811b-85a8b3a49aa6.png)
 
