### PR TITLE
Fix reference to CSSModule

### DIFF
--- a/types/lib/Toast.d.ts
+++ b/types/lib/Toast.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { CSSModule } from '../index';
+import { CSSModule } from './index';
 import { FadeProps } from './Fade';
 
 export interface ToastProps extends React.HTMLAttributes<HTMLElement> {


### PR DESCRIPTION
The 8.7.0 release has a broken import of CSSModuile at https://github.com/reactstrap/reactstrap/blob/8.7.0/types/lib/Toast.d.ts#L2

- [x] Bug fix <!-- (change which fixes an issue) -->
<!-- Put any other information you believe would be useful to know when reviewing this PR below -->

<!---
If there is an issue this PR addresses, please make sure it is in the commit message per the Git Commit Guidelines above
**AND** put the issue number below, indicating that it closes or fixes the issue.
-->
