### PR TITLE
fix(Modal): Only show backdrop when backdrop={true}

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,18 +1,18 @@
 <!---
 What types of changes does your code introduce? Put an `x` in all the boxes that apply:
 -->
-- [ ] Bug fix <!-- (change which fixes an issue) -->
+- [x] Bug fix <!-- (change which fixes an issue) -->
 - [ ] New feature <!-- (change which adds functionality) -->
 - [ ] Chore <!-- (change which doesn't affect the usage of the package (such as a documentation, build process, or project setup change)) -->
 - [ ] Breaking change <!-- (fix or feature that would cause existing functionality to change) -->
-- [ ] There is an open issue which this change addresses
-- [ ] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
-- [ ] My commits follow the [Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
-- [ ] My code follows the code style of this project.
+- [x] There is an open issue which this change addresses
+- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
+- [x] My commits follow the [Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
+- [x] My code follows the code style of this project.
 - [ ] My change requires a change to the documentation.
 - - [ ] I have updated the documentation accordingly.
 - [ ] I have added tests to cover my changes.
-- [ ] All new and existing tests passed.
+- [x] All new and existing tests passed.
 
 <!-- Put any other information you believe would be useful to know when reviewing this PR below -->
 

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -373,7 +373,7 @@ class Modal extends React.Component {
               {external}
               {this.renderModalDialog()}
             </Fade>
-            {Backdrop}
+            {backdrop && Backdrop}
           </div>
         </Portal>
       );


### PR DESCRIPTION
- [x] Bug fix <!-- (change which fixes an issue) -->
- [ ] New feature <!-- (change which adds functionality) -->
- [ ] Chore <!-- (change which doesn't affect the usage of the package (such as a documentation, build process, or project setup change)) -->
- [ ] Breaking change <!-- (fix or feature that would cause existing functionality to change) -->
- [x] There is an open issue which this change addresses
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [x] My commits follow the [Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- - [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Fade change introduced in v6.4.0 will always render modal backdrop if fade={false}.
This fixes #1267 