### PR TITLE
fix(Modal): prevent scrollbar from closing (#1097)

### DIFF
--- a/src/Modal.js
+++ b/src/Modal.js
@@ -83,8 +83,8 @@ class Modal extends React.Component {
 
     this._element = null;
     this._originalBodyPadding = null;
+    this.handleBackdropClick = this.handleBackdropClick.bind(this);
     this.handleBackdropMouseDown = this.handleBackdropMouseDown.bind(this);
-    this.handleBackdropMouseUp = this.handleBackdropMouseUp.bind(this);
     this.handleEscape = this.handleEscape.bind(this);
     this.onOpened = this.onOpened.bind(this);
     this.onClosed = this.onClosed.bind(this);
@@ -166,10 +166,8 @@ class Modal extends React.Component {
     }
   }
 
-  handleBackdropMouseDown(e) {
-    this._mouseDownElement = e.target;
-  }
-  handleBackdropMouseUp(e) {
+  // not mouseUp because scrollbar fires it, shouldn't close when user scrolls
+  handleBackdropClick(e) {
     if (e.target === this._mouseDownElement) {
       e.stopPropagation();
       if (!this.props.isOpen || this.props.backdrop !== true) return;
@@ -180,6 +178,10 @@ class Modal extends React.Component {
         this.props.toggle(e);
       }
     }
+  }
+
+  handleBackdropMouseDown(e) {
+    this._mouseDownElement = e.target;
   }
 
   handleEscape(e) {
@@ -269,8 +271,8 @@ class Modal extends React.Component {
       } = this.props;
 
       const modalAttributes = {
+        onClick: this.handleBackdropClick,
         onMouseDown: this.handleBackdropMouseDown,
-        onMouseUp: this.handleBackdropMouseUp,
         onKeyUp: this.handleEscape,
         style: { display: 'block' },
         'aria-labelledby': labelledBy,

--- a/src/__tests__/Modal.spec.js
+++ b/src/__tests__/Modal.spec.js
@@ -563,9 +563,9 @@ describe('Modal', () => {
     mouseDownEvent.initEvent('mousedown', true, true);
     modal.dispatchEvent(mouseDownEvent);
 
-    const mouseUpEvent = document.createEvent('MouseEvents');
-    mouseUpEvent.initEvent('mouseup', true, true);
-    modal.dispatchEvent(mouseUpEvent);
+    const clickEvent = document.createEvent('MouseEvents');
+    clickEvent.initEvent('click', true, true);
+    modal.dispatchEvent(clickEvent);
 
     jest.runTimersToTime(300);
 


### PR DESCRIPTION
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->
- [x] Bug fix <!-- (change which fixes an issue) -->
- [ ] New feature <!-- (change which adds functionality) -->
- [ ] Chore <!-- (change which doesn't affect the usage of the package (such as a documentation, build process, or project setup change)) -->
- [ ] Breaking change <!-- (fix or feature that would cause existing functionality to change) -->
- [x] There is an open issue which this change addresses
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [x] My commits follow the [Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- - [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- Put any other information you believe would be useful to know when reviewing this PR below -->
Kept the initial click element reference being saved on `mouseDown` #1047, that prevents closing while user is selecting text and accidentally moves cursor outside modal. But changed `mouseUp` back to `click`, which doesn't fire on scrollbar press, so that user can scroll long modals again.

<!---
If there is an issue this PR addresses, please make sure it is in the commit message per the Git Commit Guidelines above 
**AND** put the issue number below, indicating that is closes or fixes the issue.
-->
Fixes #1097.