### PR TITLE
feat(Dropdown): Added container prop to DropdownMenu using React.portal

### DIFF
--- a/docs/lib/Components/DropdownsPage.js
+++ b/docs/lib/Components/DropdownsPage.js
@@ -16,11 +16,13 @@ import DropdownSizingExample from '../examples/DropdownSizing';
 import CustomDropdownExample from '../examples/CustomDropdown';
 import DropdownUncontrolledExample from '../examples/DropdownUncontrolled';
 import DropdownSetActiveFromChildExample from '../examples/DropdownSetActiveFromChild';
+import DropdownContainerExample from '../examples/DropdownContainer';
 
 const DropdownExampleSource = require('!!raw-loader!../examples/Dropdown');
 const CustomDropdownExampleSource = require('!!raw-loader!../examples/CustomDropdown');
 const DropdownUncontrolledExampleSource = require('!!raw-loader!../examples/DropdownUncontrolled');
 const DropdownSetActiveFromChildSource = require('!!raw-loader!../examples/DropdownSetActiveFromChild');
+const DropdownContainerSource = require('!!raw-loader!../examples/DropdownContainer');
 
 export default class DropdownPage extends React.Component {
   constructor(props) {
@@ -97,7 +99,11 @@ DropdownMenu.propTypes = {
   modifiers: PropTypes.object,
   persist: PropTypes.bool, // presist the popper, even when closed. See #779 for reasoning
   // passed to popper, see https://popper.js.org/popper-documentation.html#Popper.Defaults.positionFixed
-  positionFixed: PropTypes.bool
+  positionFixed: PropTypes.bool,
+  // Element to place the menu in. Used to show the menu as a child of 'body'
+  // or other elements in the DOM instead of where it naturally is. This can be
+  // used to make the Dropdown escape a container with overflow: hidden
+  container: PropTypes.oneOfType([PropTypes.string, PropTypes.func, DOMElement]),
 };
 
 DropdownItem.propTypes = {
@@ -404,6 +410,19 @@ DropdownItem.propTypes = {
         <pre>
           <PrismCode className="language-jsx">
             {DropdownSetActiveFromChildSource}
+          </PrismCode>
+        </pre>
+
+        <SectionTitle>container</SectionTitle>
+        <p>
+          Use the <code>container</code> prop to allow the dropdown menu to be placed inside an alternate container through a React Portal. This can be used to allow the dropdown menu to escape a container with the style `overflow: hidden`.
+        </p>
+        <div className="docs-example">
+          <DropdownContainerExample />
+        </div>
+        <pre>
+          <PrismCode className="language-jsx">
+            {DropdownContainerSource}
           </PrismCode>
         </pre>
       </div>

--- a/docs/lib/Components/DropdownsPage.js
+++ b/docs/lib/Components/DropdownsPage.js
@@ -415,7 +415,7 @@ DropdownItem.propTypes = {
 
         <SectionTitle>container</SectionTitle>
         <p>
-          Use the <code>container</code> prop to allow the dropdown menu to be placed inside an alternate container through a React Portal. This can be used to allow the dropdown menu to escape a container with the style `overflow: hidden`.
+          Use the <code>container</code> prop to allow the dropdown menu to be placed inside an alternate container through a React Portal. This can be used to allow the dropdown menu to escape a container with the style <code>overflow: hidden</code>.
         </p>
         <div className="docs-example">
           <DropdownContainerExample />

--- a/docs/lib/examples/DropdownContainer.js
+++ b/docs/lib/examples/DropdownContainer.js
@@ -1,0 +1,28 @@
+import React, { useState } from 'react';
+import { Dropdown, DropdownToggle, DropdownMenu, DropdownItem } from 'reactstrap';
+
+const Example = (props) => {
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+
+  const toggle = () => setDropdownOpen(prevState => !prevState);
+  const [lastClicked, setLastClicked] = useState(null);
+
+  return (
+    <div style={{ width: 300, height: 100, border: '1px solid #000', padding: '8px', overflow: 'hidden' }}>
+      Container with overflow: hidden.<br />
+      Last clicked: {lastClicked || 'null'}
+      <Dropdown isOpen={dropdownOpen} toggle={toggle}>
+        <DropdownToggle caret>
+          Dropdown
+        </DropdownToggle>
+        <DropdownMenu container="body">
+          <DropdownItem onClick={() => setLastClicked(1)}>Action 1</DropdownItem>
+          <DropdownItem onClick={() => setLastClicked(2)}>Action 2</DropdownItem>
+          <DropdownItem onClick={() => setLastClicked(3)}>Action 3</DropdownItem>
+        </DropdownMenu>
+      </Dropdown>
+    </div>
+  );
+}
+
+export default Example;

--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -108,7 +108,11 @@ class Dropdown extends React.Component {
   }
 
   getMenuItems() {
-    return [].slice.call(this.getMenu().querySelectorAll('[role="menuitem"]'));
+    // In a real menu with a child DropdownMenu, `this.getMenu()` should never
+    // be null, but it is sometimes null in tests. To mitigate that, we just
+    // use `this.getContainer()` as the fallback `menuContainer`.
+    const menuContainer = this.getMenu() || this.getContainer();
+    return [].slice.call(menuContainer.querySelectorAll('[role="menuitem"]'));
   }
 
   addEvents() {

--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -56,8 +56,14 @@ class Dropdown extends React.Component {
     this.handleKeyDown = this.handleKeyDown.bind(this);
     this.removeEvents = this.removeEvents.bind(this);
     this.toggle = this.toggle.bind(this);
+    this.handleMenuRef = this.handleMenuRef.bind(this);
 
     this.containerRef = React.createRef();
+    this.menuRef = React.createRef();
+  }
+
+  handleMenuRef(menuRef) {
+    this.menuRef.current = menuRef;
   }
 
   getContextValue() {
@@ -66,7 +72,10 @@ class Dropdown extends React.Component {
       isOpen: this.props.isOpen,
       direction: (this.props.direction === 'down' && this.props.dropup) ? 'up' : this.props.direction,
       inNavbar: this.props.inNavbar,
-      disabled: this.props.disabled
+      disabled: this.props.disabled,
+      // Callback that should be called by DropdownMenu to provide a ref to
+      // a HTML tag that's used for the DropdownMenu
+      onMenuRef: this.handleMenuRef,
     };
   }
 
@@ -113,8 +122,10 @@ class Dropdown extends React.Component {
   handleDocumentClick(e) {
     if (e && (e.which === 3 || (e.type === 'keyup' && e.which !== keyCodes.tab))) return;
     const container = this.getContainer();
-
-    if (container.contains(e.target) && container !== e.target && (e.type !== 'keyup' || e.which === keyCodes.tab)) {
+    const menu = this.menuRef.current;
+    const clickIsInContainer = container.contains(e.target) && container !== e.target;
+    const clickIsInMenu = menu && menu.contains(e.target) && menu !== e.target;
+    if ((clickIsInContainer || clickIsInMenu) && (e.type !== 'keyup' || e.which === keyCodes.tab)) {
       return;
     }
 
@@ -143,7 +154,7 @@ class Dropdown extends React.Component {
         this.toggle(e);
         setTimeout(() => this.getMenuItems()[0].focus());
       } else if (this.props.isOpen && e.which === keyCodes.esc) {
-        this.toggle(e); 
+        this.toggle(e);
       }
     }
 

--- a/src/__tests__/DropdownMenu.spec.js
+++ b/src/__tests__/DropdownMenu.spec.js
@@ -192,4 +192,32 @@ describe('DropdownMenu', () => {
     expect(wrapper.childAt(0).hasClass('dropdown-menu')).toBe(true);
     expect(wrapper.getDOMNode().tagName.toLowerCase()).toBe('main');
   });
+
+  describe('using container', () => {
+    let element;
+
+    beforeEach(() => {
+      element = document.createElement('div');
+      document.body.appendChild(element);
+    });
+
+    afterEach(() => {
+      document.body.removeChild(element);
+      element = null;
+    });
+
+    it('should render inside container', () => {
+      isOpen = true;
+      element.innerHTML = '<div id="anotherContainer"></div>';
+      const wrapper = mount(
+        <DropdownContext.Provider value={{ isOpen, direction, inNavbar }}>
+          <DropdownMenu container="#anotherContainer">My body</DropdownMenu>
+        </DropdownContext.Provider>
+      );
+
+      expect(document.getElementById('anotherContainer').innerHTML).toContain('My body');
+      expect(wrapper.text()).toBe('My body');
+    });
+  })
+
 });

--- a/types/lib/DropdownMenu.d.ts
+++ b/types/lib/DropdownMenu.d.ts
@@ -11,6 +11,7 @@ export interface DropdownMenuProps extends React.HTMLAttributes<HTMLElement> {
   cssModule?: CSSModule;
   persist?: boolean;
   positionFixed?: boolean;
+  container?: string | HTMLElement | React.RefObject<HTMLElement>;
 }
 
 declare class DropdownMenu extends React.Component<DropdownMenuProps> {}


### PR DESCRIPTION
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->

- [ ] Bug fix <!-- (change which fixes an issue) -->
- [X] New feature <!-- (change which adds functionality) -->
- [ ] Chore <!-- (change which doesn't affect the usage of the package (such as documentation, build process, or project setup changes)) -->
- [ ] Breaking change <!-- (fix or feature that would cause existing functionality to change) -->
- [ ] There is an open issue which this change addresses
- [X] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [X] My commits follow the [Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- - [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!-- Put any other information you believe would be useful to know when reviewing this PR below -->

This is an improvement of #1513

When a Dropdown is inside a small element with overflow: hidden, it's useful to have the dropdown display directly inside of body or another container. I added the same `container` prop to DropdownMenu. Using a React Portal, this allows the dropdown to have body or any other tag as the parent.

The DropdownMenu passes its own `ref` back to the parent dropdown via an `onMenuRef` callback in the Dropdown context so that clicks outside the DropdownMenu will properly close the menu.

<!---
If there is an issue this PR addresses, please make sure it is in the commit message per the Git Commit Guidelines above
**AND** put the issue number below, indicating that it closes or fixes the issue.
-->

| Without `container` | With `container |
| --- | --- |
| ![Before container](https://user-images.githubusercontent.com/2937410/98498962-15bbbe00-21fd-11eb-94fe-05f7357ec855.gif) | ![Testing container](https://user-images.githubusercontent.com/2937410/98498973-1ce2cc00-21fd-11eb-9b23-adc177a9655c.gif) |