### PR TITLE
collapse: improve type definition. remove invalid `onOpened` and `onClosed`

### DIFF
--- a/types/lib/Collapse.d.ts
+++ b/types/lib/Collapse.d.ts
@@ -12,13 +12,11 @@ export interface CollapseProps extends React.HTMLAttributes<HTMLElement> {
     show: number;
     hide: number;
   };
-  onOpened?: () => void;
-  onClosed?: () => void;
-  onEntering?: () => void;
-  onEntered?: () => void;
-  onExit?: () => void;
-  onExiting?: () => void;
-  onExited?: () => void;
+  onEntering?: (node: HTMLElement, isAppearing: boolean) => void;
+  onEntered?: (node: HTMLElement, isAppearing: boolean) => void;
+  onExit?: (node: HTMLElement) => void;
+  onExiting?: (node: HTMLElement) => void;
+  onExited?: (node: HTMLElement) => void;
   innerRef?: React.Ref<HTMLElement>;
 }
 


### PR DESCRIPTION


- [x] Bug fix <!-- (change which fixes an issue) -->
- [ ] New feature <!-- (change which adds functionality) -->
- [ ] Chore <!-- (change which doesn't affect the usage of the package (such as documentation, build process, or project setup changes)) -->
- [ ] Breaking change <!-- (fix or feature that would cause existing functionality to change) -->
- [ ] There is an open issue which this change addresses
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [ ] My commits follow the [Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] My change requires a change to [Typescript typings](./types/lib).
  - [ ] I have updated the typings accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
----

Could not find  `onOpened` and `onClosed` in source code. also the other properties have node and boolean in the listener from `react-transition-group`