### PR TITLE
ship untranspiled source

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "README.md",
     "CHANGELOG.md",
     "lib",
-    "dist"
+    "dist",
+    "src"
   ],
   "keywords": [
     "reactstrap",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "jsdelivr": "dist/reactstrap.min.js",
   "unpkg": "dist/reactstrap.min.js",
   "cdn": "dist/reactstrap.min.js",
+  "esnext": "src",
   "scripts": {
     "report-coverage": "coveralls < ./coverage/lcov.info",
     "test": "cross-env BABEL_ENV=test react-scripts test --env=jsdom",


### PR DESCRIPTION
see http://2ality.com/2017/06/pkg-esnext.html#package-authors

this PR enables ship untranspiled source of reactstrap installed from github via `npm i reactstrap/reactstrap` so that you can transpile to target you want