### PR TITLE
feat(DropdownItem): Add support for .dropdown-item-text

### DIFF
--- a/docs/lib/Components/DropdownsPage.js
+++ b/docs/lib/Components/DropdownsPage.js
@@ -110,7 +110,8 @@ DropdownItem.propTypes = {
   onClick: PropTypes.func,
   className: PropTypes.string,
   cssModule: PropTypes.object,
-  toggle: PropTypes.bool // default: true
+  toggle: PropTypes.bool, // default: true
+  text: PropTypes.bool
 };`}
           </PrismCode>
         </pre>
@@ -170,6 +171,12 @@ DropdownItem.propTypes = {
         <pre>
           <PrismCode className="language-jsx">
 {'<DropdownItem disabled>Action</DropdownItem>'}
+          </PrismCode>
+        </pre>
+        <SectionTitle>Plaintext Menu Items</SectionTitle>
+        <pre>
+          <PrismCode className="language-jsx">
+{'<DropdownItem text>Dropdown item text</DropdownItem>'}
           </PrismCode>
         </pre>
         <SectionTitle>Sizing</SectionTitle>

--- a/docs/lib/examples/Dropdown.js
+++ b/docs/lib/examples/Dropdown.js
@@ -14,6 +14,7 @@ const Example = (props) => {
       <DropdownMenu>
         <DropdownItem header>Header</DropdownItem>
         <DropdownItem>Some Action</DropdownItem>
+        <DropdownItem text>Dropdown Item Text</DropdownItem>
         <DropdownItem disabled>Action (disabled)</DropdownItem>
         <DropdownItem divider />
         <DropdownItem>Foo Action</DropdownItem>

--- a/src/DropdownItem.js
+++ b/src/DropdownItem.js
@@ -14,7 +14,8 @@ const propTypes = {
   onClick: PropTypes.func,
   className: PropTypes.string,
   cssModule: PropTypes.object,
-  toggle: PropTypes.bool
+  toggle: PropTypes.bool,
+  text: PropTypes.bool
 };
 
 const defaultProps = {
@@ -31,7 +32,8 @@ class DropdownItem extends React.Component {
   }
 
   onClick(e) {
-    if (this.props.disabled || this.props.header || this.props.divider) {
+    const { disabled, header, divider, text } = this.props;
+    if (disabled || header || divider || text) {
       e.preventDefault();
       return;
     }
@@ -46,7 +48,8 @@ class DropdownItem extends React.Component {
   }
 
   getTabIndex() {
-    if (this.props.disabled || this.props.header || this.props.divider) {
+    const { disabled, header, divider, text } = this.props;
+    if (disabled || header || divider || text) {
       return '-1';
     }
 
@@ -63,16 +66,18 @@ class DropdownItem extends React.Component {
       tag: Tag,
       header,
       active,
+      text,
       ...props } = omit(this.props, ['toggle']);
 
     const classes = mapToCssModules(classNames(
       className,
       {
         disabled: props.disabled,
-        'dropdown-item': !divider && !header,
+        'dropdown-item': !divider && !header && !text,
         active: active,
         'dropdown-header': header,
-        'dropdown-divider': divider
+        'dropdown-divider': divider,
+        'dropdown-item-text': text
       }
     ), cssModule);
 
@@ -83,6 +88,8 @@ class DropdownItem extends React.Component {
         Tag = 'div';
       } else if (props.href) {
         Tag = 'a';
+      } else if (text) {
+        Tag = 'span'
       }
     }
 

--- a/src/DropdownItem.js
+++ b/src/DropdownItem.js
@@ -89,7 +89,7 @@ class DropdownItem extends React.Component {
       } else if (props.href) {
         Tag = 'a';
       } else if (text) {
-        Tag = 'span'
+        Tag = 'span';
       }
     }
 

--- a/src/__tests__/DropdownItem.spec.js
+++ b/src/__tests__/DropdownItem.spec.js
@@ -64,6 +64,14 @@ describe('DropdownItem', () => {
     expect(wrapper.text()).toBe('Home');
   });
 
+  it('should render dropdown item text', () => {
+    const wrapper = mount(<DropdownItem text>text</DropdownItem>);
+
+    expect(wrapper.find('span').hostNodes().length).toBe(1);
+    expect(wrapper.find('span').hostNodes().hasClass('dropdown-item-text')).toBe(true);
+    expect(wrapper.text()).toBe('text');
+  });
+
   describe('header', () => {
     it('should render h6 tag heading', () => {
       const wrapper = mount(<DropdownItem header>Heading</DropdownItem>);


### PR DESCRIPTION
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->
- [ ] Bug fix <!-- (change which fixes an issue) -->
- [x] New feature <!-- (change which adds functionality) -->
- [ ] Chore <!-- (change which doesn't affect the usage of the package (such as a documentation, build process, or project setup change)) -->
- [ ] Breaking change <!-- (fix or feature that would cause existing functionality to change) -->
- [ ] There is an open issue which this change addresses
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [x] My commits follow the [Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- - [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Adds support for plaintext menu items.

From Bootstrap docs:
> You can also create non-interactive dropdown items with .dropdown-item-text. Feel free to style further with custom CSS or text utilities.

https://getbootstrap.com/docs/4.5/components/dropdowns/#menu-items
