### PR TITLE
fix(Modal): use static openCount to become resilient to classList modification

### DIFF
--- a/src/Modal.js
+++ b/src/Modal.js
@@ -249,16 +249,13 @@ class Modal extends React.Component {
     conditionallyUpdateScrollbar();
 
     document.body.appendChild(this._element);
-    if (!this.bodyClassAdded) {
-      if (Modal.openCount === 0) {
-        document.body.className = classNames(
-          document.body.className,
-          mapToCssModules('modal-open', this.props.cssModule)
-        );
-      }
-      Modal.openCount += 1;
-      this.bodyClassAdded = true;
+    if (Modal.openCount === 0) {
+      document.body.className = classNames(
+        document.body.className,
+        mapToCssModules('modal-open', this.props.cssModule)
+      );
     }
+    Modal.openCount += 1;
   }
 
   destroy() {
@@ -272,16 +269,13 @@ class Modal extends React.Component {
       this._triggeringElement = null;
     }
 
-    if (this.bodyClassAdded) {
-      if (Modal.openCount <= 1) {
-        const modalOpenClassName = mapToCssModules('modal-open', this.props.cssModule);
-        // Use regex to prevent matching `modal-open` as part of a different class, e.g. `my-modal-opened`
-        const modalOpenClassNameRegex = new RegExp(`(^| )${modalOpenClassName}( |$)`);
-        document.body.className = document.body.className.replace(modalOpenClassNameRegex, ' ').trim();
-      }
-      Modal.openCount -= 1;
-      this.bodyClassAdded = false;
+    if (Modal.openCount <= 1) {
+      const modalOpenClassName = mapToCssModules('modal-open', this.props.cssModule);
+      // Use regex to prevent matching `modal-open` as part of a different class, e.g. `my-modal-opened`
+      const modalOpenClassNameRegex = new RegExp(`(^| )${modalOpenClassName}( |$)`);
+      document.body.className = document.body.className.replace(modalOpenClassNameRegex, ' ').trim();
     }
+    Modal.openCount -= 1;
 
     setScrollbarWidth(this._originalBodyPadding);
   }

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -250,10 +250,13 @@ class Modal extends React.Component {
 
     document.body.appendChild(this._element);
     if (!this.bodyClassAdded) {
-      document.body.className = classNames(
-        document.body.className,
-        mapToCssModules('modal-open', this.props.cssModule)
-      );
+      if (Modal.openCount === 0) {
+        document.body.className = classNames(
+          document.body.className,
+          mapToCssModules('modal-open', this.props.cssModule)
+        );
+      }
+      Modal.openCount += 1;
       this.bodyClassAdded = true;
     }
   }
@@ -270,10 +273,13 @@ class Modal extends React.Component {
     }
 
     if (this.bodyClassAdded) {
-      const modalOpenClassName = mapToCssModules('modal-open', this.props.cssModule);
-      // Use regex to prevent matching `modal-open` as part of a different class, e.g. `my-modal-opened`
-      const modalOpenClassNameRegex = new RegExp(`(^| )${modalOpenClassName}( |$)`);
-      document.body.className = document.body.className.replace(modalOpenClassNameRegex, ' ').trim();
+      if (Modal.openCount <= 1) {
+        const modalOpenClassName = mapToCssModules('modal-open', this.props.cssModule);
+        // Use regex to prevent matching `modal-open` as part of a different class, e.g. `my-modal-opened`
+        const modalOpenClassNameRegex = new RegExp(`(^| )${modalOpenClassName}( |$)`);
+        document.body.className = document.body.className.replace(modalOpenClassNameRegex, ' ').trim();
+      }
+      Modal.openCount -= 1;
       this.bodyClassAdded = false;
     }
 
@@ -385,5 +391,6 @@ class Modal extends React.Component {
 
 Modal.propTypes = propTypes;
 Modal.defaultProps = defaultProps;
+Modal.openCount = 0;
 
 export default Modal;

--- a/src/__tests__/Modal.spec.js
+++ b/src/__tests__/Modal.spec.js
@@ -658,7 +658,13 @@ describe('Modal', () => {
 
     jest.runTimersToTime(300);
     expect(document.getElementsByClassName('modal-dialog').length).toBe(2);
-    expect(document.body.className).toBe('modal-open modal-open');
+    expect(document.body.className).toBe('modal-open');
+
+    toggleNested();
+    jest.runTimersToTime(300);
+    expect(isOpenNested).toBe(false);
+    expect(document.getElementsByClassName('modal-dialog').length).toBe(2);
+    expect(document.body.className).toBe('modal-open');
 
     wrapper.unmount();
     expect(document.getElementsByClassName('modal-dialog').length).toBe(0);


### PR DESCRIPTION
- [x] Bug fix <!-- (change which fixes an issue) -->
- [ ] New feature <!-- (change which adds functionality) -->
- [ ] Chore <!-- (change which doesn't affect the usage of the package (such as a documentation, build process, or project setup change)) -->
- [ ] Breaking change <!-- (fix or feature that would cause existing functionality to change) -->
- [x] There is an open issue which this change addresses
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [x] My commits follow the [Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- - [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

For the last two bullets - I didn't add a test, but modified the existing tests.

Calls to document.body.classList removes duplicate class names.
This commit makes the Modal more resilient to these modifications by keeping a static counter on open Modals and adds "modal-open" only when the
initializing the first modal and removes "modal-open" only when destroying the last modal.

This fixes reactstrap#1189