### PR TITLE
chore: Fixed all current linter warnings

### DIFF
--- a/src/CarouselControl.js
+++ b/src/CarouselControl.js
@@ -21,6 +21,10 @@ const CarouselControl = (props) => {
 
 
   return (
+    // We need to disable this linting rule to use an `<a>` instead of
+    // `<button>` because that's what the Bootstrap examples require:
+    // https://getbootstrap.com/docs/4.5/components/carousel/#with-controls
+    // eslint-disable-next-line jsx-a11y/anchor-is-valid
     <a
       className={anchorClasses}
       style={{cursor: "pointer"}}

--- a/src/TooltipPopoverWrapper.js
+++ b/src/TooltipPopoverWrapper.js
@@ -166,7 +166,7 @@ class TooltipPopoverWrapper extends React.Component {
       this.currentTargetElement = e ? e.currentTarget || e.target : null;
       if (e && e.composedPath && typeof e.composedPath === 'function') {
         const path = e.composedPath();
-        this.currentTargetElement = path && path[0] || this.currentTargetElement;
+        this.currentTargetElement = (path && path[0]) || this.currentTargetElement;
       }
       this.toggle(e);
     }

--- a/src/__tests__/PopperContent.spec.js
+++ b/src/__tests__/PopperContent.spec.js
@@ -44,7 +44,7 @@ describe('PopperContent', () => {
 
   it('should render children when isOpen is true and container is inline and DOM node passed directly for target', () => {
     const targetElement = element.querySelector('#target');
-    
+
     const wrapper = mount(<PopperContent target={targetElement} isOpen container="inline">Yo!</PopperContent>);
     expect(targetElement).toBeDefined();
     expect(wrapper.text()).toBe('Yo!');
@@ -148,7 +148,7 @@ describe('PopperContent', () => {
 
   it('should allow a function to be used as children', () => {
     const renderChildren = jest.fn();
-    const wrapper = mount(
+    mount(
       <PopperContent target="target" isOpen>
         {renderChildren}
       </PopperContent>

--- a/src/__tests__/TooltipPopoverWrapper.spec.js
+++ b/src/__tests__/TooltipPopoverWrapper.spec.js
@@ -729,7 +729,7 @@ describe('Tooltip', () => {
 
     it('should allow a function to be used as children', () => {
       const renderChildren = jest.fn();
-      const wrapper = mount(
+      mount(
         <TooltipPopoverWrapper target="target" isOpen toggle={toggle}>
           {renderChildren}
         </TooltipPopoverWrapper>
@@ -745,16 +745,16 @@ describe('Tooltip', () => {
         </TooltipPopoverWrapper>,
         { attachTo: container }
       );
-  
+
       const Tooltips = document.getElementsByClassName('tooltip');
       expect(wrapper.find('.tooltip.show').hostNodes().length).toBe(1);
       expect(Tooltips.length).toBe(1);
       expect(Tooltips[0].textContent).toBe('Tooltip Content');
-  
+
       expect(wrapper.find('.tooltip.show').hostNodes().length).toBe(1);
       expect(Tooltips.length).toBe(1);
       expect(Tooltips[0].textContent).toBe('Tooltip Content');
-  
+
       wrapper.detach();
     });
   });

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,6 +1,5 @@
 /* global jest */
-/* eslint-disable import/no-extraneous-dependencies */
-import Enzyme, { ReactWrapper } from 'enzyme';
+import Enzyme from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 
 Enzyme.configure({ adapter: new Adapter() });


### PR DESCRIPTION
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->

- [ ] Bug fix <!-- (change which fixes an issue) -->
- [ ] New feature <!-- (change which adds functionality) -->
- [X] Chore <!-- (change which doesn't affect the usage of the package (such as documentation, build process, or project setup changes)) -->
- [ ] Breaking change <!-- (fix or feature that would cause existing functionality to change) -->
- [ ] There is an open issue which this change addresses
- [X] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [ ] My commits follow the [Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- - [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!-- Put any other information you believe would be useful to know when reviewing this PR below -->

This is a tiny cleanup change to make eslint not return any errors or warnings for the project. While working on #2016, I saw there were some linting issues and had to double-check if my change caused them. It didn't! I hope by fixing these issues anyways, I'll make it easier for future contributors to pay attention to linting errors before submitting.

## Before

```
$ yarn lint
yarn run v1.22.4
$ eslint src

/Users/harry/code/reactstrap/src/__tests__/PopperContent.spec.js
  151:11  warning  'wrapper' is assigned a value but never used  no-unused-vars

/Users/harry/code/reactstrap/src/__tests__/TooltipPopoverWrapper.spec.js
  732:13  warning  'wrapper' is assigned a value but never used  no-unused-vars

/Users/harry/code/reactstrap/src/CarouselControl.js
  24:5  warning  The href attribute is required for an anchor to be keyboard accessible. Provide a valid, navigable address as the href value. If you cannot provide an href, but still need the element to resemble a link, use a button and change it with appropriate styles. Learn more: https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/anchor-is-valid.md  jsx-a11y/anchor-is-valid

/Users/harry/code/reactstrap/src/setupTests.js
  3:18  warning  'ReactWrapper' is defined but never used  no-unused-vars

/Users/harry/code/reactstrap/src/TooltipPopoverWrapper.js
  169:42  warning  Unexpected mix of '&&' and '||'  no-mixed-operators
  169:53  warning  Unexpected mix of '&&' and '||'  no-mixed-operators

✖ 6 problems (0 errors, 6 warnings)

✨  Done in 5.54s.
```

## After

```
$ yarn lint
yarn run v1.22.4
$ eslint src
✨  Done in 4.51s.
```

<!---
If there is an issue this PR addresses, please make sure it is in the commit message per the Git Commit Guidelines above
**AND** put the issue number below, indicating that it closes or fixes the issue.
-->
