### PR TITLE
fix: Make tooltips fade out

### DIFF
--- a/src/TooltipPopoverWrapper.js
+++ b/src/TooltipPopoverWrapper.js
@@ -317,11 +317,9 @@ class TooltipPopoverWrapper extends React.Component {
   }
 
   render() {
-    if (!this.props.isOpen) {
-      return null;
+    if (this.props.isOpen) {
+      this.updateTarget();
     }
-
-    this.updateTarget();
 
     const {
       className,


### PR DESCRIPTION
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->

- [X] Bug fix <!-- (change which fixes an issue) -->
- [ ] New feature <!-- (change which adds functionality) -->
- [ ] Chore <!-- (change which doesn't affect the usage of the package (such as documentation, build process, or project setup changes)) -->
- [ ] Breaking change <!-- (fix or feature that would cause existing functionality to change) -->
- [ ] There is an open issue which this change addresses
- [X] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [X] My commits follow the [Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] My change requires a change to [Typescript typings](./types/lib).
  - [ ] I have updated the typings accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!-- Put any other information you believe would be useful to know when reviewing this PR below -->

Tooltips currently don't actually fade out, because as soon as `isOpen` is set to false, the render function in TooltipPopoverWrapper returns null.

This change makes it so that it returns something in the render function even when `isOpen` is false. We still only call `this.updateTarget()` when the tooltip is open. This ensures that the component still works for tooltips that open on a target appearing only after initial page rendering.

| Before | After |
| --- | --- |
| https://user-images.githubusercontent.com/2937410/102849462-0fa82800-43cc-11eb-92bb-b8f1d7a7443b.mov | https://user-images.githubusercontent.com/2937410/102849480-1767cc80-43cc-11eb-8030-40cab32414ed.mov |

<!---
If there is an issue this PR addresses, please make sure it is in the commit message per the Git Commit Guidelines above
**AND** put the issue number below, indicating that it closes or fixes the issue.
-->
