### PR TITLE
Fix strict mode warnings for Collapse component

### DIFF
--- a/src/Collapse.js
+++ b/src/Collapse.js
@@ -62,7 +62,7 @@ class Collapse extends Component {
       dimension: null,
     };
 
-    this.nodeRef = React.createRef();
+    this.nodeRef = props.innerRef || React.createRef();
 
     ['onEntering', 'onEntered', 'onExit', 'onExiting', 'onExited'].forEach(
       (name) => {
@@ -72,8 +72,7 @@ class Collapse extends Component {
   }
 
   getNode() {
-    const nodeRef = this.props.innerRef || this.nodeRef;
-    return nodeRef.current;
+    return this.nodeRef.current;
   }
 
   onEntering(_, isAppearing) {
@@ -125,8 +124,6 @@ class Collapse extends Component {
       ...otherProps
     } = this.props;
 
-    const nodeRef = innerRef || this.nodeRef;
-
     const { dimension } = this.state;
 
     const transitionProps = pick(otherProps, TransitionPropTypeKeys);
@@ -135,7 +132,7 @@ class Collapse extends Component {
       <Transition
         {...transitionProps}
         in={isOpen}
-        nodeRef={nodeRef}
+        nodeRef={this.nodeRef}
         onEntering={this.onEntering}
         onEntered={this.onEntered}
         onExit={this.onExit}
@@ -162,7 +159,7 @@ class Collapse extends Component {
               {...childProps}
               style={{ ...childProps.style, ...style }}
               className={classes}
-              ref={nodeRef}
+              ref={this.nodeRef}
             >
               {children}
             </Tag>

--- a/src/Collapse.js
+++ b/src/Collapse.js
@@ -71,10 +71,6 @@ class Collapse extends Component {
     );
   }
 
-  getNode() {
-    return this.nodeRef.current;
-  }
-
   onEntering(_, isAppearing) {
     const node = this.getNode();
     this.setState({ dimension: this.getDimension(node) });
@@ -105,6 +101,10 @@ class Collapse extends Component {
     const node = this.getNode();
     this.setState({ dimension: null });
     this.props.onExited(node);
+  }
+
+  getNode() {
+    return this.nodeRef.current;
   }
 
   getDimension(node) {

--- a/src/Collapse.js
+++ b/src/Collapse.js
@@ -29,11 +29,7 @@ const propTypes = {
   navbar: PropTypes.bool,
   /** Change underlying component's CSS base class name */
   cssModule: PropTypes.object,
-  innerRef: PropTypes.oneOfType([
-    PropTypes.func,
-    PropTypes.string,
-    PropTypes.object,
-  ]),
+  innerRef: PropTypes.shape({ current: PropTypes.object }),
 };
 
 const defaultProps = {
@@ -66,6 +62,8 @@ class Collapse extends Component {
       dimension: null,
     };
 
+    this.nodeRef = React.createRef();
+
     ['onEntering', 'onEntered', 'onExit', 'onExiting', 'onExited'].forEach(
       (name) => {
         this[name] = this[name].bind(this);
@@ -73,29 +71,39 @@ class Collapse extends Component {
     );
   }
 
-  onEntering(node, isAppearing) {
+  getNode() {
+    const nodeRef = this.props.innerRef || this.nodeRef;
+    return nodeRef.current;
+  }
+
+  onEntering(_, isAppearing) {
+    const node = this.getNode();
     this.setState({ dimension: this.getDimension(node) });
     this.props.onEntering(node, isAppearing);
   }
 
-  onEntered(node, isAppearing) {
+  onEntered(_, isAppearing) {
+    const node = this.getNode();
     this.setState({ dimension: null });
     this.props.onEntered(node, isAppearing);
   }
 
-  onExit(node) {
+  onExit() {
+    const node = this.getNode();
     this.setState({ dimension: this.getDimension(node) });
     this.props.onExit(node);
   }
 
-  onExiting(node) {
+  onExiting() {
+    const node = this.getNode();
     // getting this variable triggers a reflow
     const _unused = this.getDimension(node); // eslint-disable-line no-unused-vars
     this.setState({ dimension: 0 });
     this.props.onExiting(node);
   }
 
-  onExited(node) {
+  onExited() {
+    const node = this.getNode();
     this.setState({ dimension: null });
     this.props.onExited(node);
   }
@@ -117,6 +125,8 @@ class Collapse extends Component {
       ...otherProps
     } = this.props;
 
+    const nodeRef = innerRef || this.nodeRef;
+
     const { dimension } = this.state;
 
     const transitionProps = pick(otherProps, TransitionPropTypeKeys);
@@ -125,6 +135,7 @@ class Collapse extends Component {
       <Transition
         {...transitionProps}
         in={isOpen}
+        nodeRef={nodeRef}
         onEntering={this.onEntering}
         onEntered={this.onEntered}
         onExit={this.onExit}
@@ -151,7 +162,7 @@ class Collapse extends Component {
               {...childProps}
               style={{ ...childProps.style, ...style }}
               className={classes}
-              ref={this.props.innerRef}
+              ref={nodeRef}
             >
               {children}
             </Tag>

--- a/src/__tests__/Collapse.spec.js
+++ b/src/__tests__/Collapse.spec.js
@@ -32,6 +32,13 @@ describe('Collapse', () => {
     expect(wrapper.find('p').text()).toBe('hello');
   });
 
+  it('works with strict mode', () => {
+    const spy = jest.spyOn(console, 'error');
+    wrapper = mount(<React.StrictMode><Collapse/></React.StrictMode>);
+    expect(wrapper.instance()).toBeTruthy();
+    expect(spy).not.toHaveBeenCalled();
+  })
+
   it('should have default isOpen value', () => {
     wrapper = shallow(<Collapse />);
     expect(wrapper.instance().props.isOpen).toEqual(false);

--- a/src/__tests__/Collapse.spec.js
+++ b/src/__tests__/Collapse.spec.js
@@ -34,10 +34,14 @@ describe('Collapse', () => {
 
   it('works with strict mode', () => {
     const spy = jest.spyOn(console, 'error');
-    wrapper = mount(<React.StrictMode><Collapse/></React.StrictMode>);
+    wrapper = mount(
+      <React.StrictMode>
+        <Collapse />
+      </React.StrictMode>,
+    );
     expect(wrapper.instance()).toBeTruthy();
     expect(spy).not.toHaveBeenCalled();
-  })
+  });
 
   it('should have default isOpen value', () => {
     wrapper = shallow(<Collapse />);


### PR DESCRIPTION
Updates the `react-transition-group` dependency to help with compatibility with React strict mode.

- [X] Bug fix for part of #1340 
- [X] Chore since it also updates a dependency
- [X] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [X] My commits follow the [Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [X] My code follows the code style of this project.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

Helps towards fixing #1340 
Supersedes #1907 