### PR TITLE
fix(Button): remove extra close icon in `btn-close`

### DIFF
--- a/src/Button.js
+++ b/src/Button.js
@@ -59,10 +59,6 @@ class Button extends React.Component {
       ...attributes
     } = this.props;
 
-    if (close && typeof attributes.children === 'undefined') {
-      attributes.children = <span aria-hidden>×</span>;
-    }
-
     const btnOutlineColor = `btn${outline ? '-outline' : ''}-${color}`;
 
     const classes = mapToCssModules(classNames(

--- a/src/__tests__/Button.spec.js
+++ b/src/__tests__/Button.spec.js
@@ -97,20 +97,6 @@ describe('Button', () => {
     expect(block.hasClass('d-block w-100')).toBe(true);
   });
 
-  it('should render close icon utility with default props', () => {
-    const times = '×'; // unicode: U+00D7 MULTIPLICATION SIGN
-    const expectedInnerHTML = `<span aria-hidden="true">${times}</span>`;
-
-    const wrapper = shallow(<Button close />);
-    const actualInnerHTML = wrapper.children().html();
-
-    expect(wrapper.find('.btn-close').length).toBe(1);
-    expect(wrapper.find('.btn').length).toBe(0);
-    expect(wrapper.find('.btn-secondary').length).toBe(0);
-    expect(wrapper.find('button').prop('aria-label')).toMatch(/close/i);
-    expect(actualInnerHTML).toBe(expectedInnerHTML);
-  });
-
   it('should render close icon with custom child and props', () => {
     const testChild = 'close this thing';
     const wrapper = shallow(<Button close>{testChild}</Button>);

--- a/stories/examples/ButtonCloseIcon.js
+++ b/stories/examples/ButtonCloseIcon.js
@@ -1,5 +1,5 @@
-import React, { Component } from 'react';
-import { Button, Card, CardBody, CardText, CardGroup, CardTitle } from 'reactstrap';
+import React from 'react';
+import { Button } from 'reactstrap';
 
 const Example = (props) => (
   <div>


### PR DESCRIPTION
The close icon is now included automatically in Bootstrap 5. See https://getbootstrap.com/docs/5.1/components/close-button/#example

<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->

- [ ] Bug fix <!-- (change which fixes an issue) -->
- [ ] New feature <!-- (change which adds functionality) -->
- [ ] Chore <!-- (change which doesn't affect the usage of the package (such as documentation, build process, or project setup changes)) -->
- [ ] Breaking change <!-- (fix or feature that would cause existing functionality to change) -->
- [ ] There is an open issue which this change addresses
- [ ] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [ ] My commits follow the [Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] My change requires a change to [Typescript typings](./types/lib).
  - [ ] I have updated the typings accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!-- Put any other information you believe would be useful to know when reviewing this PR below -->

<!---
If there is an issue this PR addresses, please make sure it is in the commit message per the Git Commit Guidelines above
**AND** put the issue number below, indicating that it closes or fixes the issue.
-->
