### PR TITLE
Update install instructions

### DIFF
--- a/docs/lib/Home/index.js
+++ b/docs/lib/Home/index.js
@@ -36,7 +36,7 @@ export default () => {
             <h3 className="mt-5">NPM</h3>
             <p>Install reactstrap and peer dependencies via NPM</p>
             <pre>
-              <PrismCode className="language-bash">npm install --save reactstrap@next react react-dom</PrismCode>
+              <PrismCode className="language-bash">npm install --save reactstrap react react-dom</PrismCode>
             </pre>
             <p>Import the components you need</p>
             <div className="docs-example">
@@ -67,7 +67,7 @@ npm start`}
             <pre>
               <PrismCode className="language-bash">
   {`npm install bootstrap --save
-npm install --save reactstrap@next react react-dom`}
+npm install --save reactstrap react react-dom`}
               </PrismCode>
             </pre>
             <p>Import Bootstrap CSS in the <code>src/index.js</code> file:</p>


### PR DESCRIPTION
Change install instruction from:

```
npm install --save reactstrap@next react react-dom
```

to:
```
npm install --save reactstrap react react-dom
```

## Reason:
The `next` tag points to `5.0.0-beta.3` while the latest tag points to the final `5.0.0`.

See:

![image](https://user-images.githubusercontent.com/441011/38022995-644844d0-3281-11e8-95f8-667ba556e99e.png)
