### PR TITLE
fix(FormGroup): allow disable when tag is fieldset

### DIFF
--- a/src/FormGroup.js
+++ b/src/FormGroup.js
@@ -37,6 +37,10 @@ const FormGroup = (props) => {
     check && inline ? 'form-check-inline' : false,
     check && disabled ? 'disabled' : false
   ), cssModule);
+  
+  if (Tag === 'fieldset') {
+    attributes.disabled = disabled;
+  }
 
   return (
     <Tag {...attributes} className={classes} />


### PR DESCRIPTION
fieldset allows the disabled attribute and has special handling in the browser.
This change will allow the disabled prop to be passed through when the tag is a fieldset

fixes #1546

- [x] Bug fix <!-- (change which fixes an issue) -->
- [ ] New feature <!-- (change which adds functionality) -->
- [ ] Chore <!-- (change which doesn't affect the usage of the package (such as a documentation, build process, or project setup change)) -->
- [ ] Breaking change <!-- (fix or feature that would cause existing functionality to change) -->
- [x] There is an open issue which this change addresses
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [x] My commits follow the [Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- - [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.