### PR TITLE
fix(FormGroup): remove `.position-relative`

### DIFF
--- a/src/FormGroup.js
+++ b/src/FormGroup.js
@@ -32,7 +32,6 @@ const FormGroup = (props) => {
 
   const classes = mapToCssModules(classNames(
     className,
-    'position-relative',
     row ? 'row' : false,
     check ? 'form-check' : 'form-group',
     check && inline ? 'form-check-inline' : false,


### PR DESCRIPTION
PR #1074 introduced the option to have form feedback as a tooltip. That's great!  
It also added the class `.position-relative` to `FormGroup`.  
As bootstrap states

> Be sure to have a parent with position: relative on it for tooltip positioning.
> http://getbootstrap.com/docs/4.1/components/forms/#tooltips

User should be responsible of adding that class

Resolves #1269