### PR TITLE
fix(Dropdown): improve keyboard ux, WAI-ARIA

### DIFF
--- a/docs/lib/examples/Dropdown.js
+++ b/docs/lib/examples/Dropdown.js
@@ -25,10 +25,12 @@ export default class Example extends React.Component {
         </DropdownToggle>
         <DropdownMenu>
           <DropdownItem header>Header</DropdownItem>
-          <DropdownItem disabled>Action</DropdownItem>
-          <DropdownItem>Another Action</DropdownItem>
+          <DropdownItem>Some Action</DropdownItem>
+          <DropdownItem disabled>Action (disabled)</DropdownItem>
           <DropdownItem divider />
-          <DropdownItem>Another Action</DropdownItem>
+          <DropdownItem>Foo Action</DropdownItem>
+          <DropdownItem>Bar Action</DropdownItem>
+          <DropdownItem>Quo Action</DropdownItem>
         </DropdownMenu>
       </Dropdown>
     );

--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -79,7 +79,19 @@ class Dropdown extends React.Component {
   }
 
   getContainer() {
+    if (this._$container) return this._$container;
+    this._$container = ReactDOM.findDOMNode(this);
     return ReactDOM.findDOMNode(this);
+  }
+
+  getMenuCtrl() {
+    if (this._$menuCtrl) return this._$menuCtrl;
+    this._$menuCtrl = this.getContainer().querySelector('[aria-expanded]');
+    return this._$menuCtrl;
+  }
+
+  getMenuItems() {
+    return [].slice.call(this.getContainer().querySelectorAll('[role="menuitem"]'));
   }
 
   addEvents() {
@@ -106,60 +118,64 @@ class Dropdown extends React.Component {
   }
 
   handleKeyDown(e) {
-    if (keyCodes.tab === e.which ||
-      (/button/i.test(e.target.tagName) && e.which === keyCodes.space) ||
-      /input|textarea/i.test(e.target.tagName)) {
+    if (
+      /input|textarea/i.test(e.target.tagName)
+      || (keyCodes.tab === e.which && e.target.getAttribute('role') !== 'menuitem')
+    ) {
       return;
     }
 
     e.preventDefault();
+
     if (this.props.disabled) return;
 
-    const container = this.getContainer();
-
-    if ((e.which === keyCodes.space || e.which === keyCodes.enter) && this.props.isOpen && container !== e.target) {
-      e.target.click();
-    }
-
-    if (e.which === keyCodes.esc || !this.props.isOpen) {
-      this.toggle(e);
-      container.querySelector('[aria-expanded]').focus();
-      return;
-    }
-
-    const menuClass = mapToCssModules('dropdown-menu', this.props.cssModule);
-    const itemClass = mapToCssModules('dropdown-item', this.props.cssModule);
-    const disabledClass = mapToCssModules('disabled', this.props.cssModule);
-
-    const items = container.querySelectorAll(`.${menuClass} .${itemClass}:not(.${disabledClass})`);
-    if (!items.length) return;
-
-    let index = -1;
-
-    const charPressed = String.fromCharCode(e.which).toLowerCase();
-
-    for (let i = 0; i < items.length; i += 1) {
-      const firstLetter = items[i].textContent && items[i].textContent[0].toLowerCase();
-      if (firstLetter === charPressed || items[i] === e.target) {
-        index = i;
-        break;
+    if (this.getMenuCtrl() === e.target) {
+      if (
+        !this.props.isOpen
+        && ([keyCodes.space, keyCodes.enter, keyCodes.up, keyCodes.down].indexOf(e.which) > -1)
+      ) {
+        this.toggle(e);
+        setTimeout(() => this.getMenuItems()[0].focus());
       }
     }
 
-    if (e.which === keyCodes.up && index > 0) {
-      index -= 1;
+    if (this.props.isOpen && (e.target.getAttribute('role') === 'menuitem')) {
+      if ([keyCodes.tab, keyCodes.esc].indexOf(e.which) > -1) {
+        this.toggle(e);
+        this.getMenuCtrl().focus();
+      } else if ([keyCodes.space, keyCodes.enter].indexOf(e.which) > -1) {
+        e.target.click();
+        this.getMenuCtrl().focus();
+      } else if (
+        [keyCodes.down, keyCodes.up].indexOf(e.which) > -1
+        || ([keyCodes.n, keyCodes.p].indexOf(e.which) > -1 && e.ctrlKey)
+      ) {
+        const $menuitems = this.getMenuItems();
+        let index = $menuitems.indexOf(e.target);
+        if (keyCodes.up === e.which || (keyCodes.p === e.which && e.ctrlKey)) {
+          index = index !== 0 ? index - 1 : $menuitems.length - 1;
+        } else if (keyCodes.down === e.which || (keyCodes.n === e.which && e.ctrlKey)) {
+          index = index === $menuitems.length - 1 ? 0 : index + 1;
+        }
+        $menuitems[index].focus();
+      } else if (keyCodes.end === e.which) {
+        const $menuitems = this.getMenuItems();
+        $menuitems[$menuitems.length - 1].focus();
+      } else if (keyCodes.home === e.which) {
+        const $menuitems = this.getMenuItems();
+        $menuitems[0].focus();
+      } else if ((e.which >= 48) && (e.which <= 90)) {
+        const $menuitems = this.getMenuItems();
+        const charPressed = String.fromCharCode(e.which).toLowerCase();
+        for (let i = 0; i < $menuitems.length; i += 1) {
+          const firstLetter = $menuitems[i].textContent && $menuitems[i].textContent[0].toLowerCase();
+          if (firstLetter === charPressed) {
+            $menuitems[i].focus();
+            break;
+          }
+        }
+      }
     }
-
-    if (e.which === keyCodes.down && index < items.length - 1) {
-      index += 1;
-    }
-
-
-    if (index < 0) {
-      index = 0;
-    }
-
-    items[index].focus();
   }
 
   handleProps() {

--- a/src/DropdownItem.js
+++ b/src/DropdownItem.js
@@ -58,6 +58,7 @@ class DropdownItem extends React.Component {
 
   render() {
     const tabIndex = this.getTabIndex();
+    const role = tabIndex > -1 ? 'menuitem' : undefined;
     let {
       className,
       cssModule,
@@ -93,6 +94,7 @@ class DropdownItem extends React.Component {
         type={(Tag === 'button' && (props.onClick || this.props.toggle)) ? 'button' : undefined}
         {...props}
         tabIndex={tabIndex}
+        role={role}
         className={classes}
         onClick={this.onClick}
       />

--- a/src/__tests__/Dropdown.spec.js
+++ b/src/__tests__/Dropdown.spec.js
@@ -268,36 +268,14 @@ describe('Dropdown', () => {
         <Dropdown isOpen={isOpen} toggle={toggle}>
           <DropdownToggle>Toggle</DropdownToggle>
           <DropdownMenu right>
-            <DropdownItem>Test</DropdownItem>
+            <DropdownItem id="test">Test</DropdownItem>
             <DropdownItem id="divider" divider />
           </DropdownMenu>
         </Dropdown>, { attachTo: element });
 
       expect(Dropdown.prototype.toggle.mock.calls.length).toBe(0);
 
-      wrapper.simulate('keydown', { which: keyCodes.esc });
-
-      expect(Dropdown.prototype.toggle.mock.calls.length).toBe(1);
-
-      wrapper.detach();
-    });
-
-    it('should call toggle on ESC keydown when it isOpen is true', () => {
-      isOpen = false;
-      jest.spyOn(Dropdown.prototype, 'toggle');
-
-      const wrapper = mount(
-        <Dropdown isOpen={isOpen} toggle={toggle}>
-          <DropdownToggle>Toggle</DropdownToggle>
-          <DropdownMenu right>
-            <DropdownItem>Test</DropdownItem>
-            <DropdownItem id="divider" divider />
-          </DropdownMenu>
-        </Dropdown>, { attachTo: element });
-
-      expect(Dropdown.prototype.toggle.mock.calls.length).toBe(0);
-
-      wrapper.simulate('keydown', { which: keyCodes.esc });
+      wrapper.find('#test').hostNodes().simulate('keydown', { which: keyCodes.esc });
 
       expect(Dropdown.prototype.toggle.mock.calls.length).toBe(1);
 
@@ -319,7 +297,7 @@ describe('Dropdown', () => {
 
       expect(Dropdown.prototype.toggle.mock.calls.length).toBe(0);
 
-      wrapper.simulate('keydown', { which: keyCodes.down });
+      wrapper.find('[aria-haspopup]').hostNodes().simulate('keydown', { which: keyCodes.down });
 
       expect(Dropdown.prototype.toggle.mock.calls.length).toBe(1);
 
@@ -341,68 +319,101 @@ describe('Dropdown', () => {
 
       expect(Dropdown.prototype.toggle.mock.calls.length).toBe(0);
 
-      wrapper.simulate('keydown', { which: keyCodes.up });
+      wrapper.find('[aria-haspopup]').hostNodes().simulate('keydown', { which: keyCodes.up });
 
       expect(Dropdown.prototype.toggle.mock.calls.length).toBe(1);
 
       wrapper.detach();
     });
 
-    it('should focus the first menu item on up arrow keydown when it isOpen is true', () => {
-      isOpen = true;
+    it('should focus the first menuitem when toggle is triggered by enter keydown', () => {
+      jest.useFakeTimers();
       jest.spyOn(Dropdown.prototype, 'toggle');
       const focus = jest.fn();
-
       const wrapper = mount(
         <Dropdown isOpen={isOpen} toggle={toggle}>
           <DropdownToggle>Toggle</DropdownToggle>
-          <DropdownMenu right>
+          <DropdownMenu>
+            <DropdownItem header>Header</DropdownItem>
+            <DropdownItem disabled>Disabled</DropdownItem>
             <DropdownItem onFocus={focus}>Test</DropdownItem>
-            <DropdownItem id="divider" divider />
+            <DropdownItem divider />
+            <DropdownItem>Another Test</DropdownItem>
           </DropdownMenu>
-        </Dropdown>, { attachTo: element });
+        </Dropdown>, { attachTo: element }
+      );
 
+      expect(focus.mock.calls.length).toBe(0);
       expect(Dropdown.prototype.toggle.mock.calls.length).toBe(0);
 
-      wrapper.simulate('keydown', { which: keyCodes.up });
+      wrapper.find('[aria-haspopup]').hostNodes().simulate('keydown', { which: keyCodes.enter });
+      jest.runAllTimers();
 
-      expect(Dropdown.prototype.toggle.mock.calls.length).toBe(0);
       expect(focus.mock.calls.length).toBe(1);
+      expect(Dropdown.prototype.toggle.mock.calls.length).toBe(1);
 
       wrapper.detach();
     });
 
-    it('should focus the first menu item on down arrow keydown when it isOpen is true', () => {
-      isOpen = true;
+    it('should focus the first menuitem when toggle is triggered by up arrow keydown', () => {
+      jest.useFakeTimers();
       jest.spyOn(Dropdown.prototype, 'toggle');
-      const focus1 = jest.fn();
-      const focus2 = jest.fn();
-      const focus3 = jest.fn();
-
+      const focus = jest.fn();
       const wrapper = mount(
         <Dropdown isOpen={isOpen} toggle={toggle}>
           <DropdownToggle>Toggle</DropdownToggle>
-          <DropdownMenu right>
-            <DropdownItem onFocus={focus1}>Test</DropdownItem>
-            <DropdownItem onFocus={focus2}>Test</DropdownItem>
-            <DropdownItem id="divider" divider />
-            <DropdownItem onFocus={focus3}>Test</DropdownItem>
+          <DropdownMenu>
+            <DropdownItem header>Header</DropdownItem>
+            <DropdownItem disabled>Disabled</DropdownItem>
+            <DropdownItem onFocus={focus}>Test</DropdownItem>
+            <DropdownItem divider />
+            <DropdownItem>Another Test</DropdownItem>
           </DropdownMenu>
-        </Dropdown>, { attachTo: element });
+        </Dropdown>, { attachTo: element }
+      );
 
+      expect(focus.mock.calls.length).toBe(0);
       expect(Dropdown.prototype.toggle.mock.calls.length).toBe(0);
 
-      wrapper.simulate('keydown', { which: keyCodes.down });
+      wrapper.find('[aria-haspopup]').hostNodes().simulate('keydown', { which: keyCodes.up });
+      jest.runAllTimers();
 
-      expect(Dropdown.prototype.toggle.mock.calls.length).toBe(0);
-      expect(focus1.mock.calls.length).toBe(1);
-      expect(focus2.mock.calls.length).toBe(0);
-      expect(focus3.mock.calls.length).toBe(0);
+      expect(focus.mock.calls.length).toBe(1);
+      expect(Dropdown.prototype.toggle.mock.calls.length).toBe(1);
 
       wrapper.detach();
     });
 
-    it('should focus the next menu item on down arrow keydown when it isOpen is true and anther item is focused', () => {
+    it('should focus the first menuitem when toggle is triggered by down arrow keydown', () => {
+      jest.useFakeTimers();
+      jest.spyOn(Dropdown.prototype, 'toggle');
+      const focus = jest.fn();
+      const wrapper = mount(
+        <Dropdown isOpen={isOpen} toggle={toggle}>
+          <DropdownToggle>Toggle</DropdownToggle>
+          <DropdownMenu>
+            <DropdownItem header>Header</DropdownItem>
+            <DropdownItem disabled>Disabled</DropdownItem>
+            <DropdownItem onFocus={focus}>Test</DropdownItem>
+            <DropdownItem divider />
+            <DropdownItem>Another Test</DropdownItem>
+          </DropdownMenu>
+        </Dropdown>, { attachTo: element }
+      );
+
+      expect(focus.mock.calls.length).toBe(0);
+      expect(Dropdown.prototype.toggle.mock.calls.length).toBe(0);
+
+      wrapper.find('[aria-haspopup]').hostNodes().simulate('keydown', { which: keyCodes.down });
+      jest.runAllTimers();
+
+      expect(focus.mock.calls.length).toBe(1);
+      expect(Dropdown.prototype.toggle.mock.calls.length).toBe(1);
+
+      wrapper.detach();
+    });
+
+    it('should focus the next menuitem on down arrow keydown when isOpen is true', () => {
       isOpen = true;
       jest.spyOn(Dropdown.prototype, 'toggle');
       const focus1 = jest.fn();
@@ -432,6 +443,36 @@ describe('Dropdown', () => {
       wrapper.detach();
     });
 
+    it('should focus the next menuitem on ctrl + n keydown when isOpen is true', () => {
+      isOpen = true;
+      jest.spyOn(Dropdown.prototype, 'toggle');
+      const focus1 = jest.fn();
+      const focus2 = jest.fn();
+      const focus3 = jest.fn();
+
+      const wrapper = mount(
+        <Dropdown isOpen={isOpen} toggle={toggle}>
+          <DropdownToggle>Toggle</DropdownToggle>
+          <DropdownMenu right>
+            <DropdownItem id="first" onFocus={focus1}>Test</DropdownItem>
+            <DropdownItem onFocus={focus2}>Test</DropdownItem>
+            <DropdownItem id="divider" divider />
+            <DropdownItem onFocus={focus3}>Test</DropdownItem>
+          </DropdownMenu>
+        </Dropdown>, { attachTo: element });
+
+      expect(Dropdown.prototype.toggle.mock.calls.length).toBe(0);
+
+      wrapper.find('#first').hostNodes().simulate('keydown', { which: keyCodes.n, ctrlKey: true });
+
+      expect(Dropdown.prototype.toggle.mock.calls.length).toBe(0);
+      expect(focus1.mock.calls.length).toBe(0);
+      expect(focus2.mock.calls.length).toBe(1);
+      expect(focus3.mock.calls.length).toBe(0);
+
+      wrapper.detach();
+    });
+
     it('should focus the first menu item matching the character pressed when isOpen is true', () => {
       isOpen = true;
       jest.spyOn(Dropdown.prototype, 'toggle');
@@ -442,7 +483,7 @@ describe('Dropdown', () => {
       const wrapper = mount(
         <Dropdown isOpen={isOpen} toggle={toggle}>
           <DropdownToggle>Toggle</DropdownToggle>
-          <DropdownMenu id="dropdown" right>
+          <DropdownMenu right>
             <DropdownItem id="first" onFocus={focus1}>Reactstrap</DropdownItem>
             <DropdownItem onFocus={focus2}>4</DropdownItem>
             <DropdownItem id="divider" divider />
@@ -452,7 +493,7 @@ describe('Dropdown', () => {
 
       expect(Dropdown.prototype.toggle.mock.calls.length).toBe(0);
 
-      wrapper.find('#dropdown').hostNodes().simulate('keydown', { which: 52 });
+      wrapper.find('#first').hostNodes().simulate('keydown', { which: 52 });
       expect(Dropdown.prototype.toggle.mock.calls.length).toBe(0);
 
       expect(focus1.mock.calls.length).toBe(0);
@@ -492,7 +533,7 @@ describe('Dropdown', () => {
       wrapper.detach();
     });
 
-    it('should focus the previous menu item on up arrow keydown when it isOpen is true and anther item is focused', () => {
+    it('should focus the previous menu item on up arrow keydown when isOpen is true and another item is focused', () => {
       isOpen = true;
       jest.spyOn(Dropdown.prototype, 'toggle');
       const focus1 = jest.fn();
@@ -522,7 +563,37 @@ describe('Dropdown', () => {
       wrapper.detach();
     });
 
-    it('should not wrap focus with down arrow keydown', () => {
+    it('should focus the previous menuitem on ctrl + p keydown when isOpen is true and another item is focused', () => {
+      isOpen = true;
+      jest.spyOn(Dropdown.prototype, 'toggle');
+      const focus1 = jest.fn();
+      const focus2 = jest.fn();
+      const focus3 = jest.fn();
+
+      const wrapper = mount(
+        <Dropdown isOpen={isOpen} toggle={toggle}>
+          <DropdownToggle>Toggle</DropdownToggle>
+          <DropdownMenu right>
+            <DropdownItem id="first" onFocus={focus1}>Test</DropdownItem>
+            <DropdownItem id="second" onFocus={focus2}>Test</DropdownItem>
+            <DropdownItem id="divider" divider />
+            <DropdownItem onFocus={focus3}>Test</DropdownItem>
+          </DropdownMenu>
+        </Dropdown>, { attachTo: element });
+
+      expect(Dropdown.prototype.toggle.mock.calls.length).toBe(0);
+
+      wrapper.find('#second').hostNodes().simulate('keydown', { which: keyCodes.p, ctrlKey: true });
+
+      expect(Dropdown.prototype.toggle.mock.calls.length).toBe(0);
+      expect(focus1.mock.calls.length).toBe(1);
+      expect(focus2.mock.calls.length).toBe(0);
+      expect(focus3.mock.calls.length).toBe(0);
+
+      wrapper.detach();
+    });
+
+    it('should wrap focus with down arrow keydown', () => {
       isOpen = true;
       jest.spyOn(Dropdown.prototype, 'toggle');
       const focus1 = jest.fn();
@@ -545,14 +616,14 @@ describe('Dropdown', () => {
       wrapper.find('#third').hostNodes().simulate('keydown', { which: keyCodes.down });
 
       expect(Dropdown.prototype.toggle.mock.calls.length).toBe(0);
-      expect(focus1.mock.calls.length).toBe(0);
+      expect(focus1.mock.calls.length).toBe(1);
       expect(focus2.mock.calls.length).toBe(0);
-      expect(focus3.mock.calls.length).toBe(1);
+      expect(focus3.mock.calls.length).toBe(0);
 
       wrapper.detach();
     });
 
-    it('should not wrap focus with up arrow keydown', () => {
+    it('should wrap focus with up arrow keydown', () => {
       isOpen = true;
       jest.spyOn(Dropdown.prototype, 'toggle');
       const focus1 = jest.fn();
@@ -575,9 +646,71 @@ describe('Dropdown', () => {
       wrapper.find('#first').hostNodes().simulate('keydown', { which: keyCodes.up });
 
       expect(Dropdown.prototype.toggle.mock.calls.length).toBe(0);
+      expect(focus1.mock.calls.length).toBe(0);
+      expect(focus2.mock.calls.length).toBe(0);
+      expect(focus3.mock.calls.length).toBe(1);
+
+      wrapper.detach();
+    });
+
+    it('should focus the 1st item on home key keyDown', () => {
+      isOpen = true;
+      jest.spyOn(Dropdown.prototype, 'toggle');
+      const focus1 = jest.fn();
+      const focus2 = jest.fn();
+      const focus3 = jest.fn();
+
+      const wrapper = mount(
+        <Dropdown isOpen={isOpen} toggle={toggle}>
+          <DropdownToggle>Toggle</DropdownToggle>
+          <DropdownMenu>
+            <DropdownItem id="zero" disabled>Test</DropdownItem>
+            <DropdownItem id="first" onFocus={focus1}>Test</DropdownItem>
+            <DropdownItem id="second" onFocus={focus2}>Test</DropdownItem>
+            <DropdownItem id="divider" divider />
+            <DropdownItem id="third" onFocus={focus3}>Test</DropdownItem>
+          </DropdownMenu>
+        </Dropdown>, { attachTo: element });
+
+      expect(Dropdown.prototype.toggle.mock.calls.length).toBe(0);
+
+      wrapper.find('#first').hostNodes().simulate('keydown', { which: keyCodes.home });
+
+      expect(Dropdown.prototype.toggle.mock.calls.length).toBe(0);
       expect(focus1.mock.calls.length).toBe(1);
       expect(focus2.mock.calls.length).toBe(0);
       expect(focus3.mock.calls.length).toBe(0);
+
+      wrapper.detach();
+    });
+
+    it('should focus the last item on end key keyDown', () => {
+      isOpen = true;
+      jest.spyOn(Dropdown.prototype, 'toggle');
+      const focus1 = jest.fn();
+      const focus2 = jest.fn();
+      const focus3 = jest.fn();
+
+      const wrapper = mount(
+        <Dropdown isOpen={isOpen} toggle={toggle}>
+          <DropdownToggle>Toggle</DropdownToggle>
+          <DropdownMenu>
+            <DropdownItem id="zero" disabled>Test</DropdownItem>
+            <DropdownItem id="first" onFocus={focus1}>Test</DropdownItem>
+            <DropdownItem id="second" onFocus={focus2}>Test</DropdownItem>
+            <DropdownItem id="divider" divider />
+            <DropdownItem id="third" onFocus={focus3}>Test</DropdownItem>
+          </DropdownMenu>
+        </Dropdown>, { attachTo: element });
+
+      expect(Dropdown.prototype.toggle.mock.calls.length).toBe(0);
+
+      wrapper.find('#first').hostNodes().simulate('keydown', { which: keyCodes.end });
+
+      expect(Dropdown.prototype.toggle.mock.calls.length).toBe(0);
+      expect(focus1.mock.calls.length).toBe(0);
+      expect(focus2.mock.calls.length).toBe(0);
+      expect(focus3.mock.calls.length).toBe(1);
 
       wrapper.detach();
     });
@@ -608,7 +741,7 @@ describe('Dropdown', () => {
       wrapper.detach();
     });
 
-    it('should not trigger a click on buttons when an item is focused and space[bar] it pressed (browser does this)', () => {
+    it('should trigger a click on buttons when an item is focused and space[bar] it pressed (override browser defaults for focus management)', () => {
       isOpen = true;
       jest.spyOn(Dropdown.prototype, 'toggle');
       const click = jest.fn();
@@ -629,7 +762,7 @@ describe('Dropdown', () => {
       wrapper.find('#first').hostNodes().simulate('keydown', { which: keyCodes.space });
 
       expect(Dropdown.prototype.toggle.mock.calls.length).toBe(0);
-      expect(click.mock.calls.length).toBe(0);
+      expect(click.mock.calls.length).toBe(1);
 
       wrapper.detach();
     });
@@ -690,6 +823,32 @@ describe('Dropdown', () => {
       expect(Dropdown.prototype.toggle.mock.calls.length).toBe(0);
       expect(click.mock.calls.length).toBe(0);
       expect(focus.mock.calls.length).toBe(0);
+
+      wrapper.detach();
+    });
+
+    it('should toggle when isOpen is true and tab keyDown on menuitem', () => {
+      isOpen = true;
+      jest.spyOn(Dropdown.prototype, 'toggle');
+      const focus = jest.fn();
+
+      const wrapper = mount(
+        <Dropdown isOpen={isOpen} toggle={toggle}>
+          <DropdownToggle>Toggle</DropdownToggle>
+          <DropdownMenu>
+            <DropdownItem id="first">First</DropdownItem>
+            <DropdownItem id="second" onFocus={focus}>Second</DropdownItem>
+          </DropdownMenu>
+        </Dropdown>,
+        { attachTo: element }
+      );
+
+      expect(Dropdown.prototype.toggle.mock.calls.length).toBe(0);
+
+      wrapper.find('#first').hostNodes().simulate('keydown', { which: keyCodes.tab });
+
+      expect(focus.mock.calls.length).toBe(0);
+      expect(Dropdown.prototype.toggle.mock.calls.length).toBe(1);
 
       wrapper.detach();
     });

--- a/src/utils.js
+++ b/src/utils.js
@@ -175,7 +175,11 @@ export const keyCodes = {
   enter: 13,
   tab:   9,
   up:    38,
-  down:  40
+  down:  40,
+  home:  36,
+  end:   35,
+  n:     78,
+  p:     80,
 };
 
 export const PopperPlacements = [


### PR DESCRIPTION
Closes #1287 

<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->
- [ ] Bug fix <!-- (change which fixes an issue) -->
- [x] New feature <!-- (change which adds functionality) -->
- [ ] Chore <!-- (change which doesn't affect the usage of the package (such as a documentation, build process, or project setup change)) -->
- [ ] Breaking change <!-- (fix or feature that would cause existing functionality to change) -->
- [x] There is an open issue which this change addresses
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [x] My commits follow the [Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Adds additional event-handlers and focus management for the `Dropdown` component.

* focus is placed on the first menuitem on expand<sup>[1](https://www.w3.org/TR/wai-aria-practices-1.1/#menu)</sup>
* **only** space/enter opens the menu
* up/down arrow keyDown wraps<sup>[2](https://www.w3.org/TR/wai-aria-practices-1.1/#menu)</sup> (optional)
* home/end keys jump to first/last item<sup>[2](https://www.w3.org/TR/wai-aria-practices-1.1/#menu)</sup> 
* tab/space/esc returns focus to the menu button and closes the menu<sup>[1](https://www.w3.org/TR/wai-aria-practices-1.1/#menu)</sup>

![dropdown-pr](https://user-images.githubusercontent.com/30477263/48389614-1cb5a180-e6b3-11e8-9868-1e8477fc0a2e.gif)
