### PR TITLE
fix(Carousel): allow true, false, undefined, null and children of Carousel(#1063)

### DIFF
--- a/src/Carousel.js
+++ b/src/Carousel.js
@@ -109,7 +109,7 @@ class Carousel extends React.Component {
   }
 
   render() {
-    const { children, cssModule, slide, className } = this.props;
+    const { cssModule, slide, className } = this.props;
     const outerClasses = mapToCssModules(classNames(
       className,
       'carousel',
@@ -120,6 +120,8 @@ class Carousel extends React.Component {
       'carousel-inner'
     ), cssModule);
 
+    // filter out booleans, null, or undefined
+    const children = this.props.children.filter(child => child !== null && child !== undefined && typeof child !== 'boolean');
 
     const slidesOnly = children.every(child => child.type === CarouselItem);
 

--- a/src/__tests__/Carousel.spec.js
+++ b/src/__tests__/Carousel.spec.js
@@ -231,6 +231,34 @@ describe('Carousel', () => {
       expect(wrapper.find(CarouselControl).length).toEqual(2);
       expect(wrapper.find(CarouselIndicators).length).toEqual(1);
     });
+
+    it('should tolerate booleans, null and undefined values rendered as children of Carousel', () => {
+      const slides = items.map((item, idx) => {
+        return (
+          <CarouselItem
+            key={idx}
+          >
+            <CarouselCaption captionText={item.caption} captionHeader={item.caption} />
+          </CarouselItem>
+        );
+      });
+
+      const wrapper = mount(
+        <Carousel activeIndex={0} next={() => { }} previous={() => { }}>
+          {null}
+          {true}
+          {false}
+          {undefined}
+          {(() => {})()}
+          <CarouselIndicators items={items} activeIndex={0} onClickHandler={() => { }} />
+          {slides}
+          <CarouselControl direction="prev" directionText="Previous" onClickHandler={() => { }} />
+          <CarouselControl direction="next" directionText="Next" onClickHandler={() => { }} />
+        </Carousel>
+      );
+      expect(wrapper.find(CarouselControl).length).toEqual(2);
+      expect(wrapper.find(CarouselIndicators).length).toEqual(1);
+    });
   });
 
   describe('carouseling', () => {


### PR DESCRIPTION
fix(Carousel): allow true, false, undefined, null and children of Carousel(#1063) 

filter out booleans, null and undefined children
from render method of Carousel component
so they don't affect rendering