### PR TITLE
feat(Modal): Added static backdrop animation defined in Bootstrap 4.4

### DIFF
--- a/src/Modal.js
+++ b/src/Modal.js
@@ -100,6 +100,7 @@ class Modal extends React.Component {
     this.onOpened = this.onOpened.bind(this);
     this.onClosed = this.onClosed.bind(this);
     this.manageFocusAfterClose = this.manageFocusAfterClose.bind(this);
+    this.clearBackdropAnimationTimeout = this.clearBackdropAnimationTimeout.bind(this);
 
     this.state = {
       isOpen: false,
@@ -144,6 +145,8 @@ class Modal extends React.Component {
   }
 
   componentWillUnmount() {
+    this.clearBackdropAnimationTimeout();
+
     if (this.props.onExit) {
       this.props.onExit();
     }
@@ -265,8 +268,9 @@ class Modal extends React.Component {
   }
 
   handleStaticBackdropAnimation() {
+    this.clearBackdropAnimationTimeout();
     this.setState({ showStaticBackdropAnimation: true });
-    setTimeout(() => {
+    this._backdropAnimationTimeout = setTimeout(() => {
       this.setState({ showStaticBackdropAnimation: false });
     }, 100);
   }
@@ -438,6 +442,13 @@ class Modal extends React.Component {
       );
     }
     return null;
+  }
+
+  clearBackdropAnimationTimeout() {
+    if (this._backdropAnimationTimeout) {
+      clearTimeout(this._backdropAnimationTimeout);
+      this._backdropAnimationTimeout = undefined;
+    }
   }
 }
 

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -10,7 +10,8 @@ import {
   mapToCssModules,
   omit,
   focusableElements,
-  TransitionTimeouts
+  TransitionTimeouts,
+  keyCodes
 } from './utils';
 
 function noop() { }
@@ -94,6 +95,7 @@ class Modal extends React.Component {
     this.handleBackdropClick = this.handleBackdropClick.bind(this);
     this.handleBackdropMouseDown = this.handleBackdropMouseDown.bind(this);
     this.handleEscape = this.handleEscape.bind(this);
+    this.handleStaticBackdropAnimation = this.handleStaticBackdropAnimation.bind(this);
     this.handleTab = this.handleTab.bind(this);
     this.onOpened = this.onOpened.bind(this);
     this.onClosed = this.onClosed.bind(this);
@@ -101,6 +103,7 @@ class Modal extends React.Component {
 
     this.state = {
       isOpen: false,
+      showStaticBackdropAnimation: false
     };
   }
 
@@ -202,6 +205,11 @@ class Modal extends React.Component {
   handleBackdropClick(e) {
     if (e.target === this._mouseDownElement) {
       e.stopPropagation();
+
+      if (this.props.backdrop === 'static') {
+        this.handleStaticBackdropAnimation();
+      }
+
       if (!this.props.isOpen || this.props.backdrop !== true) return;
 
       const backdrop = this._dialog ? this._dialog.parentNode : null;
@@ -243,11 +251,24 @@ class Modal extends React.Component {
   }
 
   handleEscape(e) {
-    if (this.props.isOpen && this.props.keyboard && e.keyCode === 27 && this.props.toggle) {
+    if (this.props.isOpen && this.props.keyboard && e.keyCode === keyCodes.esc && this.props.toggle) {
       e.preventDefault();
       e.stopPropagation();
+
+      if (this.props.backdrop === 'static') {
+        this.handleStaticBackdropAnimation();
+        return;
+      }
+
       this.props.toggle(e);
     }
+  }
+
+  handleStaticBackdropAnimation() {
+    this.setState({ showStaticBackdropAnimation: true });
+    setTimeout(() => {
+      this.setState({ showStaticBackdropAnimation: false });
+    }, 100);
   }
 
   init() {
@@ -405,7 +426,7 @@ class Modal extends React.Component {
               onEntered={this.onOpened}
               onExited={this.onClosed}
               cssModule={cssModule}
-              className={mapToCssModules(classNames('modal', modalClassName), cssModule)}
+              className={mapToCssModules(classNames('modal', modalClassName, this.state.showStaticBackdropAnimation && 'modal-static'), cssModule)}
               innerRef={innerRef}
             >
               {external}

--- a/src/__tests__/Modal.spec.js
+++ b/src/__tests__/Modal.spec.js
@@ -2,6 +2,7 @@
 import React from 'react';
 import { mount, shallow } from 'enzyme';
 import { Modal, ModalBody, ModalHeader, ModalFooter, Button } from '../';
+import { keyCodes } from '../utils';
 
 const didMount = (component) => {
   const wrapper = mount(component);
@@ -621,6 +622,34 @@ describe('Modal', () => {
     expect(isOpen).toBe(true);
 
     document.getElementsByClassName('modal-backdrop')[0].click();
+    jest.runTimersToTime(300);
+
+    expect(isOpen).toBe(true);
+
+    wrapper.unmount();
+  });
+
+  it('should not close modal when escape key pressed when backdrop is "static"', () => {
+    isOpen = true;
+    const wrapper = didMount(
+      <Modal isOpen={isOpen} toggle={toggle} backdrop="static">
+        <button id="clicker">Does Nothing</button>
+      </Modal>
+    );
+    const instance = wrapper.instance();
+
+    jest.runTimersToTime(300);
+
+    expect(isOpen).toBe(true);
+    expect(document.getElementsByClassName('modal').length).toBe(1);
+
+    const escapeKeyUpEvent = {
+      keyCode: keyCodes.esc,
+      preventDefault: jest.fn(() => {}),
+      stopPropagation: jest.fn(() => {}),
+    };
+
+    instance.handleEscape(escapeKeyUpEvent);
     jest.runTimersToTime(300);
 
     expect(isOpen).toBe(true);


### PR DESCRIPTION
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->
- [x] Bug fix <!-- (change which fixes an issue) -->
- [x] New feature <!-- (change which adds functionality) -->
- [ ] Chore <!-- (change which doesn't affect the usage of the package (such as a documentation, build process, or project setup change)) -->
- [ ] Breaking change <!-- (fix or feature that would cause existing functionality to change) -->
- [ ] There is an open issue which this change addresses
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [x] My commits follow the [Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- - [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- Put any other information you believe would be useful to know when reviewing this PR below -->
An animation was added for static backdrop modals in Bootstrap 4.4.  This can be demoed at the following url:
https://getbootstrap.com/docs/4.4/components/modal/#static-backdrop

In addition to this, I fixed the esc key from closing a modal when the backdrop is set to static as per docs:
https://getbootstrap.com/docs/4.4/components/modal/#options

`Includes a modal-backdrop element. Alternatively, specify static for a backdrop which doesn't close the modal on click or on escape key press.`
<!---
If there is an issue this PR addresses, please make sure it is in the commit message per the Git Commit Guidelines above 
**AND** put the issue number below, indicating that is closes or fixes the issue.
-->
