### PR TITLE
fix(CustomInput): remove type prop from input node when type is select #1617

### DIFF
--- a/src/CustomInput.js
+++ b/src/CustomInput.js
@@ -54,7 +54,8 @@ function CustomInput(props) {
   const labelHtmlFor = htmlFor || attributes.id;
 
   if (type === 'select') {
-    return <select {...attributes} ref={innerRef} className={classNames(validationClassNames, customClass)}>{children}</select>;
+    const { type, ...rest } = attributes;
+    return <select {...rest} ref={innerRef} className={classNames(validationClassNames, customClass)}>{children}</select>;
   }
 
   if (type === 'file') {

--- a/src/__tests__/CustomInput.spec.js
+++ b/src/__tests__/CustomInput.spec.js
@@ -202,6 +202,11 @@ describe('Custom Inputs', () => {
       expect(select.find('select').prop('data-testprop')).toBe('yo');
     });
 
+    it('should remove type prop from the input node', () => {
+      const select = mount(<CustomInput type="select" />);
+      expect(select.find('select').prop('type')).toBeUndefined();
+    });
+
     it('should reference innerRef to the select node', () => {
       const ref = React.createRef();
       mount(<CustomInput type="select" innerRef={ref} />);


### PR DESCRIPTION
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->
- [x] Bug fix <!-- (change which fixes an issue) -->
- [ ] New feature <!-- (change which adds functionality) -->
- [ ] Chore <!-- (change which doesn't affect the usage of the package (such as a documentation, build process, or project setup change)) -->
- [ ] Breaking change <!-- (fix or feature that would cause existing functionality to change) -->
- [x] There is an open issue which this change addresses
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [x] My commits follow the [Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- - [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


To confirm this change is working:
1. `npm start`
2. Open http://localhost:8080/components/form/
3. Inspect source in browser and confirm that no `type` attribute is rendered to DOM for "Custom Select" example

closes #1617 