### PR TITLE
Modal: Don't propagate handled escape keyUp event

### DIFF
--- a/src/Modal.js
+++ b/src/Modal.js
@@ -230,6 +230,8 @@ class Modal extends React.Component {
 
   handleEscape(e) {
     if (this.props.isOpen && this.props.keyboard && e.keyCode === 27 && this.props.toggle) {
+      e.preventDefault();
+      e.stopPropagation();
       this.props.toggle(e);
     }
   }

--- a/src/__tests__/Modal.spec.js
+++ b/src/__tests__/Modal.spec.js
@@ -490,10 +490,18 @@ describe('Modal', () => {
     expect(isOpen).toBe(true);
     expect(document.getElementsByClassName('modal').length).toBe(1);
 
-    instance.handleEscape({ keyCode: 27 });
+    const escapeKeyUpEvent = {
+      keyCode: 27,
+      preventDefault: jest.fn(() => {}),
+      stopPropagation: jest.fn(() => {}),
+    };
+
+    instance.handleEscape(escapeKeyUpEvent);
     jest.runTimersToTime(300);
 
     expect(isOpen).toBe(false);
+    expect(escapeKeyUpEvent.preventDefault.mock.calls.length).toBe(1);
+    expect(escapeKeyUpEvent.stopPropagation.mock.calls.length).toBe(1);
 
     wrapper.setProps({
       isOpen: isOpen


### PR DESCRIPTION
E.g., if a modal contains an open nested modal, don't close both when pressing the escape key.