### PR TITLE
feat(DropdownMenu): centering dropdown menus

### DIFF
--- a/docs/lib/Components/DropdownsPage.js
+++ b/docs/lib/Components/DropdownsPage.js
@@ -88,6 +88,7 @@ DropdownToggle.propTypes = {
 DropdownMenu.propTypes = {
   tag: PropTypes.string,
   children: PropTypes.node.isRequired,
+  center: PropTypes.bool,
   right: PropTypes.bool,
   flip: PropTypes.bool, // default: true,
   className: PropTypes.string,
@@ -112,22 +113,44 @@ DropdownItem.propTypes = {
           </PrismCode>
         </pre>
         <SectionTitle>Alignment</SectionTitle>
-        <p>To align the <code>DropdownMenu</code> to the right, add a <code>right</code> prop to <code>Dropdown</code>.</p>
+        <p>
+          To align the <code>DropdownMenu</code> to the right, add a <code>right</code> prop to <code>DropdownMenu</code>.
+          To center the menu, add a <code>center</code> prop.
+        </p>
         <div className="docs-example">
-          <div style={{ display: 'inline-block' }}>
-            <Dropdown isOpen={this.state.example2} toggle={this.toggleExample2}>
-              <DropdownToggle caret>
-                Dropdown's menu is right-aligned
-              </DropdownToggle>
-              <DropdownMenu right>
-                <DropdownItem header>Header</DropdownItem>
-                <DropdownItem disabled>Action</DropdownItem>
-                <DropdownItem>Another Action</DropdownItem>
-                <DropdownItem divider />
-                <DropdownItem>Another Really Really Long Action (Really!)</DropdownItem>
-              </DropdownMenu>
-            </Dropdown>
-          </div>
+          <Row>
+            <Col>
+              <Dropdown isOpen={this.state.example2} toggle={this.toggleExample2}>
+                <DropdownToggle caret>
+                  Dropdown's menu is right-aligned
+                </DropdownToggle>
+                <DropdownMenu right>
+                  <DropdownItem header>Header</DropdownItem>
+                  <DropdownItem disabled>Action</DropdownItem>
+                  <DropdownItem>Another Action</DropdownItem>
+                  <DropdownItem divider />
+                  <DropdownItem>Another Really Really Long Action (Really!)</DropdownItem>
+                </DropdownMenu>
+              </Dropdown>
+            </Col>
+            <Col>
+              <Dropdown
+                isOpen={this.state.alignCenter}
+                toggle={() => this.setState({alignCenter: !this.state.alignCenter})}
+              >
+                <DropdownToggle caret>
+                  Dropdown's menu is centered
+                </DropdownToggle>
+                <DropdownMenu center>
+                  <DropdownItem header>Header</DropdownItem>
+                  <DropdownItem disabled>Action</DropdownItem>
+                  <DropdownItem>Another Action</DropdownItem>
+                  <DropdownItem divider />
+                  <DropdownItem>Another Really Really Long Action (Really!)</DropdownItem>
+                </DropdownMenu>
+              </Dropdown>
+            </Col>
+          </Row>
         </div>
         <pre>
           <PrismCode className="language-jsx">
@@ -141,6 +164,19 @@ DropdownItem.propTypes = {
     <DropdownItem>Another Action</DropdownItem>
     <DropdownItem divider/>
     <DropdownItem>Another Action</DropdownItem>
+  </DropdownMenu>
+</Dropdown>
+
+<Dropdown isOpen={this.state.dropdownOpen} toggle={this.toggle}>
+  <DropdownToggle caret>
+    Dropdown's menu is centered
+  </DropdownToggle>
+  <DropdownMenu center>
+    <DropdownItem header>Header</DropdownItem>
+    <DropdownItem disabled>Action</DropdownItem>
+    <DropdownItem>Another Action</DropdownItem>
+    <DropdownItem divider />
+    <DropdownItem>Another Really Really Long Action (Really!)</DropdownItem>
   </DropdownMenu>
 </Dropdown>`}
           </PrismCode>

--- a/src/DropdownMenu.js
+++ b/src/DropdownMenu.js
@@ -55,12 +55,7 @@ const DropdownMenu = (props, context) => {
 
     const position1 = directionPositionMap[context.direction] || 'bottom';
     const position2 = right ? 'end' : 'start';
-    if (center) {
-      attrs.placement = position1;
-    } else {
-      attrs.placement = `${position1}-${position2}`;
-    }
-
+    attrs.placement = center ? position1 : `${position1}-${position2}`;
     attrs.component = tag;
     attrs.modifiers = !flip ? {
       ...modifiers,

--- a/src/DropdownMenu.js
+++ b/src/DropdownMenu.js
@@ -13,11 +13,13 @@ const propTypes = {
   className: PropTypes.string,
   cssModule: PropTypes.object,
   persist: PropTypes.bool,
+  center: PropTypes.bool,
 };
 
 const defaultProps = {
   tag: 'div',
   flip: true,
+  center: false,
 };
 
 const contextTypes = {
@@ -36,7 +38,7 @@ const directionPositionMap = {
 };
 
 const DropdownMenu = (props, context) => {
-  const { className, cssModule, right, tag, flip, modifiers, persist, ...attrs } = props;
+  const { className, cssModule, right, tag, flip, modifiers, persist, center, ...attrs } = props;
   const classes = mapToCssModules(classNames(
     className,
     'dropdown-menu',
@@ -53,7 +55,12 @@ const DropdownMenu = (props, context) => {
 
     const position1 = directionPositionMap[context.direction] || 'bottom';
     const position2 = right ? 'end' : 'start';
-    attrs.placement = `${position1}-${position2}`;
+    if (center) {
+      attrs.placement = position1;
+    } else {
+      attrs.placement = `${position1}-${position2}`;
+    }
+
     attrs.component = tag;
     attrs.modifiers = !flip ? {
       ...modifiers,

--- a/src/__tests__/DropdownMenu.spec.js
+++ b/src/__tests__/DropdownMenu.spec.js
@@ -92,6 +92,19 @@ describe('DropdownMenu', () => {
     expect(wrapper.find('.dropdown-menu').hostNodes().hasClass('dropdown-menu-right')).toBe(true);
   });
 
+  it('should render center aligned menus', () => {
+    isOpen = true;
+    const wrapper = mount(
+      <DropdownMenu center>Ello world</DropdownMenu>,
+      {
+        context: { isOpen, direction, inNavbar, popperManager },
+        childContextTypes: { popperManager }
+      }
+    );
+
+    expect(wrapper.find(Popper).prop('placement')).toBe('bottom');
+  });
+
   it('should render down when direction is "down" on the context', () => {
     isOpen = true;
     const wrapper = shallow(


### PR DESCRIPTION
A user should have an ability to render center aligned dropdowns. The Popper.JS library supports this behavior, so we can easily implement it in the reactstrap.