### PR TITLE
feat(Progress): Allow passing in custom style object

### DIFF
--- a/src/Progress.js
+++ b/src/Progress.js
@@ -22,12 +22,14 @@ const propTypes = {
   className: PropTypes.string,
   barClassName: PropTypes.string,
   cssModule: PropTypes.object,
+  style: PropTypes.object,
 };
 
 const defaultProps = {
   tag: 'div',
   value: 0,
   max: 100,
+  style: {},
 };
 
 const Progress = (props) => {
@@ -44,6 +46,7 @@ const Progress = (props) => {
     bar,
     multi,
     tag: Tag,
+    style,
     ...attributes
   } = props;
 
@@ -65,7 +68,10 @@ const Progress = (props) => {
   const ProgressBar = multi ? children : (
     <div
       className={progressBarClasses}
-      style={{ width: `${percent}%` }}
+      style={{
+        ...style,
+        width: `${percent}%`,
+      }}
       role="progressbar"
       aria-valuenow={value}
       aria-valuemin="0"

--- a/src/__tests__/Progress.spec.js
+++ b/src/__tests__/Progress.spec.js
@@ -27,6 +27,12 @@ describe('Progress', () => {
     expect(wrapper.prop('max')).toBe(100);
   });
 
+  it('should render with "style" empty object by default', () => {
+    const wrapper = mount(<Progress />);
+
+    expect(wrapper.prop('style')).toEqual({});
+  });
+
   it('should render with the given "value" when passed as string prop', () => {
     const wrapper = mount(<Progress value="10" />);
 


### PR DESCRIPTION
Allows for more flexibility in styling

<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->
- [ ] Bug fix <!-- (change which fixes an issue) -->
- [x] New feature <!-- (change which adds functionality) -->
- [ ] Chore <!-- (change which doesn't affect the usage of the package (such as a documentation, build process, or project setup change)) -->
- [ ] Breaking change <!-- (fix or feature that would cause existing functionality to change) -->
- [ ] There is an open issue which this change addresses
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [x] My commits follow the [Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- - [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!-- Put any other information you believe would be useful to know when reviewing this PR below -->

Ran into a scenario where I could use passing in styles in this manner. 
My use case involves mapping over a collection and creating slightly rounded progress bars which overlap (to cover the space created at the corners by border-radius), and I could use the ability of passing in `zIndex` values programmatically.

I realize this makes `Progress` "special", seeing as none of the other components accept the style prop. If you want me to do this for all components, let me know.

EDIT: `DropdownMenu › should not render multiple children when isOpen is false` fails, but it shouldn't be because of this PR.

<!---
If there is an issue this PR addresses, please make sure it is in the commit message per the Git Commit Guidelines above 
**AND** put the issue number below, indicating that is closes or fixes the issue.
-->
