### PR TITLE
fix(Modal): Opening and closing a modal causes fixed content to jump (#1058)

### DIFF
--- a/src/__tests__/utils.spec.js
+++ b/src/__tests__/utils.spec.js
@@ -208,4 +208,34 @@ describe('Utils', () => {
   //   document.body.clientWidth = prevClientWidth;
   //   window.innerWidth = prevWindowInnerWidth;
   // });
+
+  describe('setScrollbarWidth', () => {
+    const scrollbarWidth = 16;
+    let initialBody;
+    beforeEach(() => {
+      initialBody = document.body;
+      document.body = document.createElement('body');
+    });
+    afterEach(() => {
+      document.body = initialBody;
+    });
+
+    it('applies padding to the body', () => {
+      Utils.setScrollbarWidth(scrollbarWidth);
+      expect(document.body.style.paddingRight).toBe(`${scrollbarWidth}px`);
+    });
+
+    it('applies padding to full-width fixed-position content', () => {
+      const controlElement = document.createElement('div');
+      const fixedElement = document.createElement('div');
+      fixedElement.classList.add('fixed-top');
+      document.body.appendChild(controlElement);
+      document.body.appendChild(fixedElement);
+
+      Utils.setScrollbarWidth(scrollbarWidth);
+
+      expect(controlElement.style.paddingRight).toBe('');
+      expect(fixedElement.style.paddingRight).toBe(`${scrollbarWidth}px`);
+    });
+  });
 });

--- a/src/utils.js
+++ b/src/utils.js
@@ -16,7 +16,12 @@ export function getScrollbarWidth() {
 }
 
 export function setScrollbarWidth(padding) {
-  document.body.style.paddingRight = padding > 0 ? `${padding}px` : null;
+  const paddingRight = padding > 0 ? `${padding}px` : null;
+  const fullWidthFixedContent = document.querySelectorAll('.fixed-top, .fixed-bottom');
+  const elementsAffectedByScrollbarWidth = [document.body, ...fullWidthFixedContent];
+  elementsAffectedByScrollbarWidth.forEach((element) => {
+    element.style.paddingRight = paddingRight; // eslint-disable-line no-param-reassign
+  });
 }
 
 export function isBodyOverflowing() {


### PR DESCRIPTION
Update setScrollbarWidth to additionally apply padding to full-width position-fixed content.

https://github.com/reactstrap/reactstrap/issues/1058