### PR TITLE
feat(bs5):  Replace .btn-block with utility classes

### DIFF
--- a/src/Button.js
+++ b/src/Button.js
@@ -71,7 +71,7 @@ class Button extends React.Component {
       close || 'btn',
       close || btnOutlineColor,
       size ? `btn-${size}` : false,
-      block ? 'btn-block' : false,
+      block ? 'd-block w-100' : false,
       { active, disabled: this.props.disabled }
     ), cssModule);
 

--- a/src/__tests__/Button.spec.js
+++ b/src/__tests__/Button.spec.js
@@ -94,7 +94,7 @@ describe('Button', () => {
   it('should render block level buttons', () => {
     const block = shallow(<Button block>Block Level Button</Button>);
 
-    expect(block.hasClass('btn-block')).toBe(true);
+    expect(block.hasClass('d-block w-100')).toBe(true);
   });
 
   it('should render close icon utility with default props', () => {


### PR DESCRIPTION
Keep prop for backwards compat

<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->

- [ ] Bug fix <!-- (change which fixes an issue) -->
- [ ] New feature <!-- (change which adds functionality) -->
- [ ] Chore <!-- (change which doesn't affect the usage of the package (such as documentation, build process, or project setup changes)) -->
- [ ] Breaking change <!-- (fix or feature that would cause existing functionality to change) -->
- [x] There is an open issue which this change addresses
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [x] My commits follow the [Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] My change requires a change to [Typescript typings](./types/lib).
  - [ ] I have updated the typings accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- Put any other information you believe would be useful to know when reviewing this PR below -->
The `btn-block` class was removed in Bootstrap 5, so this PR replaces the functionality with utility classes.
<!---
If there is an issue this PR addresses, please make sure it is in the commit message per the Git Commit Guidelines above
**AND** put the issue number below, indicating that it closes or fixes the issue.
-->

Related to: https://github.com/reactstrap/reactstrap/issues/1748
