### PR TITLE
Use correct typing (string, not number) for styles.maxHeight in DropdownsPage doc page

### DIFF
--- a/docs/lib/Components/DropdownsPage.js
+++ b/docs/lib/Components/DropdownsPage.js
@@ -323,7 +323,7 @@ DropdownItem.propTypes = {
                           styles: {
                             ...data.styles,
                             overflow: 'auto',
-                            maxHeight: 100,
+                            maxHeight: '100px',
                           },
                         };
                       },


### PR DESCRIPTION

<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->
- [x] Bug fix <!-- (change which fixes an issue) -->
- [ ] New feature <!-- (change which adds functionality) -->
- [ ] Chore <!-- (change which doesn't affect the usage of the package (such as a documentation, build process, or project setup change)) -->
- [ ] Breaking change <!-- (fix or feature that would cause existing functionality to change) -->
- [ ] There is an open issue which this change addresses
- [ ] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [x] My commits follow the [Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- - [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- Put any other information you believe would be useful to know when reviewing this PR below -->

Tiny change in docs to reflect that `maxHeight` must be a string.

<!---
If there is an issue this PR addresses, please make sure it is in the commit message per the Git Commit Guidelines above 
**AND** put the issue number below, indicating that is closes or fixes the issue.
-->
