### PR TITLE
Fix warning about invalid arguments to oneOfType

### DIFF
--- a/docs/lib/Components/FormPage.js
+++ b/docs/lib/Components/FormPage.js
@@ -79,7 +79,7 @@ export default class FormPage extends React.Component {
   invalid: PropTypes.bool, // applied the is-valid class when true, does nothing when false
   bsSize: PropTypes.string,
   cssModule: PropTypes.object,
-  children: PropTypes.oneOfType(PropTypes.node, PropTypes.array, PropTypes.func) // for type="select"
+  children: PropTypes.oneOfType([PropTypes.node, PropTypes.array, PropTypes.func]) // for type="select"
 };`}
           </PrismCode>
         </pre>

--- a/src/CustomInput.js
+++ b/src/CustomInput.js
@@ -13,7 +13,7 @@ const propTypes = {
   invalid: PropTypes.bool,
   bsSize: PropTypes.string,
   cssModule: PropTypes.object,
-  children: PropTypes.oneOfType(PropTypes.node, PropTypes.array, PropTypes.func)
+  children: PropTypes.oneOfType([PropTypes.node, PropTypes.array, PropTypes.func])
 };
 
 function CustomInput(props) {


### PR DESCRIPTION
Fixes console warning:

    Invalid argument supplied to oneOfType, expected an instance of array
