### PR TITLE
feat(Modal): Add trapFocus prop

### DIFF
--- a/docs/lib/Components/ModalsPage.js
+++ b/docs/lib/Components/ModalsPage.js
@@ -109,6 +109,7 @@ const ModalsPage = () => {
   returnFocusAfterClose: PropTypes.bool, // defaults to true
   // container to append the modal to
   container: PropTypes.oneOfType([PropTypes.string, PropTypes.func, DOMElement]),
+  trapFocus: PropTypes.bool // Traps focus within modal
 }`}
         </PrismCode>
       </pre>

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -60,7 +60,8 @@ const propTypes = {
   ]),
   unmountOnClose: PropTypes.bool,
   returnFocusAfterClose: PropTypes.bool,
-  container: targetPropType
+  container: targetPropType,
+  trapFocus: PropTypes.bool
 };
 
 const propsToOmit = Object.keys(propTypes);
@@ -86,7 +87,8 @@ const defaultProps = {
   },
   unmountOnClose: true,
   returnFocusAfterClose: true,
-  container: 'body'
+  container: 'body',
+  trapFocus: false
 };
 
 class Modal extends React.Component {
@@ -171,20 +173,24 @@ class Modal extends React.Component {
   }
 
   trapFocus (ev) {
+    if (!this.props.trapFocus) {
+      return;
+    }
+
     if (!this._element) //element is not attached
-      return ;
+      return;
 
     if (this._dialog && this._dialog.parentNode === ev.target) // initial focus when the Modal is opened
-      return ;
+      return;
 
     if (this.modalIndex < (Modal.openCount - 1)) // last opened modal
-      return ;
+      return;
 
     const children = this.getFocusableChildren();
 
     for (let i = 0; i < children.length; i++) { // focus is already inside the Modal
       if (children[i] === ev.target)
-        return ;
+        return;
     }
 
     if (children.length > 0) { // otherwise focus the first focusable element in the Modal

--- a/src/__tests__/Modal.spec.js
+++ b/src/__tests__/Modal.spec.js
@@ -1170,7 +1170,7 @@ describe('Modal', () => {
     const MockComponent = () => (
           <>
             <Button className={'first'}>Focused</Button>
-            <Modal isOpen={true}>
+            <Modal isOpen={true} trapFocus>
               <ModalBody>
                   Something else to see
                   <Button className={'focus'}>focusable element</Button>

--- a/types/lib/Modal.d.ts
+++ b/types/lib/Modal.d.ts
@@ -31,6 +31,7 @@ export interface ModalProps extends React.HTMLAttributes<HTMLElement> {
   returnFocusAfterClose?: boolean;
   container?: string | HTMLElement | React.RefObject<HTMLElement>;
   innerRef?: React.Ref<HTMLElement>;
+  trapFocus?: boolean;
 }
 
 declare class Modal extends React.Component<ModalProps> {}


### PR DESCRIPTION
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->

- [ ] Bug fix <!-- (change which fixes an issue) -->
- [x] New feature <!-- (change which adds functionality) -->
- [ ] Chore <!-- (change which doesn't affect the usage of the package (such as documentation, build process, or project setup changes)) -->
- [ ] Breaking change <!-- (fix or feature that would cause existing functionality to change) -->
- [x] There is an open issue which this change addresses
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [x] My commits follow the [Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [x] My change requires a change to [Typescript typings](./types/lib).
  - [x] I have updated the typings accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- Put any other information you believe would be useful to know when reviewing this PR below -->

<!---
If there is an issue this PR addresses, please make sure it is in the commit message per the Git Commit Guidelines above
**AND** put the issue number below, indicating that it closes or fixes the issue.
-->

Fixes #2072 and fixes #2066

This PR adds a prop `trapFocus` to modal to make the trap focus behavior opt-in (original PR #1941).  This was causing issues when other modals/portals are opened while reactstrap's modal is open.
