### PR TITLE
fix(Input): make plaintext output input by default

### DIFF
--- a/src/Input.js
+++ b/src/Input.js
@@ -75,7 +75,7 @@ class Input extends React.Component {
 
     if (plaintext || staticInput) {
       formControlClass = `${formControlClass}-plaintext`;
-      Tag = tag || 'p';
+      Tag = tag || 'input';
     } else if (fileInput) {
       formControlClass = `${formControlClass}-file`;
     } else if (checkInput) {

--- a/src/__tests__/Input.spec.js
+++ b/src/__tests__/Input.spec.js
@@ -21,10 +21,10 @@ describe('Input', () => {
     expect(wrapper.type()).toBe('textarea');
   });
 
-  it('should render with "p" tag when plaintext prop is truthy', () => {
+  it('should render with "input" tag when plaintext prop is truthy', () => {
     const wrapper = shallow(<Input type="select" plaintext />);
 
-    expect(wrapper.type()).toBe('p');
+    expect(wrapper.type()).toBe('input');
   });
 
   it('should render with "form-control-plaintext" class when plaintext prop is truthy', () => {


### PR DESCRIPTION
BREAKING CHANGE: previously plaintext on Input would output a 'p' tag. To better line up with bootstrap it will not output an 'input' tag. If you need a 'p' tag, provide tag="p" prop

<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->
- [x] Bug fix <!-- (change which fixes an issue) -->
- [ ] New feature <!-- (change which adds functionality) -->
- [ ] Chore <!-- (change which doesn't affect the usage of the package (such as a documentation, build process, or project setup change)) -->
- [x] Breaking change <!-- (fix or feature that would cause existing functionality to change) -->
- [x] There is an open issue which this change addresses
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [x] My commits follow the [Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- - [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


Closes #1225