### PR TITLE
Feat(bs5) change .close to .btn close

### DIFF
--- a/src/Alert.js
+++ b/src/Alert.js
@@ -59,7 +59,7 @@ function Alert(props) {
     { 'alert-dismissible': toggle }
   ), cssModule);
 
-  const closeClasses = mapToCssModules(classNames('close', closeClassName), cssModule);
+  const closeClasses = mapToCssModules(classNames('btn-close', closeClassName), cssModule);
 
   const alertTransition = {
     ...Fade.defaultProps,

--- a/src/Alert.js
+++ b/src/Alert.js
@@ -71,9 +71,7 @@ function Alert(props) {
   return (
     <Fade {...attributes} {...alertTransition} tag={Tag} className={classes} in={isOpen} role="alert" innerRef={innerRef}>
       {toggle ?
-        <button type="button" className={closeClasses} aria-label={closeAriaLabel} onClick={toggle}>
-          <span aria-hidden="true">&times;</span>
-        </button>
+        <button type="button" className={closeClasses} aria-label={closeAriaLabel} onClick={toggle} />
         : null}
       {children}
     </Fade>

--- a/src/Button.js
+++ b/src/Button.js
@@ -67,7 +67,7 @@ class Button extends React.Component {
 
     const classes = mapToCssModules(classNames(
       className,
-      { close },
+      close && 'btn-close',
       close || 'btn',
       close || btnOutlineColor,
       size ? `btn-${size}` : false,

--- a/src/ModalHeader.js
+++ b/src/ModalHeader.js
@@ -11,7 +11,6 @@ const propTypes = {
   cssModule: PropTypes.object,
   children: PropTypes.node,
   closeAriaLabel: PropTypes.string,
-  charCode: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   close: PropTypes.object,
 };
 
@@ -19,7 +18,6 @@ const defaultProps = {
   tag: 'h5',
   wrapTag: 'div',
   closeAriaLabel: 'Close',
-  charCode: 215,
 };
 
 const ModalHeader = (props) => {
@@ -32,7 +30,6 @@ const ModalHeader = (props) => {
     tag: Tag,
     wrapTag: WrapTag,
     closeAriaLabel,
-    charCode,
     close,
     ...attributes } = props;
 
@@ -42,11 +39,8 @@ const ModalHeader = (props) => {
   ), cssModule);
 
   if (!close && toggle) {
-    const closeIcon = typeof charCode === 'number' ? String.fromCharCode(charCode) : charCode;
     closeButton = (
-      <button type="button" onClick={toggle} className={mapToCssModules('btn-close', cssModule)} aria-label={closeAriaLabel}>
-        <span aria-hidden="true">{closeIcon}</span>
-      </button>
+      <button type="button" onClick={toggle} className={mapToCssModules('btn-close', cssModule)} aria-label={closeAriaLabel} />
     );
   }
 

--- a/src/ModalHeader.js
+++ b/src/ModalHeader.js
@@ -44,7 +44,7 @@ const ModalHeader = (props) => {
   if (!close && toggle) {
     const closeIcon = typeof charCode === 'number' ? String.fromCharCode(charCode) : charCode;
     closeButton = (
-      <button type="button" onClick={toggle} className={mapToCssModules('close', cssModule)} aria-label={closeAriaLabel}>
+      <button type="button" onClick={toggle} className={mapToCssModules('btn-close', cssModule)} aria-label={closeAriaLabel}>
         <span aria-hidden="true">{closeIcon}</span>
       </button>
     );

--- a/src/ToastHeader.js
+++ b/src/ToastHeader.js
@@ -49,7 +49,7 @@ const ToastHeader = (props) => {
   if (!close && toggle) {
     const closeIcon = typeof charCode === 'number' ? String.fromCharCode(charCode) : charCode;
     closeButton = (
-      <button type="button" onClick={toggle} className={mapToCssModules('close', cssModule)} aria-label={closeAriaLabel}>
+      <button type="button" onClick={toggle} className={mapToCssModules('btn-close', cssModule)} aria-label={closeAriaLabel}>
         <span aria-hidden="true">{closeIcon}</span>
       </button>
     );

--- a/src/ToastHeader.js
+++ b/src/ToastHeader.js
@@ -35,7 +35,6 @@ const ToastHeader = (props) => {
     tag: Tag,
     wrapTag: WrapTag,
     closeAriaLabel,
-    charCode,
     close,
     tagClassName,
     icon: iconProp,
@@ -47,11 +46,8 @@ const ToastHeader = (props) => {
   ), cssModule);
 
   if (!close && toggle) {
-    const closeIcon = typeof charCode === 'number' ? String.fromCharCode(charCode) : charCode;
     closeButton = (
-      <button type="button" onClick={toggle} className={mapToCssModules('btn-close', cssModule)} aria-label={closeAriaLabel}>
-        <span aria-hidden="true">{closeIcon}</span>
-      </button>
+      <button type="button" onClick={toggle} className={mapToCssModules('btn-close', cssModule)} aria-label={closeAriaLabel} />
     );
   }
 

--- a/src/__tests__/Alert.spec.js
+++ b/src/__tests__/Alert.spec.js
@@ -16,7 +16,7 @@ describe('Alert', () => {
   it('should pass close className down', () => {
     function noop() { }
     const alert = mount(<Alert toggle={noop} closeClassName="test-class-name">Yo!</Alert>);
-    expect(alert.find('.close').hostNodes().prop('className')).toContain('test-class-name');
+    expect(alert.find('.btn-close').hostNodes().prop('className')).toContain('test-class-name');
   });
 
   it('should pass other props down', () => {

--- a/src/__tests__/Button.spec.js
+++ b/src/__tests__/Button.spec.js
@@ -104,7 +104,7 @@ describe('Button', () => {
     const wrapper = shallow(<Button close />);
     const actualInnerHTML = wrapper.children().html();
 
-    expect(wrapper.find('.close').length).toBe(1);
+    expect(wrapper.find('.btn-close').length).toBe(1);
     expect(wrapper.find('.btn').length).toBe(0);
     expect(wrapper.find('.btn-secondary').length).toBe(0);
     expect(wrapper.find('button').prop('aria-label')).toMatch(/close/i);

--- a/src/__tests__/ModalHeader.spec.js
+++ b/src/__tests__/ModalHeader.spec.js
@@ -37,26 +37,4 @@ describe('ModalHeader', () => {
 
     expect(wrapper.type()).toBe('main');
   });
-
-  it('should render close button with custom aria-label', () => {
-    const wrapper = shallow(<ModalHeader toggle={() => {}} className="other" closeAriaLabel="oseclay">Yo!</ModalHeader>);
-
-    const closeButton = wrapper.find('button.btn-close').first();
-    expect(closeButton.prop('aria-label')).toBe('oseclay');
-  });
-
-  it('should render close button with default icon', () => {
-    const wrapper = shallow(<ModalHeader toggle={() => {}}>Yo!</ModalHeader>);
-
-    const closeButtonIcon = wrapper.find('button.btn-close span');
-    const defaultIcon = String.fromCharCode(215);
-    expect(closeButtonIcon.text()).toEqual(defaultIcon);
-  });
-
-  it('should render close button with custom icon', () => {
-    const wrapper = shallow(<ModalHeader toggle={() => {}} charCode={'X'}>Yo!</ModalHeader>);
-
-    const closeButtonIcon = wrapper.find('button.btn-close span');
-    expect(closeButtonIcon.text()).toEqual('X');
-  });
 });

--- a/src/__tests__/ModalHeader.spec.js
+++ b/src/__tests__/ModalHeader.spec.js
@@ -22,7 +22,7 @@ describe('ModalHeader', () => {
 
     expect(wrapper.hasClass('other')).toBe(true);
     expect(wrapper.hasClass('modal-header')).toBe(true);
-    expect(wrapper.find('button.close').length).toBe(1);
+    expect(wrapper.find('button.btn-close').length).toBe(1);
   });
 
   it('should render custom tag', () => {
@@ -41,14 +41,14 @@ describe('ModalHeader', () => {
   it('should render close button with custom aria-label', () => {
     const wrapper = shallow(<ModalHeader toggle={() => {}} className="other" closeAriaLabel="oseclay">Yo!</ModalHeader>);
 
-    const closeButton = wrapper.find('button.close').first();
+    const closeButton = wrapper.find('button.btn-close').first();
     expect(closeButton.prop('aria-label')).toBe('oseclay');
   });
 
   it('should render close button with default icon', () => {
     const wrapper = shallow(<ModalHeader toggle={() => {}}>Yo!</ModalHeader>);
 
-    const closeButtonIcon = wrapper.find('button.close span');
+    const closeButtonIcon = wrapper.find('button.btn-close span');
     const defaultIcon = String.fromCharCode(215);
     expect(closeButtonIcon.text()).toEqual(defaultIcon);
   });
@@ -56,7 +56,7 @@ describe('ModalHeader', () => {
   it('should render close button with custom icon', () => {
     const wrapper = shallow(<ModalHeader toggle={() => {}} charCode={'X'}>Yo!</ModalHeader>);
 
-    const closeButtonIcon = wrapper.find('button.close span');
+    const closeButtonIcon = wrapper.find('button.btn-close span');
     expect(closeButtonIcon.text()).toEqual('X');
   });
 });

--- a/src/__tests__/ToastHeader.spec.js
+++ b/src/__tests__/ToastHeader.spec.js
@@ -22,7 +22,7 @@ describe('ToastHeader', () => {
 
     expect(wrapper.hasClass('other')).toBe(true);
     expect(wrapper.hasClass('toast-header')).toBe(true);
-    expect(wrapper.find('button.close').length).toBe(1);
+    expect(wrapper.find('button.btn-close').length).toBe(1);
   });
 
   it('should render custom tag', () => {
@@ -41,14 +41,14 @@ describe('ToastHeader', () => {
   it('should render close button with custom aria-label', () => {
     const wrapper = shallow(<ToastHeader toggle={() => { }} className="other" closeAriaLabel="oseclay">Yo!</ToastHeader>);
 
-    const closeButton = wrapper.find('button.close').first();
+    const closeButton = wrapper.find('button.btn-close').first();
     expect(closeButton.prop('aria-label')).toBe('oseclay');
   });
 
   it('should render close button with default icon', () => {
     const wrapper = shallow(<ToastHeader toggle={() => { }}>Yo!</ToastHeader>);
 
-    const closeButtonIcon = wrapper.find('button.close span');
+    const closeButtonIcon = wrapper.find('button.btn-close span');
     const defaultIcon = String.fromCharCode(215);
     expect(closeButtonIcon.text()).toEqual(defaultIcon);
   });
@@ -56,7 +56,7 @@ describe('ToastHeader', () => {
   it('should render close button with custom icon', () => {
     const wrapper = shallow(<ToastHeader toggle={() => { }} charCode={'X'}>Yo!</ToastHeader>);
 
-    const closeButtonIcon = wrapper.find('button.close span');
+    const closeButtonIcon = wrapper.find('button.btn-close span');
     expect(closeButtonIcon.text()).toEqual('X');
   });
 

--- a/src/__tests__/ToastHeader.spec.js
+++ b/src/__tests__/ToastHeader.spec.js
@@ -37,40 +37,4 @@ describe('ToastHeader', () => {
 
     expect(wrapper.type()).toBe('main');
   });
-
-  it('should render close button with custom aria-label', () => {
-    const wrapper = shallow(<ToastHeader toggle={() => { }} className="other" closeAriaLabel="oseclay">Yo!</ToastHeader>);
-
-    const closeButton = wrapper.find('button.btn-close').first();
-    expect(closeButton.prop('aria-label')).toBe('oseclay');
-  });
-
-  it('should render close button with default icon', () => {
-    const wrapper = shallow(<ToastHeader toggle={() => { }}>Yo!</ToastHeader>);
-
-    const closeButtonIcon = wrapper.find('button.btn-close span');
-    const defaultIcon = String.fromCharCode(215);
-    expect(closeButtonIcon.text()).toEqual(defaultIcon);
-  });
-
-  it('should render close button with custom icon', () => {
-    const wrapper = shallow(<ToastHeader toggle={() => { }} charCode={'X'}>Yo!</ToastHeader>);
-
-    const closeButtonIcon = wrapper.find('button.btn-close span');
-    expect(closeButtonIcon.text()).toEqual('X');
-  });
-
-  it('should render icon with a color', () => {
-    const wrapper = shallow(<ToastHeader icon="primary">Yo!</ToastHeader>);
-
-    const closeButtonIcon = wrapper.find('svg');
-    expect(closeButtonIcon.hasClass('text-primary')).toBe(true);
-  });
-
-  it('should render a custom icon', () => {
-    const wrapper = shallow(<ToastHeader icon={<span className="my-header">icon</span>}>Yo!</ToastHeader>);
-
-    const closeButtonIcon = wrapper.find('span.my-header');
-    expect(closeButtonIcon.text()).toEqual("icon");
-  });
 });

--- a/types/lib/ToastHeader.d.ts
+++ b/types/lib/ToastHeader.d.ts
@@ -9,7 +9,6 @@ export interface ToastHeaderProps extends React.HTMLAttributes<HTMLElement> {
   toggle?: React.MouseEventHandler<any>;
   icon?: string | React.ReactNode;
   close?: React.ReactNode;
-  charCode?: string | number;
   closeAriaLabel?: string;
 }
 


### PR DESCRIPTION
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->

- [ ] Bug fix <!-- (change which fixes an issue) -->
- [ ] New feature <!-- (change which adds functionality) -->
- [ ] Chore <!-- (change which doesn't affect the usage of the package (such as documentation, build process, or project setup changes)) -->
- [x] Breaking change <!-- (fix or feature that would cause existing functionality to change) -->
- [x] There is an open issue which this change addresses
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [x] My commits follow the [Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] My change requires a change to [Typescript typings](./types/lib).
  - [ ] I have updated the typings accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- Put any other information you believe would be useful to know when reviewing this PR below -->
This PR changes `close` to `btn-close` per Bootstrap 5 changes. Bootstrap 5 no longer supports custom close icons, so this feature was removed from `ModalHeader` and `ToastHeader`.
<!---
If there is an issue this PR addresses, please make sure it is in the commit message per the Git Commit Guidelines above
**AND** put the issue number below, indicating that it closes or fixes the issue.
-->

Related to: https://github.com/reactstrap/reactstrap/issues/1748
