### PR TITLE
fix: add a flag to DropdownMenu for Popper update

### DIFF
--- a/src/DropdownMenu.js
+++ b/src/DropdownMenu.js
@@ -18,6 +18,7 @@ const propTypes = {
   persist: PropTypes.bool,
   strategy: PropTypes.string,
   container: targetPropType,
+  updateOnSelect: PropTypes.bool,
   right: deprecated(PropTypes.bool, 'Please use "end" instead.'),
 };
 
@@ -58,6 +59,7 @@ class DropdownMenu extends React.Component {
       persist,
       strategy,
       container,
+      updateOnSelect,
       ...attrs
     } = this.props;
 
@@ -92,7 +94,7 @@ class DropdownMenu extends React.Component {
           modifiers={poperModifiers}
           strategy={strategy}
         >
-          {({ ref, style, placement }) => {
+          {({ ref, style, placement, update }) => {
             let combinedStyle = { ...this.props.style, ...style };
 
             const handleRef = (tagRef) => {
@@ -114,6 +116,7 @@ class DropdownMenu extends React.Component {
                 aria-hidden={!this.context.isOpen}
                 className={classes}
                 data-popper-placement={placement}
+                onClick={() => updateOnSelect && update()}
               />
             );
           }}


### PR DESCRIPTION
Add a boolean prop to DropdownMenu to update the Popper position every time an item is selected (see `update` documentation here: https://popper.js.org/react-popper/v2/render-props/#children).

<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->

- [ ] Bug fix <!-- (change which fixes an issue) -->
- [x] New feature <!-- (change which adds functionality) -->
- [ ] Chore <!-- (change which doesn't affect the usage of the package (such as documentation, build process, or project setup changes)) -->
- [ ] Breaking change <!-- (fix or feature that would cause existing functionality to change) -->
- [ ] There is an open issue which this change addresses
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [x] My commits follow the [Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] My change requires a change to [Typescript typings](./types/lib).
  - [ ] I have updated the typings accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- Put any other information you believe would be useful to know when reviewing this PR below -->

<!---
If there is an issue this PR addresses, please make sure it is in the commit message per the Git Commit Guidelines above
**AND** put the issue number below, indicating that it closes or fixes the issue.
-->
