### PR TITLE
fix(TooltipPopoverWrapper) Touch not opening popover on mobile (#1425)

### DIFF
--- a/src/TooltipPopoverWrapper.js
+++ b/src/TooltipPopoverWrapper.js
@@ -222,9 +222,7 @@ class TooltipPopoverWrapper extends React.Component {
       let triggers = this.props.trigger.split(' ');
       if (triggers.indexOf('manual') === -1) {
         if (triggers.indexOf('click') > -1 || triggers.indexOf('legacy') > -1) {
-          ['click', 'touchstart'].forEach(event =>
-            document.addEventListener(event, this.handleDocumentClick, true)
-          );
+          document.addEventListener('click', this.handleDocumentClick, true);
         }
 
         if (this._target) {
@@ -267,9 +265,7 @@ class TooltipPopoverWrapper extends React.Component {
       this._target.removeEventListener('focusout', this.hide, true);
     }
 
-    ['click', 'touchstart'].forEach(event =>
-      document.removeEventListener(event, this.handleDocumentClick, true)
-    );
+    document.removeEventListener('click', this.handleDocumentClick, true)
   }
 
   updateTarget() {

--- a/src/__tests__/TooltipPopoverWrapper.spec.js
+++ b/src/__tests__/TooltipPopoverWrapper.spec.js
@@ -229,6 +229,44 @@ describe('Tooltip', () => {
     wrapper.detach();
   });
 
+  it('should open after receiving single touchstart and single click', () => {
+    const wrapper = mount(
+      <TooltipPopoverWrapper target="target" isOpen={isOpen} toggle={toggle} trigger="click">
+        Tooltip Content
+      </TooltipPopoverWrapper>,
+      { attachTo: container }
+    );
+    
+    expect(isOpen).toBe(false);
+    target.dispatchEvent(new Event('touchstart'));
+    jest.runTimersToTime(20);
+    target.dispatchEvent(new Event('click'));
+    jest.runTimersToTime(200);
+    expect(isOpen).toBe(true);
+
+    wrapper.detach();
+  });
+
+  it('should close after receiving single touchstart and single click', () => {
+    isOpen = true;
+
+    const wrapper = mount(
+      <TooltipPopoverWrapper target="target" isOpen={isOpen} toggle={toggle} trigger="click">
+        Tooltip Content
+      </TooltipPopoverWrapper>,
+      { attachTo: container }
+    );
+    
+    expect(isOpen).toBe(true);
+    target.dispatchEvent(new Event('touchstart'));
+    jest.runTimersToTime(20);
+    target.dispatchEvent(new Event('click'));
+    jest.runTimersToTime(200);
+    expect(isOpen).toBe(false);
+
+    wrapper.detach();
+  });
+
   it('should pass down custom modifiers', () => {
     const wrapper = mount(
       <TooltipPopoverWrapper


### PR DESCRIPTION
For Popovers/Tooltips with trigger="click" or trigger="legacy", touches
on mobile were triggering touchstart and then click, which caused them
to open briefly and then immediately close. This removes the
touchstart event handling to fix behaviour on mobile.

#1425 

- [x] Bug fix <!-- (change which fixes an issue) -->
- [ ] New feature <!-- (change which adds functionality) -->
- [ ] Chore <!-- (change which doesn't affect the usage of the package (such as a documentation, build process, or project setup change)) -->
- [ ] Breaking change <!-- (fix or feature that would cause existing functionality to change) -->
- [x] There is an open issue which this change addresses
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [x] My commits follow the [Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- - [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- Put any other information you believe would be useful to know when reviewing this PR below -->


<!---
If there is an issue this PR addresses, please make sure it is in the commit message per the Git Commit Guidelines above 
**AND** put the issue number below, indicating that is closes or fixes the issue.
-->
