### PR TITLE
wip: test: enable `React.StrictMode`

### DIFF
--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,9 +1,13 @@
 /* global jest */
 /* eslint-disable import/no-extraneous-dependencies */
 import Enzyme, { ReactWrapper } from 'enzyme';
+import { createElement, StrictMode } from 'react'
 import Adapter from 'enzyme-adapter-react-16';
 
-Enzyme.configure({ adapter: new Adapter() });
+Enzyme.configure({
+  adapter: new Adapter(),
+  wrappingComponent: props => createElement(StrictMode, props) 
+});
 
 global.requestAnimationFrame = function (cb) { cb(0); };
 global.window.cancelAnimationFrame = function () { };


### PR DESCRIPTION
https://reactjs.org/docs/strict-mode.html

Introduced in `react@16.3` which is minimal version that is supported
https://reactjs.org/blog/2018/03/29/react-v-16-3.html

Enzyme api uses `findDOMNode` which is a deprecated API by react
And in tests appears `findDOMNode` warning

```
Warning: findDOMNode is deprecated in StrictMode. findDOMNode was passed an instance of Button which is inside StrictMode. Instead, add a ref directly to the element you 
want to reference.
```

and

```
Warning: Legacy context API has been detected within a strict-mode tree
```

An alternative for render testing, is to use the basic react advice
https://reactjs.org/docs/testing-recipes.html#rendering

- [x] Chore <!-- (change which doesn't affect the usage of the package (such as a documentation, build process, or project setup change)) -->
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [x] My commits follow the [Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
