### PR TITLE
Tackle issue #1349 (backward-compatible Popover behavior)

### DIFF
--- a/src/TooltipPopoverWrapper.js
+++ b/src/TooltipPopoverWrapper.js
@@ -36,7 +36,8 @@ export const propTypes = {
     PropTypes.string,
     PropTypes.object
   ]),
-  trigger: PropTypes.string
+  trigger: PropTypes.string,
+  isInteractive: PropTypes.bool,
 };
 
 const DEFAULT_DELAYS = {
@@ -51,7 +52,12 @@ const defaultProps = {
   delay: DEFAULT_DELAYS,
   toggle: function () {},
   trigger: 'click',
+  isInteractive: false,
 };
+
+function isInDOMSubtree(element, subtreeRoot) {
+  return subtreeRoot && (element === subtreeRoot || subtreeRoot.contains(element));
+}
 
 class TooltipPopoverWrapper extends React.Component {
   constructor(props) {
@@ -174,17 +180,24 @@ class TooltipPopoverWrapper extends React.Component {
   }
 
   handleDocumentClick(e) {
-    if (this._target && this.props.trigger.indexOf('click') > -1) {
-      if (e.target === this._target || this._target.contains(e.target)) {
-        if (this._hideTimeout) {
-          this.clearHideTimeout();
-        }
+    const triggers = this.props.trigger.split(' ');
 
-        if (!this.props.isOpen) {
-          this.showWithDelay(e);
-        } else {
-          this.hideWithDelay(e);
-        }
+    if (this.props.isOpen && triggers.indexOf('legacy-auto-hide') > -1) {
+      // hide when clicking anywhere except target subtree (and itself if isInteractive)
+      if (!this._hideTimeout && !isInDOMSubtree(e.target, this._target) &&
+          !(this.props.isInteractive && isInDOMSubtree(e.target, this._popover))) {
+        this.hideWithDelay(e);
+      }
+    } else if (triggers.indexOf('click') > -1 && isInDOMSubtree(e.target, this._target)) {
+      // toggle when clicking target subtree
+      if (this._hideTimeout) {
+        this.clearHideTimeout();
+      }
+
+      if (!this.props.isOpen) {
+        this.showWithDelay(e);
+      } else {
+        this.hideWithDelay(e);
       }
     }
   }
@@ -193,7 +206,7 @@ class TooltipPopoverWrapper extends React.Component {
     if (this.props.trigger) {
       let triggers = this.props.trigger.split(' ');
       if (triggers.indexOf('manual') === -1) {
-        if (triggers.indexOf('click') > -1) {
+        if (triggers.indexOf('click') > -1 || triggers.indexOf('legacy-auto-hide') > -1) {
           ['click', 'touchstart'].forEach(event =>
             document.addEventListener(event, this.handleDocumentClick, true)
           );

--- a/src/TooltipPopoverWrapper.js
+++ b/src/TooltipPopoverWrapper.js
@@ -247,9 +247,9 @@ class TooltipPopoverWrapper extends React.Component {
         this.hideWithDelay,
         true
       );
-      this._target.addEventListener('keydown', this.onEscKeyDown, true);
-      this._target.addEventListener('focusin', this.show, true);
-      this._target.addEventListener('focusout', this.hide, true);
+      this._target.removeEventListener('keydown', this.onEscKeyDown, true);
+      this._target.removeEventListener('focusin', this.show, true);
+      this._target.removeEventListener('focusout', this.hide, true);
     }
 
     ['click', 'touchstart'].forEach(event =>


### PR DESCRIPTION
Via `<Popover trigger="manual" isInteractive />`.

Changed semantics for `trigger="manual"`: hide popover when clicking outside target element *and*, depending on the new `isInteractive` prop, outside the popover itself.

Would probably need some tests & documentation.