### PR TITLE
docs(*): change toggle from using this.setState to use prevState (#954)

### DIFF
--- a/docs/lib/examples/Dropdown.js
+++ b/docs/lib/examples/Dropdown.js
@@ -12,9 +12,9 @@ export default class Example extends React.Component {
   }
 
   toggle() {
-    this.setState({
-      dropdownOpen: !this.state.dropdownOpen
-    });
+    this.setState(prevState => ({
+      dropdownOpen: !prevState.dropdownOpen
+    }));
   }
 
   render() {


### PR DESCRIPTION
Example which could be bug prone. toggle() function uses actual "this.state" but sholud use "prevState".