### PR TITLE
feat: add positionFixed prop to Tooltip and Popover

### DIFF
--- a/docs/lib/Components/PopoversPage.js
+++ b/docs/lib/Components/PopoversPage.js
@@ -79,6 +79,9 @@ export default class PopoversPage extends React.Component {
   ]),
   // Custom modifiers that are passed to Popper.js, see https://popper.js.org/popper-documentation.html#modifiers
   modifiers: PropTypes.object,
+  // Whether the element the tooltip is pointing to has "position: fixed" styling. This is passed to Popper.js and
+  // will make the tooltip itself have "position: fixed" as well
+  positionFixed: PropTypes.bool,
   offset: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.number

--- a/docs/lib/Components/TooltipsPage.js
+++ b/docs/lib/Components/TooltipsPage.js
@@ -84,6 +84,9 @@ export default class TooltipsPage extends React.Component {
   ]),
   // Custom modifiers that are passed to Popper.js, see https://popper.js.org/popper-documentation.html#modifiers
   modifiers: PropTypes.object,
+  // Whether the element the tooltip is pointing to has "position: fixed" styling. This is passed to Popper.js and
+  // will make the tooltip itself have "position: fixed" as well
+  positionFixed: PropTypes.bool,
   offset: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.number

--- a/src/PopperContent.js
+++ b/src/PopperContent.js
@@ -24,6 +24,7 @@ const propTypes = {
   container: targetPropType,
   target: targetPropType.isRequired,
   modifiers: PropTypes.object,
+  positionFixed: PropTypes.bool,
   boundariesElement: PropTypes.oneOfType([PropTypes.string, DOMElement]),
   onClosed: PropTypes.func,
   fade: PropTypes.bool,

--- a/src/PopperContent.js
+++ b/src/PopperContent.js
@@ -108,6 +108,7 @@ class PopperContent extends React.Component {
       tag,
       container,
       modifiers,
+      positionFixed,
       boundariesElement,
       onClosed,
       fade,
@@ -150,6 +151,7 @@ class PopperContent extends React.Component {
           referenceElement={this.targetNode}
           modifiers={extendedModifiers}
           placement={placement}
+          positionFixed={positionFixed}
         >
           {({ ref, style, placement, outOfBoundaries, arrowProps, scheduleUpdate }) => (
             <div ref={ref} style={style} className={popperClassName} x-placement={placement} x-out-of-boundaries={outOfBoundaries ? 'true' : undefined}>

--- a/src/TooltipPopoverWrapper.js
+++ b/src/TooltipPopoverWrapper.js
@@ -32,6 +32,7 @@ export const propTypes = {
     PropTypes.number
   ]),
   modifiers: PropTypes.object,
+  positionFixed: PropTypes.bool,
   offset: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   innerRef: PropTypes.oneOfType([
     PropTypes.func,
@@ -336,6 +337,7 @@ class TooltipPopoverWrapper extends React.Component {
       popperClassName,
       container,
       modifiers,
+      positionFixed,
       offset,
       fade,
       flip,
@@ -361,6 +363,7 @@ class TooltipPopoverWrapper extends React.Component {
         popperClassName={popperClasses}
         container={container}
         modifiers={modifiers}
+        positionFixed={positionFixed}
         offset={offset}
         cssModule={cssModule}
         fade={fade}

--- a/types/lib/Popover.d.ts
+++ b/types/lib/Popover.d.ts
@@ -25,6 +25,7 @@ export interface PopoverProps extends React.HTMLAttributes<HTMLElement> {
   placementPrefix?: string;
   delay?: number | { show: number; hide: number };
   modifiers?: Popper.Modifiers;
+  positionFixed?: boolean;
   cssModule?: CSSModule;
   fade?: boolean;
   flip?: boolean;

--- a/types/lib/Tooltip.d.ts
+++ b/types/lib/Tooltip.d.ts
@@ -21,6 +21,7 @@ export interface UncontrolledTooltipProps
   autohide?: boolean;
   placement?: Popper.Placement;
   modifiers?: Popper.Modifiers;
+  positionFixed?: boolean;
   cssModule?: CSSModule;
   fade?: boolean;
   flip?: boolean;


### PR DESCRIPTION
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->

- [ ] Bug fix <!-- (change which fixes an issue) -->
- [X] New feature <!-- (change which adds functionality) -->
- [ ] Chore <!-- (change which doesn't affect the usage of the package (such as documentation, build process, or project setup changes)) -->
- [ ] Breaking change <!-- (fix or feature that would cause existing functionality to change) -->
- [ ] There is an open issue which this change addresses
- [X] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [X] My commits follow the [Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
  - [X] I have updated the documentation accordingly.
- [X] My change requires a change to [Typescript typings](./types/lib).
  - [X] I have updated the typings accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!-- Put any other information you believe would be useful to know when reviewing this PR below -->

react-popper has a positionFixed prop that allows the popover itself to have the `position: fixed` style, so that it doesn't flicker when applied to an element that itself is position-fixed. This change allows users of Tooltip/Popover components to specify this and pass it on to prevent flickering.

| Before | After |
| --- | --- |
| ![Before](https://user-images.githubusercontent.com/2937410/102677698-686f8a80-4158-11eb-9509-edf147ca3bfc.gif) | ![After](https://user-images.githubusercontent.com/2937410/102677705-71605c00-4158-11eb-8c9e-3f822961621a.gif) |

<!---
If there is an issue this PR addresses, please make sure it is in the commit message per the Git Commit Guidelines above
**AND** put the issue number below, indicating that it closes or fixes the issue.
-->
