### PR TITLE
Tooltip delay can't be circumvented by clicking away from trigger 

### DIFF
--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -157,7 +157,7 @@ class Tooltip extends React.Component {
       if (!this.props.isOpen) {
         this.toggle();
       }
-    } else if (this.props.isOpen) {
+    } else if (this.props.isOpen && e.target.getAttribute('role') !== 'tooltip') {
       if (this._showTimeout) {
         this.clearShowTimeout();
       }

--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -155,7 +155,7 @@ class Tooltip extends React.Component {
       }
 
       if (!this.props.isOpen && !this._showTimeout) {
-        this.toggle();
+        this._showTimeout = setTimeout(this.show, this.getDelay('show'));
       }
     } else if (this.props.isOpen && e.target.getAttribute('role') !== 'tooltip') {
       if (this._showTimeout) {

--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -157,6 +157,12 @@ class Tooltip extends React.Component {
       if (!this.props.isOpen) {
         this.toggle();
       }
+    } else if (this.props.isOpen) {
+      if (this._showTimeout) {
+        this.clearShowTimeout();
+      }
+
+      this._hideTimeout = setTimeout(this.hide, this.getDelay('hide'));
     }
   }
 

--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -154,7 +154,7 @@ class Tooltip extends React.Component {
         this.clearHideTimeout();
       }
 
-      if (!this.props.isOpen) {
+      if (!this.props.isOpen && !this._showTimeout) {
         this.toggle();
       }
     } else if (this.props.isOpen && e.target.getAttribute('role') !== 'tooltip') {
@@ -162,7 +162,9 @@ class Tooltip extends React.Component {
         this.clearShowTimeout();
       }
 
-      this._hideTimeout = setTimeout(this.hide, this.getDelay('hide'));
+      if (!this._hideTimeout) {
+        this._hideTimeout = setTimeout(this.hide, this.getDelay('hide'));
+      }
     }
   }
 

--- a/src/__tests__/Tooltip.spec.js
+++ b/src/__tests__/Tooltip.spec.js
@@ -131,8 +131,10 @@ describe('Tooltip', () => {
 
     expect(isOpen).toBe(false);
     instance.handleDocumentClick({ target: target });
+    jest.runTimersToTime(0);
     expect(isOpen).toBe(true);
     instance.handleDocumentClick({ target: target });
+    jest.runTimersToTime(250);
     expect(isOpen).toBe(false);
 
     wrapper.detach();
@@ -149,6 +151,7 @@ describe('Tooltip', () => {
 
     expect(isOpen).toBe(false);
     instance.handleDocumentClick({ target: innerTarget });
+    jest.runTimersToTime(0);
     expect(isOpen).toBe(true);
     wrapper.detach();
   });


### PR DESCRIPTION
This unimplements #1079 by checking if there is a hide timer already active. This mimics the behavior of Bootstrap, see [#1079 (comment)](https://github.com/reactstrap/reactstrap/pull/1083#pullrequestreview-130130462)