### PR TITLE
fix(PopperContent): Use create portal instead of unstable_renderSubtr…

### DIFF
--- a/src/PopperContent.js
+++ b/src/PopperContent.js
@@ -47,6 +47,7 @@ class PopperContent extends React.Component {
     this.handlePlacementChange = this.handlePlacementChange.bind(this);
     this.setTargetNode = this.setTargetNode.bind(this);
     this.getTargetNode = this.getTargetNode.bind(this);
+    this.getRef = this.getRef.bind(this);
     this.state = {};
   }
 
@@ -59,21 +60,10 @@ class PopperContent extends React.Component {
     };
   }
 
-  componentDidMount() {
-    this.handleProps();
-  }
-
-  componentDidUpdate(prevProps) {
-    if (this.props.isOpen !== prevProps.isOpen) {
-      this.handleProps();
-    } else if (this._element) {
-      // rerender
-      this.renderIntoSubtree();
+  componentDidUpdate() {
+    if (this._element && this._element.childNodes && this._element.childNodes[0] && this._element.childNodes[0].focus) {
+      this._element.childNodes[0].focus();
     }
-  }
-
-  componentWillUnmount() {
-    this.hide();
   }
 
   setTargetNode(node) {
@@ -88,46 +78,15 @@ class PopperContent extends React.Component {
     return getTarget(this.props.container);
   }
 
+  getRef(ref) {
+    this._element = ref;
+  }
+
   handlePlacementChange(data) {
     if (this.state.placement !== data.placement) {
       this.setState({ placement: data.placement });
     }
     return data;
-  }
-
-  handleProps() {
-    if (this.props.container !== 'inline') {
-      if (this.props.isOpen) {
-        this.show();
-      } else {
-        this.hide();
-      }
-    }
-  }
-
-  hide() {
-    if (this._element) {
-      this.getContainerNode().removeChild(this._element);
-      ReactDOM.unmountComponentAtNode(this._element);
-      this._element = null;
-    }
-  }
-
-  show() {
-    this._element = document.createElement('div');
-    this.getContainerNode().appendChild(this._element);
-    this.renderIntoSubtree();
-    if (this._element.childNodes && this._element.childNodes[0] && this._element.childNodes[0].focus) {
-      this._element.childNodes[0].focus();
-    }
-  }
-
-  renderIntoSubtree() {
-    ReactDOM.unstable_renderSubtreeIntoContainer(
-      this,
-      this.renderChildren(),
-      this._element
-    );
   }
 
   renderChildren() {
@@ -182,8 +141,10 @@ class PopperContent extends React.Component {
   render() {
     this.setTargetNode(getTarget(this.props.target));
 
-    if (this.props.container === 'inline') {
-      return this.props.isOpen ? this.renderChildren() : null;
+    if (this.props.isOpen) {
+      return this.props.container === 'inline' ?
+        this.renderChildren() :
+        ReactDOM.createPortal((<div ref={this.getRef}>{this.renderChildren()}</div>), this.getContainerNode());
     }
 
     return null;

--- a/src/__tests__/Tooltip.spec.js
+++ b/src/__tests__/Tooltip.spec.js
@@ -83,7 +83,7 @@ describe('Tooltip', () => {
 
     const tooltips = document.getElementsByClassName('tooltip');
 
-    expect(wrapper.find('.tooltip.show').hostNodes().length).toBe(0);
+    expect(wrapper.find('.tooltip.show').hostNodes().length).toBe(1);
     expect(tooltips.length).toBe(1);
     expect(tooltips[0].textContent).toBe('Tooltip Content');
     wrapper.detach();
@@ -99,8 +99,7 @@ describe('Tooltip', () => {
     );
 
     const tooltips = document.getElementsByClassName('tooltip');
-
-    expect(wrapper.find('.tooltip.show').hostNodes().length).toBe(0);
+    expect(wrapper.find('.tooltip.show').hostNodes().length).toBe(1);
     expect(tooltips.length).toBe(1);
     expect(tooltips[0].textContent).toBe('Tooltip Content');
     wrapper.detach();


### PR DESCRIPTION
…eeIntoContainer

This update *should* have no visible effects.

<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->
- [x] Bug fix <!-- (change which fixes an issue) --> 
- [ ] New feature <!-- (change which adds functionality) -->
- [ ] Chore <!-- (change which doesn't affect the usage of the package (such as a documentation, build process, or project setup change)) -->
- [ ] Breaking change <!-- (fix or feature that would cause existing functionality to change) -->
- [ ] There is an open issue which this change addresses
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [x] My commits follow the [Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- - [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- Put any other information you believe would be useful to know when reviewing this PR below -->

I am getting an obscure error occasionally with `unstable_renderSubtreeIntoContainer` on react versions newer than 15.4.1 (possibly older versions too) where react *thinks* the container is not mounted. It is the same error as https://github.com/reactstrap/reactstrap/issues/1216
I unfortunately am having trouble creating a minimally reproducible example 😕
<!---
If there is an issue this PR addresses, please make sure it is in the commit message per the Git Commit Guidelines above 
**AND** put the issue number below, indicating that is closes or fixes the issue.
-->
