### PR TITLE
chore(Breadcrumb,Pagination): improve accessibility and docs

### DIFF
--- a/docs/lib/Components/BreadcrumbsPage.js
+++ b/docs/lib/Components/BreadcrumbsPage.js
@@ -23,6 +23,28 @@ export default class BreadcrumbsPage extends React.Component {
             {BreadcrumbExampleSource}
           </PrismCode>
         </pre>
+        <h4>Properties</h4>
+        <pre>
+          <PrismCode className="language-jsx">
+{`Breadcrumb.propTypes = {
+  tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  listTag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  className: PropTypes.string,
+  listClassName: PropTypes.string,
+  cssModule: PropTypes.object,
+  children: PropTypes.node,
+  'aria-label': PropTypes.string
+};
+
+BreadcrumbItem.propTypes = {
+  tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  active: PropTypes.bool,
+  className: PropTypes.string,
+  cssModule: PropTypes.object,
+};
+`}
+          </PrismCode>
+        </pre>
         <SectionTitle>No list</SectionTitle>
         <hr />
         <p>Breadcrumbs can work without the usage of list markup.</p>

--- a/docs/lib/Components/PaginationPage.js
+++ b/docs/lib/Components/PaginationPage.js
@@ -35,9 +35,33 @@ export default class PaginationPage extends React.Component {
 {`Pagination.propTypes = {
   children: PropTypes.node,
   className: PropTypes.string,
+  listClassName: PropTypes.string,
+  cssModule: PropTypes.object,
   size: PropTypes.string,
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-}`}
+  listTag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  'aria-label': PropTypes.string
+};
+
+PaginationItem.propTypes = {
+  active: PropTypes.bool,
+  children: PropTypes.node,
+  className: PropTypes.string,
+  cssModule: PropTypes.object,
+  disabled: PropTypes.bool,
+  tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+};
+
+PaginationLink.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+  cssModule: PropTypes.object,
+  next: PropTypes.bool,
+  previous: PropTypes.bool,
+  tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  'aria-label': PropTypes.string
+};
+`}
           </PrismCode>
         </pre>
         <SectionTitle>Disabled and active states</SectionTitle>

--- a/docs/lib/examples/Pagination.js
+++ b/docs/lib/examples/Pagination.js
@@ -4,7 +4,7 @@ import { Pagination, PaginationItem, PaginationLink } from 'reactstrap';
 export default class Example extends React.Component {
   render() {
     return (
-      <Pagination>
+      <Pagination aria-label="Page navigation example">
         <PaginationItem>
           <PaginationLink previous href="#" />
         </PaginationItem>

--- a/docs/lib/examples/PaginationSizingLarge.js
+++ b/docs/lib/examples/PaginationSizingLarge.js
@@ -4,7 +4,7 @@ import { Pagination, PaginationItem, PaginationLink } from 'reactstrap';
 export default class Example extends React.Component {
   render() {
     return (
-      <Pagination size="lg">
+      <Pagination size="lg" aria-label="Page navigation example">
         <PaginationItem>
           <PaginationLink previous href="#" />
         </PaginationItem>

--- a/docs/lib/examples/PaginationSizingSmall.js
+++ b/docs/lib/examples/PaginationSizingSmall.js
@@ -4,7 +4,7 @@ import { Pagination, PaginationItem, PaginationLink } from 'reactstrap';
 export default class Example extends React.Component {
   render() {
     return (
-      <Pagination size="sm">
+      <Pagination size="sm" aria-label="Page navigation example">
         <PaginationItem>
           <PaginationLink previous href="#" />
         </PaginationItem>

--- a/docs/lib/examples/PaginationState.js
+++ b/docs/lib/examples/PaginationState.js
@@ -4,7 +4,7 @@ import { Pagination, PaginationItem, PaginationLink } from 'reactstrap';
 export default class Example extends React.Component {
   render() {
     return (
-      <Pagination>
+      <Pagination aria-label="Page navigation example">
         <PaginationItem disabled>
           <PaginationLink previous href="#" />
         </PaginationItem>

--- a/src/Breadcrumb.js
+++ b/src/Breadcrumb.js
@@ -4,29 +4,48 @@ import classNames from 'classnames';
 import { mapToCssModules } from './utils';
 
 const propTypes = {
-  tag: PropTypes.string,
+  tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  listTag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   className: PropTypes.string,
+  listClassName: PropTypes.string,
   cssModule: PropTypes.object,
+  children: PropTypes.node,
+  'aria-label': PropTypes.string
 };
 
 const defaultProps = {
-  tag: 'ol'
+  tag: 'nav',
+  listTag: 'ol',
+  'aria-label': 'breadcrumb'
 };
 
 const Breadcrumb = (props) => {
   const {
     className,
+    listClassName,
     cssModule,
+    children,
     tag: Tag,
+    listTag: ListTag,
+    'aria-label': label,
     ...attributes
   } = props;
+
   const classes = mapToCssModules(classNames(
-    className,
-    'breadcrumb'
+    className
+  ), cssModule);
+
+  const listClasses = mapToCssModules(classNames(
+    'breadcrumb',
+    listClassName
   ), cssModule);
 
   return (
-    <Tag {...attributes} className={classes} />
+    <Tag {...attributes} className={classes} aria-label={label}>
+      <ListTag className={listClasses}>
+        {children}
+      </ListTag>
+    </Tag>
   );
 };
 

--- a/src/BreadcrumbItem.js
+++ b/src/BreadcrumbItem.js
@@ -29,7 +29,7 @@ const BreadcrumbItem = (props) => {
   ), cssModule);
 
   return (
-    <Tag {...attributes} className={classes} />
+    <Tag {...attributes} className={classes} aria-current={active ? 'page' : undefined} />
   );
 };
 

--- a/src/Pagination.js
+++ b/src/Pagination.js
@@ -1,39 +1,56 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { mapToCssModules } from './utils';
+import { mapToCssModules, warnOnce } from './utils';
 
 const propTypes = {
   children: PropTypes.node,
   className: PropTypes.string,
+  listClassName: PropTypes.string,
   cssModule: PropTypes.object,
   size: PropTypes.string,
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  listTag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  'aria-label': PropTypes.string
 };
 
 const defaultProps = {
-  tag: 'ul',
+  tag: 'nav',
+  listTag: 'ul',
 };
 
 const Pagination = (props) => {
   const {
     className,
+    listClassName,
     cssModule,
     size,
     tag: Tag,
+    listTag: ListTag,
+    'aria-label': label,
     ...attributes
   } = props;
 
   const classes = mapToCssModules(classNames(
-    className,
+    className
+  ), cssModule);
+
+  const listClasses = mapToCssModules(classNames(
+    listClassName,
     'pagination',
     {
       [`pagination-${size}`]: !!size,
     }
   ), cssModule);
 
+  if (!label) {
+    warnOnce('It\'s highly recommended to pass the prop "aria-label" to the <Pagination /> component.');
+  }
+
   return (
-    <Tag {...attributes} className={classes} />
+    <Tag className={classes} aria-label={label}>
+      <ListTag {...attributes} className={listClasses} />
+    </Tag>
   );
 };
 

--- a/src/Pagination.js
+++ b/src/Pagination.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { mapToCssModules, warnOnce } from './utils';
+import { mapToCssModules } from './utils';
 
 const propTypes = {
   children: PropTypes.node,
@@ -17,6 +17,7 @@ const propTypes = {
 const defaultProps = {
   tag: 'nav',
   listTag: 'ul',
+  'aria-label': 'pagination'
 };
 
 const Pagination = (props) => {
@@ -42,10 +43,6 @@ const Pagination = (props) => {
       [`pagination-${size}`]: !!size,
     }
   ), cssModule);
-
-  if (!label) {
-    warnOnce('It\'s highly recommended to pass the prop "aria-label" to the <Pagination /> component.');
-  }
 
   return (
     <Tag className={classes} aria-label={label}>

--- a/src/__tests__/Breadcrumb.spec.js
+++ b/src/__tests__/Breadcrumb.spec.js
@@ -9,16 +9,22 @@ describe('Breadcrumb', () => {
     expect(wrapper.text()).toBe('Yo!');
   });
 
+  it('should render "nav" by default', () => {
+    const wrapper = shallow(<Breadcrumb>Yo!</Breadcrumb>);
+
+    expect(wrapper.type()).toBe('nav');
+  });
+
   it('should render "ol" by default', () => {
     const wrapper = shallow(<Breadcrumb>Yo!</Breadcrumb>);
 
-    expect(wrapper.type()).toBe('ol');
+    expect(wrapper.children().type()).toBe('ol');
   });
 
   it('should render with the "breadcrumb" class', () => {
     const wrapper = shallow(<Breadcrumb>Default Breadcrumb</Breadcrumb>);
 
-    expect(wrapper.hasClass('breadcrumb')).toBe(true);
+    expect(wrapper.children().hasClass('breadcrumb')).toBe(true);
   });
 
   it('should render custom tag', () => {

--- a/src/__tests__/Pagination.spec.js
+++ b/src/__tests__/Pagination.spec.js
@@ -3,10 +3,16 @@ import { shallow, mount } from 'enzyme';
 import { Pagination } from '../';
 
 describe('Pagination', () => {
-  it('should render default tag', () => {
+  it('should render "nav" tag by default', () => {
     const wrapper = mount(<Pagination />);
 
-    expect(wrapper.find('ul').hostNodes().length).toBe(1);
+    expect(wrapper.find('nav').hostNodes().length).toBe(1);
+  });
+
+  it('should render default list tag', () => {
+    const wrapper = mount(<Pagination />);
+
+    expect(wrapper.children().find('ul').hostNodes().length).toBe(1);
   });
 
   it('should render custom tag', () => {
@@ -18,7 +24,7 @@ describe('Pagination', () => {
   it('should render with "pagination" class', () => {
     const wrapper = shallow(<Pagination />);
 
-    expect(wrapper.hasClass('pagination')).toBe(true);
+    expect(wrapper.children().hasClass('pagination')).toBe(true);
   });
 
   it('should render children', () => {
@@ -31,7 +37,7 @@ describe('Pagination', () => {
     const small = shallow(<Pagination size="sm" />);
     const large = shallow(<Pagination size="lg" />);
 
-    expect(small.hasClass('pagination-sm')).toBe(true);
-    expect(large.hasClass('pagination-lg')).toBe(true);
+    expect(small.children().hasClass('pagination-sm')).toBe(true);
+    expect(large.children().hasClass('pagination-lg')).toBe(true);
   });
 });


### PR DESCRIPTION
## Breadcrumb:
- [x]  add `<nav>` wrapper element
- [x]  add `aria-label` prop (default: `"breadcrumb"`)
- [x]  add `aria-current="page"` to the last item of the set to indicate that it represents the current page.
- [x]  add properties section to the docs.

According to [Bootstrap docs](https://getbootstrap.com/docs/4.1/components/breadcrumb/#accessibility).

## Pagination:
- [x]  add `<nav>` wrapper element
- [x]  add `aria-label` prop (default: `"pagination"`)
- [x]  update examples and add properties section to the docs.

According to [Bootstrap docs](https://getbootstrap.com/docs/4.1/components/pagination/#overview).