### PR TITLE
fix(Modal): Allow esc to close static backdrop modal when keyboard is true

### DIFF
--- a/docs/lib/examples/ModalBackdrop.js
+++ b/docs/lib/examples/ModalBackdrop.js
@@ -10,6 +10,7 @@ const ModalExample = (props) => {
   } = props;
   const [modal, setModal] = useState(false);
   const [backdrop, setBackdrop] = useState(true);
+  const [keyboard, setKeyboard] = useState(true);
 
   const toggle = () => setModal(!modal);
 
@@ -19,6 +20,10 @@ const ModalExample = (props) => {
       value = JSON.parse(value);
     }
     setBackdrop(value);
+  }
+
+  const changeKeyboard = e => {
+    setKeyboard(e.currentTarget.checked);
   }
 
   return (
@@ -32,10 +37,15 @@ const ModalExample = (props) => {
             <option value="static">"static"</option>
           </Input>
         </FormGroup>
+        <FormGroup className="mx-2" check>
+          <Label check>
+            <Input type="checkbox" checked={keyboard} onChange={changeKeyboard} /> Keyboard
+          </Label>
+        </FormGroup>
         {' '}
         <Button color="danger" onClick={toggle}>{buttonLabel}</Button>
       </Form>
-      <Modal isOpen={modal} toggle={toggle} className={className} backdrop={backdrop}>
+      <Modal isOpen={modal} toggle={toggle} className={className} backdrop={backdrop} keyboard={keyboard}>
         <ModalHeader toggle={toggle}>Modal title</ModalHeader>
         <ModalBody>
           Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -254,16 +254,19 @@ class Modal extends React.Component {
   }
 
   handleEscape(e) {
-    if (this.props.isOpen && this.props.keyboard && e.keyCode === keyCodes.esc && this.props.toggle) {
-      e.preventDefault();
-      e.stopPropagation();
+    if (this.props.isOpen && e.keyCode === keyCodes.esc && this.props.toggle) {
+      if (this.props.keyboard) {
+        e.preventDefault();
+        e.stopPropagation();
 
-      if (this.props.backdrop === 'static') {
-        this.handleStaticBackdropAnimation();
-        return;
+        this.props.toggle(e);
       }
-
-      this.props.toggle(e);
+      else if (this.props.backdrop === 'static') {
+        e.preventDefault();
+        e.stopPropagation();
+        
+        this.handleStaticBackdropAnimation();
+      }
     }
   }
 

--- a/src/__tests__/Modal.spec.js
+++ b/src/__tests__/Modal.spec.js
@@ -511,7 +511,7 @@ describe('Modal', () => {
     expect(document.getElementsByClassName('modal').length).toBe(1);
 
     const escapeKeyUpEvent = {
-      keyCode: 27,
+      keyCode: keyCodes.esc,
       preventDefault: jest.fn(() => {}),
       stopPropagation: jest.fn(() => {}),
     };
@@ -629,10 +629,10 @@ describe('Modal', () => {
     wrapper.unmount();
   });
 
-  it('should not close modal when escape key pressed when backdrop is "static"', () => {
+  it('should not close modal when escape key pressed and backdrop is "static" and keyboard=false', () => {
     isOpen = true;
     const wrapper = didMount(
-      <Modal isOpen={isOpen} toggle={toggle} backdrop="static">
+      <Modal isOpen={isOpen} toggle={toggle} backdrop="static" keyboard={false}>
         <button id="clicker">Does Nothing</button>
       </Modal>
     );
@@ -657,10 +657,38 @@ describe('Modal', () => {
     wrapper.unmount();
   });
 
-  it('should animate when backdrop is "static" and escape key pressed', () => {
+  it('should close modal when escape key pressed and backdrop is "static" and keyboard=true', () => {
     isOpen = true;
     const wrapper = didMount(
-      <Modal isOpen={isOpen} toggle={toggle} backdrop="static">
+      <Modal isOpen={isOpen} toggle={toggle} backdrop="static" keyboard={true}>
+        <button id="clicker">Does Nothing</button>
+      </Modal>
+    );
+    const instance = wrapper.instance();
+
+    jest.runTimersToTime(300);
+
+    expect(isOpen).toBe(true);
+    expect(document.getElementsByClassName('modal').length).toBe(1);
+
+    const escapeKeyUpEvent = {
+      keyCode: keyCodes.esc,
+      preventDefault: jest.fn(() => {}),
+      stopPropagation: jest.fn(() => {}),
+    };
+
+    instance.handleEscape(escapeKeyUpEvent);
+    jest.runTimersToTime(300);
+
+    expect(isOpen).toBe(false);
+
+    wrapper.unmount();
+  });
+
+  it('should animate when backdrop is "static" and escape key pressed and keyboard=false', () => {
+    isOpen = true;
+    const wrapper = didMount(
+      <Modal isOpen={isOpen} toggle={toggle} backdrop="static" keyboard={false}>
         <button id="clicker">Does Nothing</button>
       </Modal>
     );


### PR DESCRIPTION
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->
- [x] Bug fix <!-- (change which fixes an issue) -->
- [ ] New feature <!-- (change which adds functionality) -->
- [ ] Chore <!-- (change which doesn't affect the usage of the package (such as a documentation, build process, or project setup change)) -->
- [ ] Breaking change <!-- (fix or feature that would cause existing functionality to change) -->
- [x] There is an open issue which this change addresses
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [x] My commits follow the [Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- - [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Fixes #1766 

I've also added a keyboard prop modifier to the modal example so you can play with the different keyboard/backdrop props combinations.

<!-- Put any other information you believe would be useful to know when reviewing this PR below -->


<!---
If there is an issue this PR addresses, please make sure it is in the commit message per the Git Commit Guidelines above 
**AND** put the issue number below, indicating that is closes or fixes the issue.
-->
