### PR TITLE
feat(UncontrolledDropdown): add onToggle callback

### DIFF
--- a/src/UncontrolledDropdown.js
+++ b/src/UncontrolledDropdown.js
@@ -13,8 +13,11 @@ export default class UncontrolledDropdown extends Component {
     this.toggle = this.toggle.bind(this);
   }
 
-  toggle() {
+  toggle(e) {
     this.setState({ isOpen: !this.state.isOpen });
+    if (this.props.onToggle) {
+      this.props.onToggle(e, !this.state.isOpen);
+    }
   }
 
   render() {
@@ -24,5 +27,6 @@ export default class UncontrolledDropdown extends Component {
 
 UncontrolledDropdown.propTypes = {
   defaultOpen: PropTypes.bool,
+  onToggle: PropTypes.func,
   ...Dropdown.propTypes
 };


### PR DESCRIPTION
Add `onToggle` to `UncontrolledDropdown`. The purpose of this new prop is to allow the user to be informed when the dropdown is toggled (opened/closed) as well as the new state of `isOpen` while still being uncontrolled.
when the dropdown is toggled, `onToggle` is called with the `event` and a `boolean` representing the new state (`true` mean the dropdown is being opened, `false` means it is being closed).

<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->
- [ ] Bug fix <!-- (change which fixes an issue) -->
- [x] New feature <!-- (change which adds functionality) -->
- [ ] Chore <!-- (change which doesn't affect the usage of the package (such as a documentation, build process, or project setup change)) -->
- [ ] Breaking change <!-- (fix or feature that would cause existing functionality to change) -->
- [ ] There is an open issue which this change addresses
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [x] My commits follow the [Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- - [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.