### PR TITLE
refactor(TabContent): remove obsolete `react-lifecycles-compat`

### DIFF
--- a/package.json
+++ b/package.json
@@ -257,7 +257,6 @@
     "@babel/runtime": "^7.2.0",
     "classnames": "^2.2.3",
     "prop-types": "^15.5.8",
-    "react-lifecycles-compat": "^3.0.4",
     "react-popper": "^1.3.6",
     "react-transition-group": "^2.3.1"
   },

--- a/src/TabContent.js
+++ b/src/TabContent.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import { polyfill } from 'react-lifecycles-compat';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { TabContext } from './TabContext';
@@ -53,7 +52,6 @@ class TabContent extends Component {
   }
 }
 
-polyfill(TabContent);
 export default TabContent;
 
 TabContent.propTypes = propTypes;


### PR DESCRIPTION
- [x] Refactor
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [x] My commits follow the [Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.

New lifecycle methods were introduced in [`react@16.3`][1]
`reactstrap` has listed minimal `react` supported version as `16.3`

[1]: https://reactjs.org/blog/2018/03/29/react-v-16-3.html
