### PR TITLE
Tooltip inner ref

### DIFF
--- a/docs/lib/Components/TooltipsPage.js
+++ b/docs/lib/Components/TooltipsPage.js
@@ -76,7 +76,12 @@ export default class TooltipsPage extends React.Component {
   offset: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.number
-  ])
+  ]),
+  // Custom ref handler that will be assigned to the "ref" of the <div> wrapping the tooltip elements
+  innerRef: PropTypes.oneOfType([
+    PropTypes.func, 
+    PropTypes.string
+  ]),
 }`}
           </PrismCode>
         </pre>

--- a/docs/lib/Components/TooltipsPage.js
+++ b/docs/lib/Components/TooltipsPage.js
@@ -80,7 +80,8 @@ export default class TooltipsPage extends React.Component {
   // Custom ref handler that will be assigned to the "ref" of the <div> wrapping the tooltip elements
   innerRef: PropTypes.oneOfType([
     PropTypes.func, 
-    PropTypes.string
+    PropTypes.string,
+    PropTypes.object
   ]),
 }`}
           </PrismCode>

--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -34,6 +34,7 @@ const propTypes = {
     PropTypes.string,
     PropTypes.number
   ]),
+  innerRef: PropTypes.object,
 };
 
 const DEFAULT_DELAYS = {
@@ -225,6 +226,7 @@ class Tooltip extends React.Component {
       >
         <div
           {...attributes}
+          ref={this.props.innerRef}
           className={classes}
           role="tooltip"
           aria-hidden={this.props.isOpen}

--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -36,7 +36,8 @@ const propTypes = {
   ]),
   innerRef: PropTypes.oneOfType([
     PropTypes.func,
-    PropTypes.string
+    PropTypes.string,
+    PropTypes.object
   ]),
 };
 

--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -34,7 +34,10 @@ const propTypes = {
     PropTypes.string,
     PropTypes.number
   ]),
-  innerRef: PropTypes.object,
+  innerRef: PropTypes.oneOfType([
+    PropTypes.func, 
+    PropTypes.string
+  ]),
 };
 
 const DEFAULT_DELAYS = {

--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -35,7 +35,7 @@ const propTypes = {
     PropTypes.number
   ]),
   innerRef: PropTypes.oneOfType([
-    PropTypes.func, 
+    PropTypes.func,
     PropTypes.string
   ]),
 };


### PR DESCRIPTION
Adding a innerRef prop to the `div` wrapping the `Tooltip` so it can accesed _from the outside_
This PR solves the issue https://github.com/reactstrap/reactstrap/issues/1089