### PR TITLE
fix(Tooltip): fix render failure if target ref is null

### DIFF
--- a/src/__tests__/utils.spec.js
+++ b/src/__tests__/utils.spec.js
@@ -189,6 +189,7 @@ describe('Utils', () => {
     it('should return null if the `current` property of the target is null', () => {
       const target = { current: null };
       expect(Utils.getTarget(target)).toBeNull();
+      expect(Utils.getTarget(target, true)).toStrictEqual([]);
     });
   });
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -305,6 +305,9 @@ export function getTarget(target, allElements) {
     if (isArrayOrNodeList(els)) {
       return els;
     }
+    if (els === null) {
+      return [];
+    }
     return [els];
   } else {
     if (isArrayOrNodeList(els)) {


### PR DESCRIPTION
This commit fixes this issue described by https://github.com/reactstrap/reactstrap/issues/1686#issuecomment-546079793, where the `getTarget` function was returning `[null]` when the allElements param was true and the ref passed in had a 'current' value of `null`. The downstream effect of this was that tooltips would fail to render. The `getTarget` function now returns an empty array (`[]`).

<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->
- [x] Bug fix <!-- (change which fixes an issue) -->
- [ ] New feature <!-- (change which adds functionality) -->
- [ ] Chore <!-- (change which doesn't affect the usage of the package (such as a documentation, build process, or project setup change)) -->
- [ ] Breaking change <!-- (fix or feature that would cause existing functionality to change) -->
- [x] There is an open issue which this change addresses
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [x] My commits follow the [Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- - [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- Put any other information you believe would be useful to know when reviewing this PR below -->


<!---
If there is an issue this PR addresses, please make sure it is in the commit message per the Git Commit Guidelines above 
**AND** put the issue number below, indicating that is closes or fixes the issue.
-->

Fixes https://github.com/reactstrap/reactstrap/issues/1686