### PR TITLE
feat(Row): add innerRef prop

### DIFF
--- a/docs/lib/Components/LayoutPage.js
+++ b/docs/lib/Components/LayoutPage.js
@@ -44,7 +44,12 @@ export default class LayoutsPage extends React.Component {
   sm: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   md: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   lg: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-  xl: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
+  xl: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  innerRef: PropTypes.oneOfType([
+    PropTypes.object,
+    PropTypes.string,
+    PropTypes.func,
+  ])
 }`}
           </PrismCode>
         </pre>

--- a/src/Row.js
+++ b/src/Row.js
@@ -16,7 +16,12 @@ const propTypes = {
   sm: rowColsPropType,
   md: rowColsPropType,
   lg: rowColsPropType,
-  xl: rowColsPropType
+  xl: rowColsPropType,
+  innerRef: PropTypes.oneOfType([
+    PropTypes.object,
+    PropTypes.string,
+    PropTypes.func,
+  ])
 };
 
 const defaultProps = {
@@ -32,6 +37,7 @@ const Row = (props) => {
     tag: Tag,
     form,
     widths,
+    innerRef,
     ...attributes
   } = props;
 
@@ -58,7 +64,7 @@ const Row = (props) => {
   ), cssModule);
 
   return (
-    <Tag {...attributes} className={classes} />
+    <Tag {...attributes} className={classes} ref={innerRef}/>
   );
 };
 

--- a/src/__tests__/Row.spec.js
+++ b/src/__tests__/Row.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import { Row } from '../';
 
 describe('Row', () => {
@@ -45,5 +45,12 @@ describe('Row', () => {
     const wrapper = shallow(<Row sm={6} />);
 
     expect(wrapper.hasClass('row-cols-sm-6')).toBe(true);
+  });
+
+  it('should reference innerRef to the row node', () => {
+    const ref = React.createRef();
+    mount(<Row innerRef={ref} />);
+    expect(ref.current).not.toBeNull();
+    expect(ref.current).toBeInstanceOf(HTMLElement);
   });
 });

--- a/types/lib/Row.d.ts
+++ b/types/lib/Row.d.ts
@@ -15,6 +15,7 @@ export interface RowProps
   md?: number | string;
   lg?: number | string;
   xl?: number | string;
+  innerRef?: React.Ref<HTMLElement>;
 }
 
 declare class Row extends React.Component<RowProps> {}


### PR DESCRIPTION
add innerRef prop in Row component to be able to access underlying DOM
element

<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->

- [ ] Bug fix <!-- (change which fixes an issue) -->
- [x] New feature <!-- (change which adds functionality) -->
- [ ] Chore <!-- (change which doesn't affect the usage of the package (such as documentation, build process, or project setup changes)) -->
- [ ] Breaking change <!-- (fix or feature that would cause existing functionality to change) -->
- [ ] There is an open issue which this change addresses
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [x] My commits follow the [Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [x] My change requires a change to [Typescript typings](./types/lib).
  - [x] I have updated the typings accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- Put any other information you believe would be useful to know when reviewing this PR below -->
Hello. I did follow your code convention with innerRefs instead of ref forwarding. I don't consider this as a breaking change since it's a different approach as a forwardRef which should be considered breaking change in a component library.

<!---
If there is an issue this PR addresses, please make sure it is in the commit message per the Git Commit Guidelines above
**AND** put the issue number below, indicating that it closes or fixes the issue.
-->
