### PR TITLE
fix(Util): Modify to use CSS escaped string when 'taget' is ID

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "lodash.isfunction": "^3.0.9",
     "lodash.isobject": "^3.0.2",
     "lodash.tonumber": "^4.0.3",
+    "css.escape": "^1.5.1",
     "prop-types": "^15.5.8",
     "react-popper": "^0.10.4",
     "react-transition-group": "^2.3.1"

--- a/src/__tests__/utils.spec.js
+++ b/src/__tests__/utils.spec.js
@@ -136,6 +136,16 @@ describe('Utils', () => {
       document.querySelectorAll.mockRestore();
     });
 
+    it('should query the document for the css escaped id target if the target is a string and could not be found normally', () => {
+      const element = document.createElement('div');
+      element.setAttribute('id', '[0].thing');
+      document.body.appendChild(element);
+      jest.spyOn(document, 'querySelectorAll');
+      expect(Utils.getTarget('[0].thing')).toEqual(element);
+      expect(document.querySelectorAll).toHaveBeenCalledWith('#\\[0\\]\\.thing');
+      document.querySelectorAll.mockRestore(); 
+    }) 
+
     it('should return the input target if it is not a function nor a string', () => {
       const target = {};
       expect(Utils.getTarget(target)).toEqual(target);

--- a/src/__tests__/utils.spec.js
+++ b/src/__tests__/utils.spec.js
@@ -143,8 +143,8 @@ describe('Utils', () => {
       jest.spyOn(document, 'querySelectorAll');
       expect(Utils.getTarget('[0].thing')).toEqual(element);
       expect(document.querySelectorAll).toHaveBeenCalledWith('#\\[0\\]\\.thing');
-      document.querySelectorAll.mockRestore(); 
-    }) 
+      document.querySelectorAll.mockRestore();
+    });
 
     it('should return the input target if it is not a function nor a string', () => {
       const target = {};

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+import 'css.escape'; // polyfill: CSS.escape
+
 import Container from './Container';
 import Row from './Row';
 import Col from './Col';

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,5 +1,7 @@
 /* global jest */
 /* eslint-disable import/no-extraneous-dependencies */
+import 'css.escape'; // polyfill: CSS.escape
+
 import Enzyme, { ReactWrapper } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -199,7 +199,7 @@ export function findDOMElements(target) {
   if (typeof target === 'string' && canUseDOM) {
     let selection;
     try {
-      selection = document.querySelectorAll(target); 
+      selection = document.querySelectorAll(target);
       if (!selection.length) {
         selection = document.querySelectorAll(`#${CSS.escape(target)}`);
       }

--- a/src/utils.js
+++ b/src/utils.js
@@ -197,9 +197,14 @@ export function findDOMElements(target) {
     return target();
   }
   if (typeof target === 'string' && canUseDOM) {
-    let selection = document.querySelectorAll(target);
-    if (!selection.length) {
-      selection = document.querySelectorAll(`#${target}`);
+    let selection;
+    try {
+      selection = document.querySelectorAll(target); 
+      if (!selection.length) {
+        selection = document.querySelectorAll(`#${CSS.escape(target)}`);
+      }
+    } catch (err) {
+      selection = document.querySelectorAll(`#${CSS.escape(target)}`);
     }
     if (!selection.length) {
       throw new Error(

--- a/yarn.lock
+++ b/yarn.lock
@@ -2366,6 +2366,10 @@ css-what@2.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.0.tgz#9467d032c38cfaefb9f2d79501253062f87fa1bd"
 
+css.escape@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
+
 cssesc@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-0.1.0.tgz#c814903e45623371a0477b40109aaafbeeaddbb4"


### PR DESCRIPTION
When trying to pass a specific DOM id attribute to the target property of the 'Tooltip' component, an exception is thrown when the DOM id is an invalid selector so I modified lines for making 'target' to be CSS escaped.

---

When I run my test cases that uses the invalid selector, I get the following logs.

```
SyntaxError: '[0].etcdName-Tooltip' is not a valid selector

      at emit (node_modules/nwsapi/src/nwsapi.js:552:17)
      at _querySelectorAll (node_modules/nwsapi/src/nwsapi.js:1371:9)
      at Object._querySelector [as first] (node_modules/nwsapi/src/nwsapi.js:1310:14)
      at DocumentImpl.<anonymous> (node_modules/jsdom/lib/jsdom/living/nodes/ParentNode-impl.js:65:42)
      at DocumentImpl.querySelector (node_modules/jsdom/lib/jsdom/utils.js:123:45)
      at Document.querySelector (node_modules/jsdom/lib/jsdom/living/generated/Document.js:689:45)
      at getTarget (node_modules/reactstrap/src/utils.js:127:30)
      at Tooltip.componentDidMount (node_modules/reactstrap/src/Tooltip.js:67:20)
      at commitLifeCycles (node_modules/react-dom/cjs/react-dom.development.js:14248:22)
      at commitAllLifeCycles (node_modules/react-dom/cjs/react-dom.development.js:15342:7)
```

```
The target 'config.masterHosts-Tooltip' could not be identified in the dom, tip: check spelling

      at findDOMElements (node_modules/reactstrap/src/utils.js:210:13)
      at getTarget (node_modules/reactstrap/src/utils.js:224:15)
      at Tooltip.componentDidMount (node_modules/reactstrap/src/Tooltip.js:72:20)
      at commitLifeCycles (node_modules/react-dom/cjs/react-dom.development.js:14248:22)
      at commitAllLifeCycles (node_modules/react-dom/cjs/react-dom.development.js:15342:7)
      at HTMLUnknownElement.callCallback (node_modules/react-dom/cjs/react-dom.development.js:100:14)
...
```