### PR TITLE
fix(Carousel): Fix deprecated lifecycle method componentWillReceiveProps

### DIFF
--- a/src/Carousel.js
+++ b/src/Carousel.js
@@ -31,19 +31,24 @@ class Carousel extends React.Component {
     document.addEventListener('keyup', this.handleKeyPress);
   }
 
-  componentWillReceiveProps(nextProps) {
-    this.setInterval(nextProps);
-    // Calculate the direction to turn
-    if (this.props.activeIndex + 1 === nextProps.activeIndex) {
-      this.setState({ direction: 'right' });
-    } else if (this.props.activeIndex - 1 === nextProps.activeIndex) {
-      this.setState({ direction: 'left' });
-    } else if (this.props.activeIndex > nextProps.activeIndex) {
-      this.setState({ direction: this.state.indicatorClicked ? 'left' : 'right' });
-    } else if (this.props.activeIndex !== nextProps.activeIndex) {
-      this.setState({ direction: this.state.indicatorClicked ? 'right' : 'left' });
-    }
-    this.setState({ indicatorClicked: false });
+  componentDidUpdate(prevProps){
+    // we try to simulate the componentWillReceive props
+    // purpose, if the props are the same we are not interested to
+    // proceed anymore in the function.
+    if(prevProps === this.props) return;
+
+    this.setInterval(this.props);
+       // Calculate the direction to turn
+     if (prevProps.activeIndex + 1 === this.props.activeIndex) {
+       this.setState({ direction: 'right' });
+     } else if (prevProps.activeIndex - 1 === this.props.activeIndex) {
+       this.setState({ direction: 'left' });
+     } else if (prevProps.activeIndex > this.props.activeIndex) {
+       this.setState({ direction: this.state.indicatorClicked ? 'left' : 'right' });
+     } else if (prevProps.activeIndex !== this.props.activeIndex) {
+       this.setState({ direction: this.state.indicatorClicked ? 'right' : 'left' });
+     }
+     this.setState({ indicatorClicked: false });
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
Fix https://github.com/reactstrap/reactstrap/issues/1602

<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->
- [x] Bug fix <!-- (change which fixes an issue) -->
- [ ] New feature <!-- (change which adds functionality) -->
- [ ] Chore <!-- (change which doesn't affect the usage of the package (such as a documentation, build process, or project setup change)) -->
- [ ] Breaking change <!-- (fix or feature that would cause existing functionality to change) -->
- [x] There is an open issue which this change addresses
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [x] My commits follow the [Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- - [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- Put any other information you believe would be useful to know when reviewing this PR below -->

My approach for solving this issue was to delete the componentWillReceiveProps in favor of a componentDidUpdate implementation with the same logic, another approach was to switch to the new static method getDerivedStateFromProps, I tried the switch but the final result was really messy and full of workaround in order to not refactoring all the component and in particular the timeout handling logic. Using the componentDidUpdate results in a more clean and smooth logic implementation.

Refers to the issue https://github.com/reactstrap/reactstrap/issues/1602


<!---
If there is an issue this PR addresses, please make sure it is in the commit message per the Git Commit Guidelines above 
**AND** put the issue number below, indicating that is closes or fixes the issue.
-->
