### PR TITLE
Added element as a prop type for the label prop

### DIFF
--- a/src/CustomInput.js
+++ b/src/CustomInput.js
@@ -7,7 +7,7 @@ const propTypes = {
   className: PropTypes.string,
   id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
   type: PropTypes.string.isRequired,
-  label: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+  label: PropTypes.node,
   inline: PropTypes.bool,
   valid: PropTypes.bool,
   invalid: PropTypes.bool,

--- a/src/CustomInput.js
+++ b/src/CustomInput.js
@@ -7,7 +7,7 @@ const propTypes = {
   className: PropTypes.string,
   id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
   type: PropTypes.string.isRequired,
-  label: PropTypes.string,
+  label: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   inline: PropTypes.bool,
   valid: PropTypes.bool,
   invalid: PropTypes.bool,


### PR DESCRIPTION
Hi, for the custom input field, when I pass a react element as a label it throws a validation error from PropTypes.

With this solution I can't pass a `I agree to <a>Terms and conditions</a>` element because it's rendering as a text.

I think Custom Input should accept either text or element as labels.