### PR TITLE
Add support for CustomInput type='switch'

### DIFF
--- a/docs/lib/examples/CustomControls.js
+++ b/docs/lib/examples/CustomControls.js
@@ -22,6 +22,14 @@ export default class Example extends React.Component {
           </div>
         </FormGroup>
         <FormGroup>
+          <Label for="exampleCheckbox">Switches</Label>
+          <div>
+            <CustomInput type="switch" id="exampleCustomSwitch" name="customSwitch" label="Turn on this custom switch" />
+            <CustomInput type="switch" id="exampleCustomSwitch2" name="customSwitch" label="Or this one" />
+            <CustomInput type="switch" id="exampleCustomSwitch3" label="But not this disabled one" disabled />
+          </div>
+        </FormGroup>
+        <FormGroup>
           <Label for="exampleCheckbox">Inline</Label>
           <div>
             <CustomInput type="checkbox" id="exampleCustomInline" label="An inline custom input" inline />

--- a/src/CustomInput.js
+++ b/src/CustomInput.js
@@ -61,7 +61,7 @@ function CustomInput(props) {
     );
   }
 
-  if (type !== 'checkbox' && type !== 'radio') {
+  if (type !== 'checkbox' && type !== 'radio' && type !== 'switch') {
     return <input {...attributes} ref={innerRef} className={classNames(validationClassNames, customClass)} />;
   }
 
@@ -77,6 +77,7 @@ function CustomInput(props) {
     <div className={wrapperClasses}>
       <input
         {...attributes}
+        type={type === 'switch' ? 'checkbox' : type}
         ref={innerRef}
         className={classNames(validationClassNames, mapToCssModules('custom-control-input', cssModule))}
       />

--- a/src/__tests__/CustomInput.spec.js
+++ b/src/__tests__/CustomInput.spec.js
@@ -103,6 +103,56 @@ describe('Custom Inputs', () => {
     });
   });
 
+  describe('CustomSwitch', () => {
+    it('should render an optional label', () => {
+      const checkbox = mount(<CustomInput type="switch" label="Yo!" />);
+      expect(checkbox.find('label').text()).toBe('Yo!');
+    });
+
+    it('should render children in the outer div', () => {
+      const checkbox = shallow(<CustomInput type="switch" />);
+      expect(checkbox.type()).toBe('div');
+    });
+
+    it('should render an input with the type of checkbox', () => {
+      const checkbox = mount(<CustomInput type="switch" />);
+      expect(checkbox.find('input').prop('type')).toBe('checkbox');
+    });
+
+    it('should pass id to both the input and label nodes', () => {
+      const checkbox = mount(<CustomInput type="switch" id="yo" />);
+      expect(checkbox.find('input').prop('id')).toBe('yo');
+      expect(checkbox.find('label').prop('htmlFor')).toBe('yo');
+    });
+
+    it('should pass classNames to the outer div', () => {
+      const checkbox = mount(<CustomInput type="switch" className="yo" />);
+      expect(checkbox.find('.custom-control').prop('className').indexOf('yo') > -1).toBeTruthy();
+    });
+
+    it('should add class is-invalid when invalid is true', () => {
+      const checkbox = mount(<CustomInput type="switch" invalid />);
+      expect(checkbox.find('input').prop('className').indexOf('is-invalid') > -1).toBeTruthy();
+    });
+
+    it('should add class is-valid when valid is true', () => {
+      const checkbox = mount(<CustomInput type="switch" valid />);
+      expect(checkbox.find('input').prop('className').indexOf('is-valid') > -1).toBeTruthy();
+    });
+
+    it('should pass all other props to the input node', () => {
+      const checkbox = mount(<CustomInput type="switch" data-testprop="yo" />);
+      expect(checkbox.find('input').prop('data-testprop')).toBe('yo');
+    });
+
+    it('should reference innerRef to the input node', () => {
+      const ref = React.createRef();
+      mount(<CustomInput type="switch" innerRef={ref} />);
+      expect(ref.current).not.toBeNull();
+      expect(ref.current).toBeInstanceOf(HTMLInputElement);
+    });
+  });
+
   describe('CustomSelect', () => {
     it('should render children in the outer div', () => {
       const select = shallow(<CustomInput type="select" />);


### PR DESCRIPTION
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->
- [ ] Bug fix <!-- (change which fixes an issue) -->
- [x] New feature <!-- (change which adds functionality) -->
- [ ] Chore <!-- (change which doesn't affect the usage of the package (such as a documentation, build process, or project setup change)) -->
- [ ] Breaking change <!-- (fix or feature that would cause existing functionality to change) -->
- [x] There is an open issue which this change addresses
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [x] My commits follow the [Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- - [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- Put any other information you believe would be useful to know when reviewing this PR below -->

In addition to the change suggested in the relevant issue, I had to make sure that `type='switch'` doesn't get passed down to the `input` element, and first gets changed to `checkbox`.

<!---
If there is an issue this PR addresses, please make sure it is in the commit message per the Git Commit Guidelines above 
**AND** put the issue number below, indicating that is closes or fixes the issue.
-->

This PR addresses #1348 