### PR TITLE
fix(Modal): closes when dragging outside modal

### DIFF
--- a/src/Modal.js
+++ b/src/Modal.js
@@ -78,7 +78,8 @@ class Modal extends React.Component {
 
     this._element = null;
     this._originalBodyPadding = null;
-    this.handleBackdropClick = this.handleBackdropClick.bind(this);
+    this.handleBackdropMouseDown = this.handleBackdropMouseDown.bind(this);
+    this.handleBackdropMouseUp = this.handleBackdropMouseUp.bind(this);
     this.handleEscape = this.handleEscape.bind(this);
     this.onOpened = this.onOpened.bind(this);
     this.onClosed = this.onClosed.bind(this);
@@ -160,14 +161,19 @@ class Modal extends React.Component {
     }
   }
 
-  handleBackdropClick(e) {
-    e.stopPropagation();
-    if (!this.props.isOpen || this.props.backdrop !== true) return;
+  handleBackdropMouseDown(e) {
+    this._mouseDownElement = e.target;
+  }
+  handleBackdropMouseUp(e) {
+    if (e.target === this._mouseDownElement) {
+      e.stopPropagation();
+      if (!this.props.isOpen || this.props.backdrop !== true) return;
 
-    const container = this._dialog;
+      const container = this._dialog;
 
-    if (e.target && !container.contains(e.target) && this.props.toggle) {
-      this.props.toggle(e);
+      if (e.target && !container.contains(e.target) && this.props.toggle) {
+        this.props.toggle(e);
+      }
     }
   }
 
@@ -257,7 +263,8 @@ class Modal extends React.Component {
       } = this.props;
 
       const modalAttributes = {
-        onClick: this.handleBackdropClick,
+        onMouseDown: this.handleBackdropMouseDown,
+        onMouseUp: this.handleBackdropMouseUp,
         onKeyUp: this.handleEscape,
         style: { display: 'block' },
         'aria-labelledby': labelledBy,

--- a/src/__tests__/Modal.spec.js
+++ b/src/__tests__/Modal.spec.js
@@ -557,13 +557,13 @@ describe('Modal', () => {
 
     expect(isOpen).toBe(true);
 
-    var modal = document.getElementsByClassName('modal')[0];
+    const modal = document.getElementsByClassName('modal')[0];
 
-    var mouseDownEvent = document.createEvent('MouseEvents');
+    const mouseDownEvent = document.createEvent('MouseEvents');
     mouseDownEvent.initEvent('mousedown', true, true);
     modal.dispatchEvent(mouseDownEvent);
 
-    var mouseUpEvent = document.createEvent('MouseEvents');
+    const mouseUpEvent = document.createEvent('MouseEvents');
     mouseUpEvent.initEvent('mouseup', true, true);
     modal.dispatchEvent(mouseUpEvent);
 

--- a/src/__tests__/Modal.spec.js
+++ b/src/__tests__/Modal.spec.js
@@ -557,7 +557,16 @@ describe('Modal', () => {
 
     expect(isOpen).toBe(true);
 
-    document.getElementsByClassName('modal')[0].click();
+    var modal = document.getElementsByClassName('modal')[0];
+
+    var mouseDownEvent = document.createEvent('MouseEvents');
+    mouseDownEvent.initEvent('mousedown', true, true);
+    modal.dispatchEvent(mouseDownEvent);
+
+    var mouseUpEvent = document.createEvent('MouseEvents');
+    mouseUpEvent.initEvent('mouseup', true, true);
+    modal.dispatchEvent(mouseUpEvent);
+
     jest.runTimersToTime(300);
 
     expect(isOpen).toBe(false);


### PR DESCRIPTION
Modal dialog closes when mouse button is pressed over the dialog window but released outside the window.

See angular-ui/bootstrap#5810 for video. Pull request is based on code changes made in that project.
