### PR TITLE
Tooltip: Custom `className` for the arrow element through `props`

### DIFF
--- a/docs/lib/Components/TooltipsPage.js
+++ b/docs/lib/Components/TooltipsPage.js
@@ -51,6 +51,8 @@ export default class TooltipsPage extends React.Component {
   className: PropTypes.string,
   // Apply class to the inner-tooltip
   innerClassName: PropTypes.string,
+  // Apply class to the arrow-tooltip ('arrow' by default)
+  arrowClassName: PropTypes.string,
   // optionally hide tooltip when hovering over tooltip content - default true
   autohide: PropTypes.bool,
   // convenience attachments for popover

--- a/src/PopperContent.js
+++ b/src/PopperContent.js
@@ -28,7 +28,6 @@ const defaultProps = {
   hideArrow: false,
   isOpen: false,
   offset: 0,
-  arrowClassName: 'arrow',
   fallbackPlacement: 'flip',
   flip: true,
   container: 'body',
@@ -147,7 +146,10 @@ class PopperContent extends React.Component {
       modifiers,
       ...attrs
     } = this.props;
-    const arrowClassName = mapToCssModules(_arrowClassName, cssModule);
+    const arrowClassName = mapToCssModules(classNames(
+      'arrow',
+      _arrowClassName
+    ), cssModule);
     const placement = (this.state.placement || attrs.placement).split('-')[0];
     const popperClassName = mapToCssModules(classNames(
       className,

--- a/src/PopperContent.js
+++ b/src/PopperContent.js
@@ -10,6 +10,7 @@ const propTypes = {
   className: PropTypes.string,
   placement: PropTypes.string,
   placementPrefix: PropTypes.string,
+  arrowClassName: PropTypes.string,
   hideArrow: PropTypes.bool,
   tag: PropTypes.string,
   isOpen: PropTypes.bool.isRequired,
@@ -27,6 +28,7 @@ const defaultProps = {
   hideArrow: false,
   isOpen: false,
   offset: 0,
+  arrowClassName: 'arrow',
   fallbackPlacement: 'flip',
   flip: true,
   container: 'body',
@@ -137,6 +139,7 @@ class PopperContent extends React.Component {
       offset,
       fallbackPlacement,
       placementPrefix,
+      arrowClassName,
       hideArrow,
       className,
       tag,
@@ -144,7 +147,7 @@ class PopperContent extends React.Component {
       modifiers,
       ...attrs
     } = this.props;
-    const arrowClassName = mapToCssModules('arrow', cssModule);
+    const _arrowClassName = mapToCssModules(arrowClassName, cssModule);
     const placement = (this.state.placement || attrs.placement).split('-')[0];
     const popperClassName = mapToCssModules(classNames(
       className,
@@ -165,7 +168,7 @@ class PopperContent extends React.Component {
     return (
       <ReactPopper modifiers={extendedModifiers} {...attrs} component={tag} className={popperClassName} x-placement={this.state.placement || attrs.placement}>
         {children}
-        {!hideArrow && <Arrow className={arrowClassName} />}
+        {!hideArrow && <Arrow className={_arrowClassName} />}
       </ReactPopper>
     );
   }

--- a/src/PopperContent.js
+++ b/src/PopperContent.js
@@ -139,7 +139,7 @@ class PopperContent extends React.Component {
       offset,
       fallbackPlacement,
       placementPrefix,
-      arrowClassName,
+      arrowClassName: _arrowClassName,
       hideArrow,
       className,
       tag,
@@ -147,7 +147,7 @@ class PopperContent extends React.Component {
       modifiers,
       ...attrs
     } = this.props;
-    const _arrowClassName = mapToCssModules(arrowClassName, cssModule);
+    const arrowClassName = mapToCssModules(_arrowClassName, cssModule);
     const placement = (this.state.placement || attrs.placement).split('-')[0];
     const popperClassName = mapToCssModules(classNames(
       className,
@@ -168,7 +168,7 @@ class PopperContent extends React.Component {
     return (
       <ReactPopper modifiers={extendedModifiers} {...attrs} component={tag} className={popperClassName} x-placement={this.state.placement || attrs.placement}>
         {children}
-        {!hideArrow && <Arrow className={_arrowClassName} />}
+        {!hideArrow && <Arrow className={arrowClassName} />}
       </ReactPopper>
     );
   }

--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -21,6 +21,7 @@ const propTypes = {
   hideArrow: PropTypes.bool,
   className: PropTypes.string,
   innerClassName: PropTypes.string,
+  arrowClassName: PropTypes.string,
   cssModule: PropTypes.object,
   toggle: PropTypes.func,
   autohide: PropTypes.bool,
@@ -229,6 +230,7 @@ class Tooltip extends React.Component {
         hideArrow={this.props.hideArrow}
         placement={this.props.placement}
         placementPrefix={this.props.placementPrefix}
+        arrowClassName={this.props.arrowClassName}
         container={this.props.container}
         modifiers={this.props.modifiers}
         offset={this.props.offset}


### PR DESCRIPTION
PR to solve the issue → #1117 