### PR TITLE
Update Navbar example with actual background color

### DIFF
--- a/docs/lib/examples/Navbar.js
+++ b/docs/lib/examples/Navbar.js
@@ -29,7 +29,7 @@ export default class Example extends React.Component {
   render() {
     return (
       <div>
-        <Navbar color="faded" light expand="md">
+        <Navbar color="light" light expand="md">
           <NavbarBrand href="/">reactstrap</NavbarBrand>
           <NavbarToggler onClick={this.toggle} />
           <Collapse isOpen={this.state.isOpen} navbar>


### PR DESCRIPTION
Background colors have changed in Bootstrap. The `faded` color doesn't exist anymore so the Navbar example should use `light` instead.

See Bootstrap documentation: https://getbootstrap.com/docs/4.0/components/navbar/