### PR TITLE
feat(NavbarToggler): add aria-label to NavbarToggler

### DIFF
--- a/src/NavbarToggler.js
+++ b/src/NavbarToggler.js
@@ -31,7 +31,7 @@ const NavbarToggler = (props) => {
   ), cssModule);
 
   return (
-    <Tag {...attributes} className={classes}>
+    <Tag aria-label="Toggle navigation" {...attributes} className={classes}>
       {children || <span className={mapToCssModules('navbar-toggler-icon', cssModule)} />}
     </Tag>
   );

--- a/src/__tests__/NavbarToggler.spec.js
+++ b/src/__tests__/NavbarToggler.spec.js
@@ -6,19 +6,20 @@ describe('NavbarToggler', () => {
   it('should render .navbar-toggler markup', () => {
     const wrapper = shallow(<NavbarToggler />);
 
-    expect(wrapper.html()).toBe('<button type="button" class="navbar-toggler"><span class="navbar-toggler-icon"></span></button>');
+    expect(wrapper.prop('aria-label')).toBe('Toggle navigation');
+    expect(wrapper.html()).toBe('<button aria-label="Toggle navigation" type="button" class="navbar-toggler"><span class="navbar-toggler-icon"></span></button>');
   });
 
   it('should render custom tag', () => {
     const wrapper = shallow(<NavbarToggler tag="div" />);
 
-    expect(wrapper.html()).toBe('<div type="button" class="navbar-toggler"><span class="navbar-toggler-icon"></span></div>');
+    expect(wrapper.html()).toBe('<div aria-label="Toggle navigation" type="button" class="navbar-toggler"><span class="navbar-toggler-icon"></span></div>');
   });
 
   it('should render children instead of navbar-toggler-icon ', () => {
     const wrapper = shallow(<NavbarToggler>Children</NavbarToggler>);
 
-    expect(wrapper.html()).toBe('<button type="button" class="navbar-toggler">Children</button>');
+    expect(wrapper.html()).toBe('<button aria-label="Toggle navigation" type="button" class="navbar-toggler">Children</button>');
   });
 
   it('should pass additional classNames', () => {


### PR DESCRIPTION
This adds the aria-label to the NavbarToggler as
seen in the bootstrap docs.

Fixes #1632

- [ ] Bug fix <!-- (change which fixes an issue) -->
- [x] New feature <!-- (change which adds functionality) -->
- [ ] Chore <!-- (change which doesn't affect the usage of the package (such as a documentation, build process, or project setup change)) -->
- [ ] Breaking change <!-- (fix or feature that would cause existing functionality to change) -->
- [x] There is an open issue which this change addresses
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [x] My commits follow the [Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- - [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.