### PR TITLE
fix: Dropdown disabled toggle issue

### DIFF
--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -52,10 +52,11 @@ class Dropdown extends React.Component {
 
   getContextValue() {
     return {
-      toggle: this.props.toggle,
+      toggle: this.toggle,
       isOpen: this.props.isOpen,
       direction: (this.props.direction === 'down' && this.props.dropup) ? 'up' : this.props.direction,
       inNavbar: this.props.inNavbar,
+      disabled: this.props.disabled
     };
   }
 

--- a/src/DropdownContext.js
+++ b/src/DropdownContext.js
@@ -7,6 +7,7 @@ import React from 'react';
  *  isOpen: PropTypes.bool.isRequired,
  *  direction: PropTypes.oneOf(['up', 'down', 'left', 'right']).isRequired,
  *  inNavbar: PropTypes.bool.isRequired,
+ *  disabled: PropTypes.bool
  * }
  */
 export const DropdownContext = React.createContext({});

--- a/src/DropdownToggle.js
+++ b/src/DropdownToggle.js
@@ -33,7 +33,7 @@ class DropdownToggle extends React.Component {
   }
 
   onClick(e) {
-    if (this.props.disabled) {
+    if (this.props.disabled || this.context.disabled) {
       e.preventDefault();
       return;
     }

--- a/src/__tests__/Dropdown.spec.js
+++ b/src/__tests__/Dropdown.spec.js
@@ -735,7 +735,7 @@ describe('Dropdown', () => {
 
       wrapper.find('#first').hostNodes().simulate('keydown', { which: keyCodes.space });
 
-      expect(Dropdown.prototype.toggle.mock.calls.length).toBe(0);
+      expect(Dropdown.prototype.toggle.mock.calls.length).toBe(1);
       expect(click.mock.calls.length).toBe(1);
 
       wrapper.detach();
@@ -761,7 +761,7 @@ describe('Dropdown', () => {
 
       wrapper.find('#first').hostNodes().simulate('keydown', { which: keyCodes.space });
 
-      expect(Dropdown.prototype.toggle.mock.calls.length).toBe(0);
+      expect(Dropdown.prototype.toggle.mock.calls.length).toBe(1);
       expect(click.mock.calls.length).toBe(1);
 
       wrapper.detach();


### PR DESCRIPTION
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->
- [x] Bug fix <!-- (change which fixes an issue) -->
- [ ] New feature <!-- (change which adds functionality) -->
- [ ] Chore <!-- (change which doesn't affect the usage of the package (such as a documentation, build process, or project setup change)) -->
- [ ] Breaking change <!-- (fix or feature that would cause existing functionality to change) -->
- [x] There is an open issue which this change addresses
- [xI have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [x] My commits follow the [Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- - [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!-- Put any other information you believe would be useful to know when reviewing this PR below -->
This fix addresses the issue where Dropdown will be passed a
`disabled` prop, yet it is still clickable. This is due to context
being passed the user-defined `toggle` prop directly, rather than
our defined `this.toggle` function that includes a check for
`disabled`.

<!---
If there is an issue this PR addresses, please make sure it is in the commit message per the Git Commit Guidelines above 
**AND** put the issue number below, indicating that is closes or fixes the issue.
-->
Fixes #1542
