### PR TITLE
docs(Button): Update PropTypes and added DefaultProps

### DIFF
--- a/docs/lib/Components/ButtonsPage.js
+++ b/docs/lib/Components/ButtonsPage.js
@@ -34,23 +34,42 @@ export default class ButtonsPage extends React.Component {
           <PrismCode className="language-jsx">
 {`Button.propTypes = {
   active: PropTypes.bool,
+  'aria-label': PropTypes.string,
   block: PropTypes.bool,
   color: PropTypes.string, // default: 'secondary'
   disabled: PropTypes.bool,
+  outline: PropTypes.bool,
 
   // Pass in a Component to override default button element
   // example: react-router Link
   // default: 'button'
-  tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  tag: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.string,
+    PropTypes.shape({ $$typeof: PropTypes.symbol, render: PropTypes.func }),
+    PropTypes.arrayOf(PropTypes.oneOfType([
+      PropTypes.func,
+      PropTypes.string,
+      PropTypes.shape({ $$typeof: PropTypes.symbol, render: PropTypes.func }),
+    ]))
+  ]),
 
   // ref will only get you a reference to the Button component, use innerRef to get a reference to the DOM element (for things like focus management).
-  innerRef: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  innerRef: PropTypes.oneOfType([PropTypes.object, PropTypes.func, PropTypes.string]),
 
   onClick: PropTypes.func,
   size: PropTypes.string,
+  children: PropTypes.node,
+  className: PropTypes.string,
+  cssModule: PropTypes.object,
 
   // use close prop for BS4 close icon utility
   close: PropTypes.bool,
+}
+
+Button.defaultProps = {
+  color: 'secondary',
+  tag: 'button',
 }`}
           </PrismCode>
         </pre>


### PR DESCRIPTION
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->
- [ ] Bug fix <!-- (change which fixes an issue) -->
- [ ] New feature <!-- (change which adds functionality) -->
- [x] Chore <!-- (change which doesn't affect the usage of the package (such as a documentation, build process, or project setup change)) -->
- [ ] Breaking change <!-- (fix or feature that would cause existing functionality to change) -->
- [ ] There is an open issue which this change addresses
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [x] My commits follow the [Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- - [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- Put any other information you believe would be useful to know when reviewing this PR below -->
I find out that the Button props documentation does not correspond to the code. Mainly it was missing `outline` prop. I have updated the documentation of props for the Button component accordingly to the code.

<!---
If there is an issue this PR addresses, please make sure it is in the commit message per the Git Commit Guidelines above 
**AND** put the issue number below, indicating that is closes or fixes the issue.
-->
