### PR TITLE
Removes condition to call close when modal is unmounting

### DIFF
--- a/src/Modal.js
+++ b/src/Modal.js
@@ -147,9 +147,7 @@ class Modal extends React.Component {
 
     if (this._element) {
       this.destroy();
-      if (this.state.isOpen) {
-        this.close();
-      }
+      this.close();
     }
 
     this._isMounted = false;

--- a/src/__tests__/Modal.spec.js
+++ b/src/__tests__/Modal.spec.js
@@ -746,6 +746,40 @@ describe('Modal', () => {
     expect(document.body.className).toBe('');
   });
 
+  it.only('should not keep modal-open class on the body if the modal is not rendered', () => {
+    class ModalWrapper extends React.Component {
+      constructor (props) {
+        super(props);
+
+        this.state = {
+          displayModal: true
+        };
+      }
+
+      componentDidMount() {
+        this.setState({ displayModal: false });
+      }
+
+      render () {
+        const { displayModal } = this.state;
+
+        return (
+          <div>
+            {displayModal && (
+              <Modal isOpen={true} toggle={toggle}>
+                Hello!
+              </Modal>
+            )}
+          </div>
+        )
+      }
+    }
+
+    mount(<ModalWrapper />);
+
+    expect(document.body.className).toBe('');
+  })
+
   it('should remove exactly modal-open class from body', () => {
     // set a body class which includes modal-open
     document.body.className = 'my-modal-opened';


### PR DESCRIPTION
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->
- [x] Bug fix <!-- (change which fixes an issue) -->
- [ ] New feature <!-- (change which adds functionality) -->
- [ ] Chore <!-- (change which doesn't affect the usage of the package (such as a documentation, build process, or project setup change)) -->
- [ ] Breaking change <!-- (fix or feature that would cause existing functionality to change) -->
- [ ] There is an open issue which this change addresses
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [ ] My commits follow the [Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- - [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!-- Put any other information you believe would be useful to know when reviewing this PR below -->

Fixes #1626: Class 'modal-open' is persisted on body even when the Modal component is unmounted.

I'm not sure why close is conditionally called after destroying a modal but it feels like the cleanup code should run unconditionally.

I'm also not sure if my test is written in the best way. It demonstrates the problem but it looks a little clunky. Any advice is appreciated.

I might need a bit of help getting this PR into a state that into the appropriate state for merge as I got confused whilst reading the contribution guidelines.

<!---
If there is an issue this PR addresses, please make sure it is in the commit message per the Git Commit Guidelines above 
**AND** put the issue number below, indicating that is closes or fixes the issue.
-->

#1626