### PR TITLE
 docs(GitHub): fix capitalisation

### DIFF
--- a/docs/lib/examples/Navbar.js
+++ b/docs/lib/examples/Navbar.js
@@ -38,7 +38,7 @@ export default class Example extends React.Component {
                 <NavLink href="/components/">Components</NavLink>
               </NavItem>
               <NavItem>
-                <NavLink href="https://github.com/reactstrap/reactstrap">Github</NavLink>
+                <NavLink href="https://github.com/reactstrap/reactstrap">GitHub</NavLink>
               </NavItem>
               <UncontrolledDropdown nav inNavbar>
                 <DropdownToggle nav caret>

--- a/docs/lib/examples/NavbarToggler.js
+++ b/docs/lib/examples/NavbarToggler.js
@@ -28,7 +28,7 @@ export default class Example extends React.Component {
                 <NavLink href="/components/">Components</NavLink>
               </NavItem>
               <NavItem>
-                <NavLink href="https://github.com/reactstrap/reactstrap">Github</NavLink>
+                <NavLink href="https://github.com/reactstrap/reactstrap">GitHub</NavLink>
               </NavItem>
             </Nav>
           </Collapse>


### PR DESCRIPTION
The style guide of GitHub prefers GitHub over Github. These were the only two places with this kind of capitalisation