### PR TITLE
patch: V5 Carousel Updates

### DIFF
--- a/src/Carousel.js
+++ b/src/Carousel.js
@@ -285,8 +285,4 @@ Carousel.defaultProps = {
   fade: false,
 };
 
-Carousel.childContextTypes = {
-  direction: PropTypes.string
-};
-
 export default Carousel;


### PR DESCRIPTION
fix https://github.com/reactstrap/reactstrap/issues/2417 by removing childContextTypes definition from the Carousel component

- [x] Bug fix
- [ ] New feature
- [x] Chore
- [ ] Breaking change
- [x] There is an open issue which this change addresses
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [x] My commits follow the [Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] My change requires a change to [Typescript typings](./types/lib).
  - [ ] I have updated the typings accordingly.
- [ ] I have added tests to cover my changes.
- [x] All Existing tests passed.
