### PR TITLE
fix(docs): use ReactDOM.hydrate instead of ReactDOM.render

### DIFF
--- a/docs/lib/app.js
+++ b/docs/lib/app.js
@@ -19,7 +19,7 @@ if (typeof document !== 'undefined') {
     Holder = require('holderjs');
   });
 
-  ReactDOM.render(
+  ReactDOM.hydrate(
     <Router
       onUpdate={() => {
         window.scrollTo(0, 0);


### PR DESCRIPTION
Fixes warning.
[Reacts's documentation](https://reactjs.org/docs/react-dom.html#reference) says:

> Using `ReactDOM.render()` to hydrate a server-rendered container is deprecated and will be removed in **React 17**. Use `hydrate()` instead.