### PR TITLE
chore(deps): bump react-transition-group from 2.3.1 to 4.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -259,7 +259,7 @@
     "prop-types": "^15.5.8",
     "react-lifecycles-compat": "^3.0.4",
     "react-popper": "^1.3.6",
-    "react-transition-group": "^2.3.1"
+    "react-transition-group": "^4.3.0"
   },
   "peerDependencies": {
     "react": "^16.3.0",


### PR DESCRIPTION
bump [react-transition-group](https://github.com/reactjs/react-transition-group) from 2.3.1 to 4.3.0

