### PR TITLE
Fix issue #1358 - don't treat clicks on Portal children as Modal backdrop clicks

### DIFF
--- a/src/Modal.js
+++ b/src/Modal.js
@@ -191,9 +191,9 @@ class Modal extends React.Component {
       e.stopPropagation();
       if (!this.props.isOpen || this.props.backdrop !== true) return;
 
-      const container = this._dialog;
+      const backdrop = this._dialog ? this._dialog.parentNode : null;
 
-      if (e.target && !container.contains(e.target) && this.props.toggle) {
+      if (backdrop && e.target === backdrop && this.props.toggle) {
         this.props.toggle(e);
       }
     }


### PR DESCRIPTION
By simply checking whether the click is directly on the backdrop div element (parent of the modal dialog). Works for me after a quick check (incl. nested modals).