### PR TITLE
fix: use new react-transition-group api

### DIFF
--- a/src/CarouselItem.js
+++ b/src/CarouselItem.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { Transition } from 'react-transition-group';
-import { mapToCssModules, TransitionTimeouts, TransitionStatuses, tagPropType } from './utils';
+import { mapToCssModules, TransitionTimeouts, TransitionStatuses, tagPropType, mergeRefs } from './utils';
 
 class CarouselItem extends React.Component {
   constructor(props) {
@@ -19,34 +19,37 @@ class CarouselItem extends React.Component {
     this.onExited = this.onExited.bind(this);
   }
 
-  onEnter(node, isAppearing) {
+  onEnter(isAppearing) {
     this.setState({ startAnimation: false });
-    this.props.onEnter(node, isAppearing);
+    this.props.onEnter(this.nodeRef.current, isAppearing);
   }
 
-  onEntering(node, isAppearing) {
+  onEntering(isAppearing) {
     // getting this variable triggers a reflow
-    const offsetHeight = node.offsetHeight;
+    const offsetHeight = this.nodeRef.current.offsetHeight;
     this.setState({ startAnimation: true });
-    this.props.onEntering(node, isAppearing);
+    this.props.onEntering(this.nodeRef.current, isAppearing);
     return offsetHeight;
   }
 
-  onExit(node) {
+  onExit() {
     this.setState({ startAnimation: false });
-    this.props.onExit(node);
+    this.props.onExit(this.nodeRef.current);
   }
 
-  onExiting(node) {
+  onExiting() {
     this.setState({ startAnimation: true });
-    node.dispatchEvent(new CustomEvent('slide.bs.carousel'));
-    this.props.onExiting(node);
+    this.nodeRef.current.dispatchEvent(new CustomEvent('slide.bs.carousel'));
+    this.props.onExiting(this.nodeRef.current);
   }
 
-  onExited(node) {
-    node.dispatchEvent(new CustomEvent('slid.bs.carousel'));
-    this.props.onExited(node);
+  onExited() {
+    this.nodeRef.current.dispatchEvent(new CustomEvent('slid.bs.carousel'));
+    this.props.onExited(this.nodeRef.current);
   }
+
+  nodeRef = React.createRef()
+  mergedRefs = mergeRefs(this.nodeRef, this.props.nodeRef)
 
   render() {
     const { in: isIn, children, cssModule, slide, tag: Tag, className, ...transitionProps } = this.props;
@@ -62,6 +65,7 @@ class CarouselItem extends React.Component {
         onExit={this.onExit}
         onExiting={this.onExiting}
         onExited={this.onExited}
+        nodeRef={this.nodeRef}
       >
         {(status) => {
           const { direction } = this.context;
@@ -80,7 +84,7 @@ class CarouselItem extends React.Component {
           ), cssModule);
 
           return (
-            <Tag className={itemClasses}>
+            <Tag className={itemClasses} ref={this.mergedRefs}>
               {children}
             </Tag>
           );

--- a/src/CarouselItem.js
+++ b/src/CarouselItem.js
@@ -49,10 +49,10 @@ class CarouselItem extends React.Component {
   }
 
   nodeRef = React.createRef()
-  mergedRefs = mergeRefs(this.nodeRef, this.props.nodeRef)
 
   render() {
     const { in: isIn, children, cssModule, slide, tag: Tag, className, ...transitionProps } = this.props;
+    const mergedRefs = mergeRefs(this.nodeRef, this.props.nodeRef)
 
     return (
       <Transition
@@ -84,7 +84,7 @@ class CarouselItem extends React.Component {
           ), cssModule);
 
           return (
-            <Tag className={itemClasses} ref={this.mergedRefs}>
+            <Tag className={itemClasses} ref={mergedRefs}>
               {children}
             </Tag>
           );

--- a/src/Collapse.js
+++ b/src/Collapse.js
@@ -90,7 +90,6 @@ class Collapse extends Component {
   }
 
   nodeRef = React.createRef()
-  mergedRefs = mergeRefs(this.nodeRef, this.props.innerRef, this.props.nodeRef)
 
   render() {
     const {
@@ -110,6 +109,7 @@ class Collapse extends Component {
 
     const transitionProps = pick(otherProps, TransitionPropTypeKeys);
     const childProps = omit(otherProps, TransitionPropTypeKeys);
+    const mergedRefs = mergeRefs(this.nodeRef, this.props.innerRef, this.props.nodeRef)
 
     return (
       <Transition
@@ -136,7 +136,7 @@ class Collapse extends Component {
               {...childProps}
               style={{ ...childProps.style, ...style }}
               className={classes}
-              ref={this.mergedRefs}
+              ref={mergedRefs}
             >
               {children}
             </Tag>

--- a/src/Fade.js
+++ b/src/Fade.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { Transition } from 'react-transition-group';
-import { mapToCssModules, omit, pick, TransitionPropTypeKeys, TransitionTimeouts, tagPropType } from './utils';
+import { mapToCssModules, omit, pick, TransitionPropTypeKeys, TransitionTimeouts, tagPropType, mergeRefs } from './utils';
 
 const propTypes = {
   ...Transition.propTypes,
@@ -43,14 +43,17 @@ function Fade(props) {
     cssModule,
     children,
     innerRef,
+    nodeRef: propsNodeRef,
     ...otherProps
   } = props;
 
   const transitionProps = pick(otherProps, TransitionPropTypeKeys);
   const childProps = omit(otherProps, TransitionPropTypeKeys);
+  const nodeRef = React.useRef()
+  const mergedRefs = React.useCallback(mergeRefs(nodeRef, innerRef, propsNodeRef), [nodeRef, innerRef, propsNodeRef]);
 
   return (
-    <Transition {...transitionProps}>
+    <Transition {...transitionProps} nodeRef={nodeRef}>
       {(status) => {
         const isActive = status === 'entered';
         const classes = mapToCssModules(classNames(
@@ -59,7 +62,7 @@ function Fade(props) {
           isActive && baseClassActive
         ), cssModule);
         return (
-          <Tag className={classes} {...childProps} ref={innerRef}>
+          <Tag className={classes} {...childProps} ref={mergedRefs}>
             {children}
           </Tag>
         );

--- a/src/__tests__/Carousel.spec.js
+++ b/src/__tests__/Carousel.spec.js
@@ -1,10 +1,16 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import { Carousel } from '../';
+import { Carousel as CarouselComponent } from '../';
 import CarouselItem from '../CarouselItem';
 import CarouselIndicators from '../CarouselIndicators';
 import CarouselControl from '../CarouselControl';
 import CarouselCaption from '../CarouselCaption';
+
+class Carousel extends CarouselComponent {
+  render() {
+    return <React.StrictMode>{super.render()}</React.StrictMode>
+  }
+}
 
 describe('Carousel', () => {
   beforeEach(() => {

--- a/src/__tests__/Collapse.spec.js
+++ b/src/__tests__/Collapse.spec.js
@@ -1,6 +1,12 @@
 import React from 'react';
 import { shallow, mount } from 'enzyme';
-import { Collapse } from '../';
+import { Collapse as CollapseComponent } from '../';
+
+class Collapse extends CollapseComponent {
+  render() {
+    return <React.StrictMode>{super.render()}</React.StrictMode>
+  }
+}
 
 describe('Collapse', () => {
   let isOpen;

--- a/src/__tests__/Fade.spec.js
+++ b/src/__tests__/Fade.spec.js
@@ -1,7 +1,15 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import { TransitionGroup } from 'react-transition-group';
-import { Fade } from '../';
+import { Fade as FadeComponent } from '../';
+
+function Fade(props) {
+  return (
+    <React.StrictMode>
+      <FadeComponent {...props} />
+    </React.StrictMode>
+  )
+}
 
 class Helper extends React.Component {
   constructor(props) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -113,16 +113,16 @@ export function deprecated(propType, explanation) {
 }
 
 // Shim Element if needed (e.g. in Node environment)
-const Element = (typeof window === 'object' && window.Element) || function() {};
+const Element = (typeof window === 'object' && window.Element) || function () { };
 
 export function DOMElement(props, propName, componentName) {
   if (!(props[propName] instanceof Element)) {
     return new Error(
       'Invalid prop `' +
-        propName +
-        '` supplied to `' +
-        componentName +
-        '`. Expected prop to be an instance of Element. Validation failed.'
+      propName +
+      '` supplied to `' +
+      componentName +
+      '`. Expected prop to be an instance of Element. Validation failed.'
     );
   }
 }
@@ -228,9 +228,9 @@ export function isReactRefObj(target) {
 
 function getTag(value) {
   if (value == null) {
-        return value === undefined ? '[object Undefined]' : '[object Null]'
-    }
-    return Object.prototype.toString.call(value)
+    return value === undefined ? '[object Undefined]' : '[object Null]'
+  }
+  return Object.prototype.toString.call(value)
 }
 
 export function toNumber(value) {
@@ -371,3 +371,13 @@ export const focusableElements = [
   'video[controls]',
   '[contenteditable]:not([contenteditable="false"])',
 ];
+
+export function mergeRefs(ref1, ref2, ref3) {
+  return (value) => [ref1, ref2, ref3].filter(Boolean).forEach(ref => {
+    if (typeof ref === 'function') {
+      ref(value)
+    } else if (ref != null) {
+      ref.current = value
+    }
+  })
+}


### PR DESCRIPTION
- [x] Bug fix <!-- (change which fixes an issue) -->
- [ ] New feature <!-- (change which adds functionality) -->
- [ ] Chore <!-- (change which doesn't affect the usage of the package (such as documentation, build process, or project setup changes)) -->
- [ ] Breaking change <!-- (fix or feature that would cause existing functionality to change) -->
- [x] There is an open issue which this change addresses
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [x] My commits follow the [Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] My change requires a change to [Typescript typings](./types/lib).
  - [ ] I have updated the typings accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Update of `react-transition-group` does not solve warnings in StrictMode.
`react-transition-group` has a new API that uses refs instead of `findDOMNode`

This does not completely get rid of StrictMode warnings, it seems that Carousel is still using legacy context API. I made a PR related to this in the past, https://github.com/reactstrap/reactstrap/pull/1831 but the tests break

Related #1289
Related #1340
Related #1992
Related #1289
Related #1833
Related #1468
Related #1738

ps1: I am the author of new `react-transition-api` API that uses refs https://github.com/reactjs/react-transition-group/pull/559
ps2: I had access to this repo in the past, but I reset 2FA, and I lost access to it