### PR TITLE
fix(UncontrolledCarousel): add bootstrap classes to img to make it re…

### DIFF
--- a/src/UncontrolledCarousel.js
+++ b/src/UncontrolledCarousel.js
@@ -65,7 +65,7 @@ class UncontrolledCarousel extends Component {
           onExited={this.onExited}
           key={item.src}
         >
-          <img src={item.src} alt={item.altText} />
+          <img className="d-block w-100" src={item.src} alt={item.altText} />
           <CarouselCaption captionText={item.caption} captionHeader={item.caption} />
         </CarouselItem>
       );


### PR DESCRIPTION
…sponsive

Carousel images should have classes "d-block" and "w-100" to make them responsive as shown in the bootstrap documentation. You can add them yourself when using the normal Carousel component because you create your own img elements but you can't do that for the UncontrolledCarousel component. This PR adds the classes to the img element so it is properly responsive.