### PR TITLE
fix(DropdownMenu): add x-placement attribute

### DIFF
--- a/docs/lib/Components/DropdownsPage.js
+++ b/docs/lib/Components/DropdownsPage.js
@@ -113,14 +113,14 @@ DropdownItem.propTypes = {
           <div style={{ display: 'inline-block' }}>
             <Dropdown isOpen={this.state.example2} toggle={this.toggleExample2}>
               <DropdownToggle caret>
-                This dropdown's menu is right-aligned
+                Dropdown's menu is right-aligned
               </DropdownToggle>
               <DropdownMenu right>
                 <DropdownItem header>Header</DropdownItem>
                 <DropdownItem disabled>Action</DropdownItem>
                 <DropdownItem>Another Action</DropdownItem>
                 <DropdownItem divider />
-                <DropdownItem>Another Action</DropdownItem>
+                <DropdownItem>Another Really Really Long Action (Really!)</DropdownItem>
               </DropdownMenu>
             </Dropdown>
           </div>

--- a/docs/lib/UI/PageTitle.js
+++ b/docs/lib/UI/PageTitle.js
@@ -15,7 +15,7 @@ PageTitle.propTypes = {
 
 PageTitle.defaultProps = {
   tag: 'h2',
-  classNames: 'h3',
+  className: 'h3',
 };
 
 export default PageTitle;

--- a/src/DropdownMenu.js
+++ b/src/DropdownMenu.js
@@ -67,6 +67,7 @@ const DropdownMenu = (props, context) => {
       {...attrs}
       aria-hidden={!context.isOpen}
       className={classes}
+      x-placement={attrs.placement}
     />
   );
 };

--- a/src/PopperContent.js
+++ b/src/PopperContent.js
@@ -163,7 +163,7 @@ class PopperContent extends React.Component {
     };
 
     return (
-      <ReactPopper modifiers={extendedModifiers} {...attrs} component={tag} className={popperClassName}>
+      <ReactPopper modifiers={extendedModifiers} {...attrs} component={tag} className={popperClassName} x-placement={this.state.placement || attrs.placement}>
         {children}
         {!hideArrow && <Arrow className={arrowClassName} />}
       </ReactPopper>


### PR DESCRIPTION
react-popper no longer adds the attribute and it is needed for bootstrap 4.1.0

Fixes #962