### PR TITLE
feat(modal): add optional return focus after close

### DIFF
--- a/docs/lib/Components/ModalsPage.js
+++ b/docs/lib/Components/ModalsPage.js
@@ -12,6 +12,7 @@ import ModalExternalExample from '../examples/ModalExternal';
 import ModalCustomCloseIconExample from '../examples/ModalCustomCloseIcon';
 import ModalCustomCloseButtonExample from '../examples/ModalCustomCloseButton';
 import ModalDestructuringExample from '../examples/ModalDestructuring';
+import ModalFocusAfterClose from '../examples/ModalFocusAfterClose';
 
 const ModalBackdropExampleSource = require('!!raw-loader!../examples/ModalBackdrop');
 const ModalCustomCloseButtonExampleSource = require('!!raw-loader!../examples/ModalCustomCloseButton');
@@ -22,6 +23,7 @@ const ModalExternalExampleSource = require('!!raw-loader!../examples/ModalExtern
 const ModalFadelessExampleSource = require('!!raw-loader!../examples/ModalFadeless');
 const ModalNestedExampleSource = require('!!raw-loader!../examples/ModalNested');
 const ModalDestructuringExampleSource = require('!!raw-loader!../examples/ModalDestructuring');
+const ModalFocusOnDestroyExampleSource = require('!!raw-loader!../examples/ModalFocusAfterClose');
 
 const ModalsPage = () => {
   return (
@@ -215,6 +217,20 @@ const ModalsPage = () => {
           {ModalDestructuringExampleSource}
         </PrismCode>
       </pre>
+
+       <h4>Focus after close</h4>
+       <div className="docs-example">
+         <div className="btn-group">
+           <div className="btn">
+             <ModalFocusAfterClose />
+           </div>
+         </div>
+       </div>
+       <pre>
+         <PrismCode className="language-jsx">
+           {ModalFocusOnDestroyExampleSource}
+         </PrismCode>
+       </pre>
     </div>
   );
 };

--- a/docs/lib/examples/ModalFocusAfterClose.js
+++ b/docs/lib/examples/ModalFocusAfterClose.js
@@ -1,0 +1,51 @@
+/* eslint react/no-multi-comp: 0, react/prop-types: 0 */
+
+import React from 'react';
+import { Button, Modal, ModalBody, ModalFooter, Label, Input, FormGroup, Form } from 'reactstrap';
+
+class ModalFocusAfterClose extends React.Component {
+    constructor() {
+        super();
+        this.state = {
+            open: false,
+            focusAfterClose: true
+        };
+        this.toggle = this.toggle.bind(this);
+        this.handleSelectChange = this.handleSelectChange.bind(this);
+    }
+
+    toggle() {
+        this.setState(({ open }) => ({ open: !open }));
+    }
+
+    handleSelectChange({target: { value }}) {
+        this.setState({ focusAfterClose: JSON.parse(value) });
+    }
+
+    render() {
+        return (
+            <div>
+                <Form inline onSubmit={(e) => e.preventDefault()}>
+                    <FormGroup>
+                        <Label for="focusAfterClose">Focus After Close</Label>
+                        <Input className="mx-2" type="select" id="focusAfterClose" onChange={this.handleSelectChange}>
+                            <option value="true">Yes</option>
+                            <option value="false">No</option>
+                        </Input>
+                    </FormGroup>
+                    <Button color="danger" onClick={this.toggle}>Open</Button>
+                </Form>
+                <Modal returnFocusAfterClose={this.state.focusAfterClose} isOpen={this.state.open}>
+                    <ModalBody>
+                        Observe the "Open" button. It will be focused after close when "returnFocusAfterClose" is true and will not be focused if "returnFocusAfterClose" is false.
+                    </ModalBody>
+                    <ModalFooter>
+                        <Button color="primary" onClick={this.toggle}>Close</Button>
+                    </ModalFooter>
+                </Modal>
+            </div>
+        )
+    }
+}
+
+export default ModalFocusAfterClose;

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -54,7 +54,8 @@ const propTypes = {
     PropTypes.string,
     PropTypes.func,
   ]),
-  unmountOnClose: PropTypes.bool
+  unmountOnClose: PropTypes.bool,
+  returnFocusAfterClose: PropTypes.bool
 };
 
 const propsToOmit = Object.keys(propTypes);
@@ -77,7 +78,8 @@ const defaultProps = {
     mountOnEnter: true,
     timeout: TransitionTimeouts.Fade, // uses standard fade transition
   },
-  unmountOnClose: true
+  unmountOnClose: true,
+  returnFocusAfterClose: true
 };
 
 class Modal extends React.Component {
@@ -93,6 +95,7 @@ class Modal extends React.Component {
     this.handleTab = this.handleTab.bind(this);
     this.onOpened = this.onOpened.bind(this);
     this.onClosed = this.onClosed.bind(this);
+    this.manageFocusAfterClose = this.manageFocusAfterClose.bind(this);
 
     this.state = {
       isOpen: props.isOpen,
@@ -281,8 +284,13 @@ class Modal extends React.Component {
       this._element = null;
     }
 
+    this.manageFocusAfterClose();
+  }
+
+  manageFocusAfterClose() {
     if (this._triggeringElement) {
-      if (this._triggeringElement.focus) this._triggeringElement.focus();
+      const { returnFocusAfterClose } = this.props;
+      if (this._triggeringElement.focus && returnFocusAfterClose) this._triggeringElement.focus();
       this._triggeringElement = null;
     }
   }
@@ -294,7 +302,7 @@ class Modal extends React.Component {
       const modalOpenClassNameRegex = new RegExp(`(^| )${modalOpenClassName}( |$)`);
       document.body.className = document.body.className.replace(modalOpenClassNameRegex, ' ').trim();
     }
-
+    this.manageFocusAfterClose();
     Modal.openCount = Math.max(0, Modal.openCount - 1);
 
     setScrollbarWidth(this._originalBodyPadding);


### PR DESCRIPTION
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->
- [ ] Bug fix <!-- (change which fixes an issue) -->
- [x] New feature <!-- (change which adds functionality) -->
- [ ] Chore <!-- (change which doesn't affect the usage of the package (such as a documentation, build process, or project setup change)) -->
- [ ] Breaking change <!-- (fix or feature that would cause existing functionality to change) -->
- [ ] There is an open issue which this change addresses
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [x] My commits follow the [Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- - [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!-- Put any other information you believe would be useful to know when reviewing this PR below -->
This PR adds optional prop "returnFocusAfterClose". It allows the user to adjust if they would like to return the focus to the last focused element before the modal has opened. It is working with both "unmount" and "non unmount" close. The default value of the property is "true". Currently there is an inconsistent behaviour about focus managing after close for "unmount" and "non unmount" closing (when the Modal is destroyed the focus is returned to the last element, when it is just closed, the focus is somewhere). 
<!---
If there is an issue this PR addresses, please make sure it is in the commit message per the Git Commit Guidelines above 
**AND** put the issue number below, indicating that is closes or fixes the issue.
-->
