### PR TITLE
feat(pagination-links): added props for first and last. changed carets…

### DIFF
--- a/docs/lib/Components/PaginationPage.js
+++ b/docs/lib/Components/PaginationPage.js
@@ -58,6 +58,8 @@ PaginationLink.propTypes = {
   cssModule: PropTypes.object,
   next: PropTypes.bool,
   previous: PropTypes.bool,
+  first: PropTypes.bool,
+  last: PropTypes.bool,
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   'aria-label': PropTypes.string
 };

--- a/docs/lib/examples/Pagination.js
+++ b/docs/lib/examples/Pagination.js
@@ -5,6 +5,9 @@ export default class Example extends React.Component {
   render() {
     return (
       <Pagination aria-label="Page navigation example">
+      <PaginationItem>
+          <PaginationLink first href="#" />
+        </PaginationItem>
         <PaginationItem>
           <PaginationLink previous href="#" />
         </PaginationItem>
@@ -35,6 +38,9 @@ export default class Example extends React.Component {
         </PaginationItem>
         <PaginationItem>
           <PaginationLink next href="#" />
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink last href="#" />
         </PaginationItem>
       </Pagination>
     );

--- a/docs/lib/examples/PaginationSizingLarge.js
+++ b/docs/lib/examples/PaginationSizingLarge.js
@@ -6,6 +6,9 @@ export default class Example extends React.Component {
     return (
       <Pagination size="lg" aria-label="Page navigation example">
         <PaginationItem>
+          <PaginationLink first href="#" />
+        </PaginationItem>
+        <PaginationItem>
           <PaginationLink previous href="#" />
         </PaginationItem>
         <PaginationItem>
@@ -25,6 +28,9 @@ export default class Example extends React.Component {
         </PaginationItem>
         <PaginationItem>
           <PaginationLink next href="#" />
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink last href="#" />
         </PaginationItem>
       </Pagination>
     );

--- a/docs/lib/examples/PaginationSizingSmall.js
+++ b/docs/lib/examples/PaginationSizingSmall.js
@@ -5,6 +5,9 @@ export default class Example extends React.Component {
   render() {
     return (
       <Pagination size="sm" aria-label="Page navigation example">
+      <PaginationItem>
+          <PaginationLink first href="#" />
+        </PaginationItem>
         <PaginationItem>
           <PaginationLink previous href="#" />
         </PaginationItem>
@@ -25,6 +28,9 @@ export default class Example extends React.Component {
         </PaginationItem>
         <PaginationItem>
           <PaginationLink next href="#" />
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink last href="#" />
         </PaginationItem>
       </Pagination>
     );

--- a/docs/lib/examples/PaginationState.js
+++ b/docs/lib/examples/PaginationState.js
@@ -5,6 +5,9 @@ export default class Example extends React.Component {
   render() {
     return (
       <Pagination aria-label="Page navigation example">
+      <PaginationItem disabled>
+          <PaginationLink first href="#" />
+        </PaginationItem>
         <PaginationItem disabled>
           <PaginationLink previous href="#" />
         </PaginationItem>
@@ -35,6 +38,9 @@ export default class Example extends React.Component {
         </PaginationItem>
         <PaginationItem>
           <PaginationLink next href="#" />
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink last href="#" />
         </PaginationItem>
       </Pagination>
     );

--- a/src/PaginationLink.js
+++ b/src/PaginationLink.js
@@ -10,6 +10,8 @@ const propTypes = {
   cssModule: PropTypes.object,
   next: PropTypes.bool,
   previous: PropTypes.bool,
+  first: PropTypes.bool,
+  last: PropTypes.bool,
   tag: tagPropType,
 };
 
@@ -23,6 +25,8 @@ const PaginationLink = (props) => {
     cssModule,
     next,
     previous,
+    first,
+    last,
     tag: Tag,
     ...attributes
   } = props;
@@ -37,13 +41,22 @@ const PaginationLink = (props) => {
     defaultAriaLabel = 'Previous';
   } else if (next) {
     defaultAriaLabel = 'Next';
+  } else if (first) {
+    defaultAriaLabel = 'First';
+  } else if (last) {
+    defaultAriaLabel = 'Last';
   }
+
   const ariaLabel = props['aria-label'] || defaultAriaLabel;
 
   let defaultCaret;
   if (previous) {
-    defaultCaret = '\u00ab';
+    defaultCaret = '\u2039';
   } else if (next) {
+    defaultCaret = '\u203A';
+  } else if (first) {
+    defaultCaret = '\u00ab';
+  } else if (last) {
     defaultCaret = '\u00bb';
   }
 
@@ -56,7 +69,7 @@ const PaginationLink = (props) => {
     Tag = 'button';
   }
 
-  if (previous || next) {
+  if (previous || next || first || last) {
     children = [
       <span
         aria-hidden="true"

--- a/src/__tests__/PaginationLink.spec.js
+++ b/src/__tests__/PaginationLink.spec.js
@@ -31,7 +31,7 @@ describe('PaginationLink', () => {
     const wrapper = shallow(<PaginationLink previous />);
 
     expect(wrapper.prop('aria-label')).toBe('Previous');
-    expect(wrapper.find({ 'aria-hidden': 'true' }).text()).toBe('\u00ab');
+    expect(wrapper.find({ 'aria-hidden': 'true' }).text()).toBe('\u2039');
     expect(wrapper.find('.sr-only').text()).toBe('Previous');
   });
 
@@ -39,7 +39,7 @@ describe('PaginationLink', () => {
     const wrapper = shallow(<PaginationLink next />);
 
     expect(wrapper.prop('aria-label')).toBe('Next');
-    expect(wrapper.find({ 'aria-hidden': 'true' }).text()).toBe('\u00bb');
+    expect(wrapper.find({ 'aria-hidden': 'true' }).text()).toBe('\u203A');
     expect(wrapper.find('.sr-only').text()).toBe('Next');
   });
 
@@ -47,7 +47,7 @@ describe('PaginationLink', () => {
     const wrapper = shallow(<PaginationLink previous children={[]} />);
 
     expect(wrapper.prop('aria-label')).toBe('Previous');
-    expect(wrapper.find({ 'aria-hidden': 'true' }).text()).toBe('\u00ab');
+    expect(wrapper.find({ 'aria-hidden': 'true' }).text()).toBe('\u2039');
     expect(wrapper.find('.sr-only').text()).toBe('Previous');
   });
 
@@ -55,7 +55,7 @@ describe('PaginationLink', () => {
     const wrapper = shallow(<PaginationLink next children={[]} />);
 
     expect(wrapper.prop('aria-label')).toBe('Next');
-    expect(wrapper.find({ 'aria-hidden': 'true' }).text()).toBe('\u00bb');
+    expect(wrapper.find({ 'aria-hidden': 'true' }).text()).toBe('\u203A');
     expect(wrapper.find('.sr-only').text()).toBe('Next');
   });
 
@@ -77,4 +77,37 @@ describe('PaginationLink', () => {
 
     expect(wrapper.find({ 'aria-hidden': 'true' }).text()).toBe('Yo');
   });
+
+  it('should render first', () => {
+    const wrapper = shallow(<PaginationLink first />);
+
+    expect(wrapper.prop('aria-label')).toBe('First');
+    expect(wrapper.find({ 'aria-hidden': 'true' }).text()).toBe('\u00ab');
+    expect(wrapper.find('.sr-only').text()).toBe('First');
+  });
+
+  it('should render last', () => {
+    const wrapper = shallow(<PaginationLink last />);
+
+    expect(wrapper.prop('aria-label')).toBe('Last');
+    expect(wrapper.find({ 'aria-hidden': 'true' }).text()).toBe('\u00bb');
+    expect(wrapper.find('.sr-only').text()).toBe('Last');
+  });
+
+  it('should render default first caret with children as an empty array', () => {
+    const wrapper = shallow(<PaginationLink first children={[]} />);
+
+    expect(wrapper.prop('aria-label')).toBe('First');
+    expect(wrapper.find({ 'aria-hidden': 'true' }).text()).toBe('\u00ab');
+    expect(wrapper.find('.sr-only').text()).toBe('First');
+  });
+
+  it('should render default last caret with children as an empty array', () => {
+    const wrapper = shallow(<PaginationLink last children={[]} />);
+
+    expect(wrapper.prop('aria-label')).toBe('Last');
+    expect(wrapper.find({ 'aria-hidden': 'true' }).text()).toBe('\u00bb');
+    expect(wrapper.find('.sr-only').text()).toBe('Last');
+  });
+
 });


### PR DESCRIPTION
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->
- [ ] Bug fix <!-- (change which fixes an issue) -->
- [x] New feature <!-- (change which adds functionality) -->
- [ ] Chore <!-- (change which doesn't affect the usage of the package (such as a documentation, build process, or project setup change)) -->
- [ ] Breaking change <!-- (fix or feature that would cause existing functionality to change) -->
- [ ] There is an open issue which this change addresses
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [x] My commits follow the [Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- - [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!-- Put any other information you believe would be useful to know when reviewing this PR below -->
Currently the `next` and `previous` props on the `PaginationLink` component have default carets that symbolize `first` and `last`. I added new props for `first` and `last` in order to have both features for navigating to any of these.

One change that is not breaking but does impact the view on the UI is the now the `next` and `previous` props are displaying single carets instead of double caret. I am not sure if this should be treated as a BREAKING CHANGE or not as its very minor in this case.

<!---
If there is an issue this PR addresses, please make sure it is in the commit message per the Git Commit Guidelines above 
**AND** put the issue number below, indicating that is closes or fixes the issue.
-->
