### PR TITLE
test(PopperContent): remove debug statement

### DIFF
--- a/src/__tests__/PopperContent.spec.js
+++ b/src/__tests__/PopperContent.spec.js
@@ -117,8 +117,6 @@ describe('PopperContent', () => {
   it('should have x-placement of auto by default', () => {
     const wrapper = mount(<PopperContent target="target" isOpen container="inline">Yo!</PopperContent>);
 
-    console.log(wrapper.debug());
-
     expect(wrapper.find('div[x-placement="auto"]').exists()).toBe(true);
   });
 


### PR DESCRIPTION
I accidentally left a debug statement in https://github.com/reactstrap/reactstrap/pull/1669 that was merged. This commit removes the debug statement.

<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->
- [ ] Bug fix <!-- (change which fixes an issue) -->
- [ ] New feature <!-- (change which adds functionality) -->
- [ ] Chore <!-- (change which doesn't affect the usage of the package (such as a documentation, build process, or project setup change)) -->
- [ ] Breaking change <!-- (fix or feature that would cause existing functionality to change) -->
- [ ] There is an open issue which this change addresses
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [x] My commits follow the [Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- - [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- Put any other information you believe would be useful to know when reviewing this PR below -->


<!---
If there is an issue this PR addresses, please make sure it is in the commit message per the Git Commit Guidelines above 
**AND** put the issue number below, indicating that is closes or fixes the issue.
-->
