### PR TITLE
docs(Tooltip): Update documented default value

### DIFF
--- a/docs/lib/Components/TooltipsPage.js
+++ b/docs/lib/Components/TooltipsPage.js
@@ -47,7 +47,7 @@ export default class TooltipsPage extends React.Component {
   ]).isRequired,
   // Where to inject the popper DOM node, default to body
   container: PropTypes.oneOfType([PropTypes.string, PropTypes.func, DOMElement]),
-  // optionally override show/hide delays - default { show: 0, hide: 250 }
+  // optionally override show/hide delays - default { show: 0, hide: 50 }
   delay: PropTypes.oneOfType([
     PropTypes.shape({ show: PropTypes.number, hide: PropTypes.number }),
     PropTypes.number


### PR DESCRIPTION
The default delay props for Tooltip was updated in v8 but the document is still using old value.
Actual value: https://github.com/reactstrap/reactstrap/blob/master/src/TooltipPopoverWrapper.js#L45
Related PRs:
* https://github.com/reactstrap/reactstrap/commit/87a6bda08122c0532d026d22d1b5a05837c0f2fb#diff-52e105e14e9d0085df72911cf37a3915
* https://github.com/reactstrap/reactstrap/commit/ee15c869ec955c70ef84618aec70bf2d15935bad#diff-52e105e14e9d0085df72911cf37a3915

<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->
- [ ] Bug fix <!-- (change which fixes an issue) -->
- [ ] New feature <!-- (change which adds functionality) -->
- [ ] Chore <!-- (change which doesn't affect the usage of the package (such as a documentation, build process, or project setup change)) -->
- [ ] Breaking change <!-- (fix or feature that would cause existing functionality to change) -->
- [ ] There is an open issue which this change addresses
- [ ] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [ ] My commits follow the [Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- - [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!-- Put any other information you believe would be useful to know when reviewing this PR below -->


<!---
If there is an issue this PR addresses, please make sure it is in the commit message per the Git Commit Guidelines above 
**AND** put the issue number below, indicating that is closes or fixes the issue.
-->
