### PR TITLE
feat(ListGroup): Add horizontal prop

### DIFF
--- a/docs/lib/Components/ListGroupPage.js
+++ b/docs/lib/Components/ListGroupPage.js
@@ -10,6 +10,7 @@ import ListGroupAnchorsAndButtonsExample from '../examples/ListGroupAnchorsAndBu
 import ListGroupContextualClassesExample from '../examples/ListGroupContextualClasses';
 import ListGroupCustomContentExample from '../examples/ListGroupCustomContent';
 import ListGroupFlushExample from '../examples/ListGroupFlush';
+import ListGroupHorizontalExample from '../examples/ListGroupHorizontal';
 
 const ListGroupBadgeExampleSource = require('!!raw-loader!../examples/ListGroupBadge');
 const ListGroupExampleSource = require('!!raw-loader!../examples/ListGroup');
@@ -18,6 +19,7 @@ const ListGroupAnchorsAndButtonsExampleSource = require('!!raw-loader!../example
 const ListGroupContextualClassesExampleSource = require('!!raw-loader!../examples/ListGroupContextualClasses');
 const ListGroupCustomContentExampleSource = require('!!raw-loader!../examples/ListGroupCustomContent');
 const ListGroupFlushExampleSource = require('!!raw-loader!../examples/ListGroupFlush')
+const ListGroupHorizontalExampleSource = require("!!raw-loader!../examples/ListGroupHorizontal");
 
 export default class ListGroupPage extends React.Component {
   render() {
@@ -105,6 +107,16 @@ export default class ListGroupPage extends React.Component {
         <pre>
           <PrismCode className="language-jsx">
             {ListGroupFlushExampleSource}
+          </PrismCode>
+        </pre>
+
+        <legend>Horizontal</legend>
+        <div className="docs-example">
+          <ListGroupHorizontalExample />
+        </div>
+        <pre>
+          <PrismCode className="language-jsx">
+            {ListGroupHorizontalExampleSource}
           </PrismCode>
         </pre>
       </div>

--- a/docs/lib/Components/ListGroupPage.js
+++ b/docs/lib/Components/ListGroupPage.js
@@ -42,6 +42,8 @@ export default class ListGroupPage extends React.Component {
     tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
     // boolean to render list group items edge-to-edge in a parent container
     flush: PropTypes.bool,
+    // boolean to render list group items horizontal. string for specific breakpoint, or true to be always horizontal
+    horizontal: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
     className: PropTypes.string,
     cssModule: PropTypes.object,
   }`

--- a/docs/lib/examples/ListGroupHorizontal.js
+++ b/docs/lib/examples/ListGroupHorizontal.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { ListGroup, ListGroupItem } from 'reactstrap';
+
+const Example = (props) => {
+  return (
+    <div>
+      <p>The <code>horizontal</code> prop can be a Boolean or a string specifying one of Bootstrap's breakpoints</p>
+      <ListGroup horizontal>
+        <ListGroupItem tag="a" href="#">Cras justo odio</ListGroupItem>
+        <ListGroupItem tag="a" href="#">Dapibus ac facilisis in</ListGroupItem>
+        <ListGroupItem tag="a" href="#">Morbi leo risus</ListGroupItem>
+        <ListGroupItem tag="a" href="#">Porta ac consectetur ac</ListGroupItem>
+        <ListGroupItem tag="a" href="#">Vestibulum at eros</ListGroupItem>
+      </ListGroup>
+      <p className="mt-3">This list group is horizontal at the <code>lg</code> breakpoint and up.</p>
+      <ListGroup horizontal="lg">
+        <ListGroupItem tag="a" href="#">Cras justo odio</ListGroupItem>
+        <ListGroupItem tag="a" href="#">Dapibus ac facilisis in</ListGroupItem>
+        <ListGroupItem tag="a" href="#">Morbi leo risus</ListGroupItem>
+        <ListGroupItem tag="a" href="#">Porta ac consectetur ac</ListGroupItem>
+        <ListGroupItem tag="a" href="#">Vestibulum at eros</ListGroupItem>
+      </ListGroup>
+      <p className="mt-3">Note that horizontal list groups cannot be combined with flush list groups. If <code>flush</code> is <code>true</code> then <code>horizontal</code> has no effect.</p>
+    </div>
+
+  );
+}
+
+export default Example;

--- a/src/ListGroup.js
+++ b/src/ListGroup.js
@@ -8,10 +8,20 @@ const propTypes = {
   flush: PropTypes.bool,
   className: PropTypes.string,
   cssModule: PropTypes.object,
+  horizontal: PropTypes.oneOfType([PropTypes.bool, PropTypes.string])
 };
 
 const defaultProps = {
   tag: 'ul'
+};
+
+const getHorizontalClass = horizontal => {
+  if (horizontal === false) {
+    return false;
+  } else if (horizontal === true || horizontal === "xs") {
+    return "list-group-horizontal";
+  }
+  return `list-group-horizontal-${horizontal}`;
 };
 
 const ListGroup = (props) => {
@@ -20,12 +30,15 @@ const ListGroup = (props) => {
     cssModule,
     tag: Tag,
     flush,
+    horizontal,
     ...attributes
   } = props;
   const classes = mapToCssModules(classNames(
     className,
     'list-group',
-    flush ? 'list-group-flush' : false
+    // list-group-horizontal cannot currently be mixed with list-group-flush
+    // we only try to apply horizontal classes if flush is false
+    flush ? 'list-group-flush' : getHorizontalClass(horizontal)
   ), cssModule);
 
   return (

--- a/src/ListGroup.js
+++ b/src/ListGroup.js
@@ -12,7 +12,8 @@ const propTypes = {
 };
 
 const defaultProps = {
-  tag: 'ul'
+  tag: 'ul',
+  horizontal: false
 };
 
 const getHorizontalClass = horizontal => {

--- a/src/__tests__/ListGroup.spec.js
+++ b/src/__tests__/ListGroup.spec.js
@@ -18,6 +18,31 @@ describe('ListGroup', () => {
     expect(wrapper.hasClass('list-group-flush')).toBe(true);
   });
 
+  it('should render with "horizontal"', () => {
+    const wrapper = shallow(<ListGroup horizontal>Yo!</ListGroup>);
+
+    expect(wrapper.text()).toBe("Yo!");
+    expect(wrapper.hasClass("list-group")).toBe(true);
+    expect(wrapper.hasClass("list-group-horizontal")).toBe(true);
+  });
+
+  it('should not render with "horizontal" if flush is true', () => {
+    const wrapper = shallow(<ListGroup flush horizontal>Yo!</ListGroup>);
+
+    expect(wrapper.text()).toBe("Yo!");
+    expect(wrapper.hasClass("list-group")).toBe(true);
+    expect(wrapper.hasClass("list-group-flush")).toBe(true);
+    expect(wrapper.hasClass("list-group-horizontal")).toBe(false);
+  });
+
+  it('should render with "horizontal-{breakpoint}"', () => {
+    const wrapper = shallow(<ListGroup horizontal="lg">Yo!</ListGroup>);
+
+    expect(wrapper.text()).toBe("Yo!");
+    expect(wrapper.hasClass("list-group")).toBe(true);
+    expect(wrapper.hasClass("list-group-horizontal-lg")).toBe(true);
+  });
+
   it('should render additional classes', () => {
     const wrapper = shallow(<ListGroup className="other">Yo!</ListGroup>);
 


### PR DESCRIPTION
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->
- [ ] Bug fix <!-- (change which fixes an issue) -->
- [x] New feature <!-- (change which adds functionality) -->
- [ ] Chore <!-- (change which doesn't affect the usage of the package (such as a documentation, build process, or project setup change)) -->
- [ ] Breaking change <!-- (fix or feature that would cause existing functionality to change) -->
- [ ] There is an open issue which this change addresses
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [x] My commits follow the [Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- - [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- Put any other information you believe would be useful to know when reviewing this PR below -->

This PR adds a `horizontal` prop to `ListGroup` in order to add support for [horizontal list groups](https://getbootstrap.com/docs/4.4/components/list-group/#horizontal)

Horizontal list groups can't be mixed with flush list groups, so I made the decision to ignore the `horizontal` prop if `flush` is `true`. Happy to take guidance on this point though.

The `getHorizontalClass` function I based on the [analogous function](https://github.com/reactstrap/reactstrap/blob/master/src/Nav.js#L25-L33) in the source for `Nav` in order to be consistent with existing code.