### PR TITLE
Allow popovers/tooltips to pass through flip prop

### DIFF
--- a/docs/lib/Components/PopoversPage.js
+++ b/docs/lib/Components/PopoversPage.js
@@ -77,7 +77,16 @@ export default class PopoversPage extends React.Component {
   offset: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.number
-  ])
+  ]),
+
+  // Whether to show/hide the popover with a fade effect
+  // (default: true)
+  fade: PropTypes.bool,
+
+  // Whether to flip the direction of the popover if too close to
+  // the container edge
+  // (default: true)
+  flip: PropTypes.bool,
 }`}
           </PrismCode>
         </pre>

--- a/docs/lib/Components/TooltipsPage.js
+++ b/docs/lib/Components/TooltipsPage.js
@@ -88,7 +88,16 @@ export default class TooltipsPage extends React.Component {
     PropTypes.func,
     PropTypes.string,
     PropTypes.object
-  ])
+  ]),
+
+  // Whether to show/hide the popover with a fade effect
+  // (default: true)
+  fade: PropTypes.bool,
+
+  // Whether to flip the direction of the popover if too close to
+  // the container edge
+  // (default: true)
+  flip: PropTypes.bool,
 }`}
           </PrismCode>
         </pre>

--- a/src/TooltipPopoverWrapper.js
+++ b/src/TooltipPopoverWrapper.js
@@ -39,6 +39,7 @@ export const propTypes = {
   ]),
   trigger: PropTypes.string,
   fade: PropTypes.bool,
+  flip: PropTypes.bool,
 };
 
 const DEFAULT_DELAYS = {
@@ -312,6 +313,7 @@ class TooltipPopoverWrapper extends React.Component {
       modifiers,
       offset,
       fade,
+      flip,
     } = this.props;
 
     const attributes = omit(this.props, Object.keys(propTypes));
@@ -337,6 +339,7 @@ class TooltipPopoverWrapper extends React.Component {
         cssModule={cssModule}
         onClosed={this.onClosed}
         fade={fade}
+        flip={flip}
       >
         <div
           {...attributes}

--- a/src/__tests__/TooltipPopoverWrapper.spec.js
+++ b/src/__tests__/TooltipPopoverWrapper.spec.js
@@ -236,7 +236,7 @@ describe('Tooltip', () => {
       </TooltipPopoverWrapper>,
       { attachTo: container }
     );
-    
+
     expect(isOpen).toBe(false);
     target.dispatchEvent(new Event('touchstart'));
     jest.runTimersToTime(20);
@@ -256,7 +256,7 @@ describe('Tooltip', () => {
       </TooltipPopoverWrapper>,
       { attachTo: container }
     );
-    
+
     expect(isOpen).toBe(true);
     target.dispatchEvent(new Event('touchstart'));
     jest.runTimersToTime(20);
@@ -312,6 +312,17 @@ describe('Tooltip', () => {
     );
 
     expect(wrapper.find(PopperContent).props().offset).toEqual('100');
+    wrapper.unmount();
+  });
+
+  it('should pass down flip', () => {
+    const wrapper = mount(
+      <TooltipPopoverWrapper isOpen target="target" flip={false}>
+        Tooltip Content
+      </TooltipPopoverWrapper>
+    );
+
+    expect(wrapper.find(PopperContent).props().flip).toBe(false);
     wrapper.unmount();
   });
 


### PR DESCRIPTION
- [ ] Bug fix <!-- (change which fixes an issue) -->
- [x] New feature <!-- (change which adds functionality) -->
- [ ] Chore <!-- (change which doesn't affect the usage of the package (such as a documentation, build process, or project setup change)) -->
- [ ] Breaking change <!-- (fix or feature that would cause existing functionality to change) -->
- [ ] There is an open issue which this change addresses
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [x] My commits follow the [Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- - [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Currently, Popper will by default flip a Popover or Tooltip if it's close to the edge of the container (typically the screen). For example:

```
<Tooltip placement="top" ...>
```

will get rendered as `placement="bottom"` if it's too close to the top of the screen.

This PR lets us disable this behavior if we want to by doing:

```
<Tooltip placement="top" flip={false} ...>
```