### PR TITLE
feat(Input): Use form-control-range for range inputs

### DIFF
--- a/docs/lib/examples/InputType.js
+++ b/docs/lib/examples/InputType.js
@@ -126,6 +126,10 @@ const Example = (props) => {
           It's a bit lighter and easily wraps to a new line.
         </FormText>
       </FormGroup>
+      <FormGroup>
+        <Label for="exampleRange">Range</Label>
+        <Input type="range" name="range" id="exampleRange" />
+      </FormGroup>
       <FormGroup check>
         <Label check>
           <Input type="radio" /> Option one is this and that—be sure to

--- a/src/Input.js
+++ b/src/Input.js
@@ -69,6 +69,7 @@ class Input extends React.Component {
     const fileInput = type === 'file';
     const textareaInput = type === 'textarea';
     const selectInput = type === 'select';
+    const rangeInput = type === 'range';
     let Tag = tag || (selectInput || textareaInput ? type : 'input');
 
     let formControlClass = 'form-control';
@@ -78,6 +79,8 @@ class Input extends React.Component {
       Tag = tag || 'input';
     } else if (fileInput) {
       formControlClass = `${formControlClass}-file`;
+    } else if (rangeInput) {
+      formControlClass = `${formControlClass}-range`;
     } else if (checkInput) {
       if (addon) {
         formControlClass = null;

--- a/src/__tests__/Input.spec.js
+++ b/src/__tests__/Input.spec.js
@@ -221,4 +221,11 @@ describe('Input', () => {
     expect(input.find('[type="select"]').exists()).toBe(false);
     expect(textarea.find('[type="textarea"]').exists()).toBe(false);
   });
+
+  it('should render with "form-control-range" not "form-control" class when type is range', () => {
+    const wrapper = shallow(<Input type="range" />);
+
+    expect(wrapper.hasClass('form-control-range')).toBe(true);
+    expect(wrapper.hasClass('form-control')).toBe(false);
+  });
 });


### PR DESCRIPTION
Range inputs should have the class `form-control-range` rather than `form-control`
https://getbootstrap.com/docs/4.1/components/forms/#range-inputs

<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->
- [ ] Bug fix <!-- (change which fixes an issue) -->
- [x] New feature <!-- (change which adds functionality) -->
- [ ] Chore <!-- (change which doesn't affect the usage of the package (such as a documentation, build process, or project setup change)) -->
- [ ] Breaking change <!-- (fix or feature that would cause existing functionality to change) -->
- [ ] There is an open issue which this change addresses
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [x] My commits follow the [Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- - [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- Put any other information you believe would be useful to know when reviewing this PR below -->


<!---
If there is an issue this PR addresses, please make sure it is in the commit message per the Git Commit Guidelines above 
**AND** put the issue number below, indicating that is closes or fixes the issue.
-->
