### PR TITLE
feat(Popover/Tooltip): Implented usage of react 16.3 RefObject as target

### DIFF
--- a/src/Popover.js
+++ b/src/Popover.js
@@ -2,20 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import PopperContent from './PopperContent';
-import { getTarget, DOMElement, mapToCssModules, omit, PopperPlacements } from './utils';
+import { getTarget, mapToCssModules, omit, PopperPlacements, targetPropType } from './utils';
 
 const propTypes = {
   placement: PropTypes.oneOf(PopperPlacements),
-  target: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-    DOMElement,
-  ]).isRequired,
-  container: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-    DOMElement,
-  ]),
+  target: targetPropType.isRequired,
+  container: targetPropType,
   boundariesElement: PropTypes.string,
   isOpen: PropTypes.bool,
   disabled: PropTypes.bool,
@@ -58,8 +50,8 @@ class Popover extends React.Component {
     this.toggle = this.toggle.bind(this);
     this.show = this.show.bind(this);
     this.hide = this.hide.bind(this);
+    this._target = null;
   }
-
   componentDidMount() {
     this._target = getTarget(this.props.target);
     this.handleProps();
@@ -124,13 +116,15 @@ class Popover extends React.Component {
   }
 
   handleDocumentClick(e) {
-    if (e.target !== this._target && !this._target.contains(e.target) && e.target !== this._popover && !(this._popover && this._popover.contains(e.target))) {
-      if (this._hideTimeout) {
-        this.clearHideTimeout();
-      }
+    if (this._target) {
+      if (e.target !== this._target && !this._target.contains(e.target) && e.target !== this._popover && !(this._popover && this._popover.contains(e.target))) {
+        if (this._hideTimeout) {
+          this.clearHideTimeout();
+        }
 
-      if (this.props.isOpen) {
-        this.toggle(e);
+        if (this.props.isOpen) {
+          this.toggle(e);
+        }
       }
     }
   }

--- a/src/PopperContent.js
+++ b/src/PopperContent.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import classNames from 'classnames';
 import { Arrow, Popper as ReactPopper } from 'react-popper';
-import { getTarget, DOMElement, mapToCssModules } from './utils';
+import { getTarget, targetPropType, mapToCssModules } from './utils';
 
 const propTypes = {
   children: PropTypes.node.isRequired,
@@ -18,8 +18,8 @@ const propTypes = {
   offset: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   fallbackPlacement: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
   flip: PropTypes.bool,
-  container: PropTypes.oneOfType([PropTypes.string, PropTypes.func, DOMElement]),
-  target: PropTypes.oneOfType([PropTypes.string, PropTypes.func, DOMElement]).isRequired,
+  container: targetPropType,
+  target: targetPropType.isRequired,
   modifiers: PropTypes.object,
   boundariesElement: PropTypes.string,
 };

--- a/src/PopperTargetHelper.js
+++ b/src/PopperTargetHelper.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import { getTarget, DOMElement } from './utils';
+import { getTarget, targetPropType } from './utils';
 
 const PopperTargetHelper = (props, context) => {
   context.popperManager.setTargetNode(getTarget(props.target));
@@ -11,7 +11,7 @@ PopperTargetHelper.contextTypes = {
 };
 
 PopperTargetHelper.propTypes = {
-  target: PropTypes.oneOfType([PropTypes.string, PropTypes.func, DOMElement]).isRequired,
+  target: targetPropType.isRequired,
 };
 
 export default PopperTargetHelper;

--- a/src/__tests__/Popover.spec.js
+++ b/src/__tests__/Popover.spec.js
@@ -376,6 +376,19 @@ describe('Popover', () => {
     wrapper.detach();
   });
 
+  it('should not throw when passed a ref object as the target', () => {
+    const targetObj = React.createRef();
+
+    const wrapper = mount(
+      <Popover target={targetObj} isOpen={isOpen} toggle={toggle}>Yo!</Popover>,
+      { attachTo: container }
+    );
+
+    toggle();
+
+    wrapper.detach();
+  });
+
   describe('delay', () => {
     it('should accept a number', () => {
       isOpen = true;

--- a/src/__tests__/Tooltip.spec.js
+++ b/src/__tests__/Tooltip.spec.js
@@ -300,6 +300,19 @@ describe('Tooltip', () => {
     wrapper.detach();
   });
 
+  it('should not throw when passed a ref object as the target', () => {
+    const targetObj = React.createRef();
+    const event = createSpyObj('event', ['preventDefault']);
+    const wrapper = mount(
+      <Tooltip target={targetObj}>Yo!</Tooltip>,
+      { attachTo: container });
+
+    const instance = wrapper.instance();
+    instance.toggle(event);
+
+    wrapper.detach();
+  });
+
   describe('delay', () => {
     it('should accept a number', () => {
       isOpen = true;

--- a/src/__tests__/Uncontrolled.spec.js
+++ b/src/__tests__/Uncontrolled.spec.js
@@ -114,4 +114,10 @@ describe('UncontrolledTooltip', () => {
     const tooltip = shallow(<UncontrolledTooltip boundariesElement="window" target="blah">Yo!</UncontrolledTooltip>);
     expect(tooltip.prop('boundariesElement')).toBe('window');
   });
+
+  it('should render correctly with a ref object as the target', () => {
+    const target = React.createRef();
+    const tooltip = shallow(<UncontrolledTooltip target={target}>Yo!</UncontrolledTooltip>);
+    expect(tooltip.exists()).toBe(true);
+  });
 });

--- a/src/__tests__/utils.spec.js
+++ b/src/__tests__/utils.spec.js
@@ -157,6 +157,16 @@ describe('Utils', () => {
         Utils.getTarget(target);
       }).toThrow(`The target '${target}' could not be identified in the dom, tip: check spelling`);
     });
+
+    it('should return the value of the `current` object if it is a react Ref object', () => {
+      const target = { current: { name: 'hello' } };
+      expect(Utils.getTarget(target)).toEqual(target.current);
+    });
+
+    it('should return null if the `current` property of the target is null', () => {
+      const target = { current: null };
+      expect(Utils.getTarget(target)).toBeNull();
+    });
   });
 
   describe('setGlobalCssModule', () => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,5 @@
 import isFunction from 'lodash.isfunction';
+import PropTypes from 'prop-types';
 
 // https://github.com/twbs/bootstrap/blob/v4.0.0-alpha.4/js/src/modal.js#L436-L443
 export function getScrollbarWidth() {
@@ -124,6 +125,14 @@ export function DOMElement(props, propName, componentName) {
   }
 }
 
+export const targetPropType = PropTypes.oneOfType([
+  PropTypes.string,
+  PropTypes.func,
+  DOMElement,
+  PropTypes.shape({ current: PropTypes.any })
+]);
+
+
 /* eslint key-spacing: ["error", { afterColon: true, align: "value" }] */
 // These are all setup to match what is in the bootstrap _variables.scss
 // https://github.com/twbs/bootstrap/blob/v4-dev/scss/_variables.scss
@@ -192,7 +201,17 @@ export const canUseDOM = !!(
   window.document.createElement
 );
 
+export function isReactRefObj(target) {
+  if (target && typeof target === 'object') {
+    return 'current' in target;
+  }
+  return false;
+}
+
 export function findDOMElements(target) {
+  if (isReactRefObj(target)) {
+    return target.current;
+  }
   if (isFunction(target)) {
     return target();
   }
@@ -212,8 +231,12 @@ export function findDOMElements(target) {
 }
 
 export function isArrayOrNodeList(els) {
+  if (els === null) {
+    return false;
+  }
   return Array.isArray(els) || (canUseDOM && typeof els.length === 'number');
 }
+
 
 export function getTarget(target) {
   const els = findDOMElements(target);


### PR DESCRIPTION
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->
- [x] Bug fix <!-- (change which fixes an issue) -->
- [x] New feature <!-- (change which adds functionality) -->
- [ ] Chore <!-- (change which doesn't affect the usage of the package (such as a documentation, build process, or project setup change)) -->
- [ ] Breaking change <!-- (fix or feature that would cause existing functionality to change) -->
- [x] There is an open issue which this change addresses
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [x] My commits follow the [Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- Put any other information you believe would be useful to know when reviewing this PR below -->
R.E. issue #1198

This pull request adds support for using React 16.3 `createRef` object as the `target` and `container` props for `Tooltip` and `Popover` components. I have updated the type definitions in [my fork](https://github.com/josh-degraw/DefinitelyTyped/tree/reactstrap-josh-degraw/types/reactstrap) so that those can be updated as well.

I added tests to cover my changes, but testing is definitely _not_ my forte, so if I did something wrong there or I'm missing something, please let me know and I'll fix / update it ASAP.

<!---
If there is an issue this PR addresses, please make sure it is in the commit message per the Git Commit Guidelines above 
**AND** put the issue number below, indicating that is closes or fixes the issue.
-->
