### PR TITLE
mark reactstrap as sideEffects free

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "unpkg": "dist/reactstrap.min.js",
   "cdn": "dist/reactstrap.min.js",
   "esnext": "src",
+  "sideEffects": false,
   "scripts": {
     "report-coverage": "coveralls < ./coverage/lcov.info",
     "test": "cross-env BABEL_ENV=test react-scripts test --env=jsdom",


### PR DESCRIPTION
because this
```js
import "reactstrap"
```
is same as 
```js
// nothing
```

related PR https://github.com/ReactTraining/react-router/pull/6082