### PR TITLE
fix(Modal): only show backdrop when prop is true

### DIFF
--- a/src/Modal.js
+++ b/src/Modal.js
@@ -348,14 +348,14 @@ class Modal extends React.Component {
         timeout: hasTransition ? this.props.backdropTransition.timeout : 0,
       };
 
-      const Backdrop = hasTransition ?
+      const Backdrop = backdrop && (hasTransition ?
         (<Fade
           {...backdropTransition}
           in={isOpen && !!backdrop}
           cssModule={cssModule}
           className={mapToCssModules(classNames('modal-backdrop', backdropClassName), cssModule)}
         />)
-        : <div className={mapToCssModules(classNames('modal-backdrop', 'show', backdropClassName), cssModule)} />;
+        : <div className={mapToCssModules(classNames('modal-backdrop', 'show', backdropClassName), cssModule)} />);
 
       return (
         <Portal node={this._element}>
@@ -373,7 +373,7 @@ class Modal extends React.Component {
               {external}
               {this.renderModalDialog()}
             </Fade>
-            {backdrop && Backdrop}
+            {Backdrop}
           </div>
         </Portal>
       );

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -373,7 +373,7 @@ class Modal extends React.Component {
               {external}
               {this.renderModalDialog()}
             </Fade>
-            {Backdrop}
+            {backdrop && Backdrop}
           </div>
         </Portal>
       );

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -348,14 +348,16 @@ class Modal extends React.Component {
         timeout: hasTransition ? this.props.backdropTransition.timeout : 0,
       };
 
-      const Backdrop = backdrop && (hasTransition ?
-        (<Fade
-          {...backdropTransition}
-          in={isOpen && !!backdrop}
-          cssModule={cssModule}
-          className={mapToCssModules(classNames('modal-backdrop', backdropClassName), cssModule)}
-        />)
-        : <div className={mapToCssModules(classNames('modal-backdrop', 'show', backdropClassName), cssModule)} />);
+      const Backdrop = backdrop && (
+        hasTransition ?
+          (<Fade
+            {...backdropTransition}
+            in={isOpen && !!backdrop}
+            cssModule={cssModule}
+            className={mapToCssModules(classNames('modal-backdrop', backdropClassName), cssModule)}
+          />)
+          : <div className={mapToCssModules(classNames('modal-backdrop', 'show', backdropClassName), cssModule)} />
+      );
 
       return (
         <Portal node={this._element}>


### PR DESCRIPTION

- [x] Bug fix <!-- (change which fixes an issue) -->
- [ ] New feature <!-- (change which adds functionality) -->
- [ ] Chore <!-- (change which doesn't affect the usage of the package (such as a documentation, build process, or project setup change)) -->
- [ ] Breaking change <!-- (fix or feature that would cause existing functionality to change) -->
- [x] There is an open issue which this change addresses
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [x] My commits follow the [Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- - [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Change introduced in v6.4.0 causes Modal backdrop to incorrectly render when `backdrop={false}`, if `fade={false}`.  This change will only render backdrop if `backdrop` is true.

Fixes #1267 