### PR TITLE
fix(Dropdown): replace e.target with e.currentTarget

### DIFF
--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -98,7 +98,7 @@ class Dropdown extends React.Component {
     const menu = this.getMenu();
     const toggle = this.getToggle();
 
-    const targetIsToggle = e.target === toggle;
+    const targetIsToggle = e.currentTarget === toggle;
     const clickIsInMenu = menu && menu.contains(e.target) && menu !== e.target;
 
     let clickIsInInput = false;


### PR DESCRIPTION
- [x] Bug fix <!-- (change which fixes an issue) -->
- [ ] New feature <!-- (change which adds functionality) -->
- [ ] Chore <!-- (change which doesn't affect the usage of the package (such as documentation, build process, or project setup changes)) -->
- [ ] Breaking change <!-- (fix or feature that would cause existing functionality to change) -->
- [ ] There is an open issue which this change addresses
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [x] My commits follow the [Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] My change requires a change to [Typescript typings](./types/lib).
  - [ ] I have updated the typings accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

I noticed a bug where HTML elements inside the DropdownToggle will prevent the dropdowns to be closed because the toggle method will be called twice (I guess once for the DropdownToggle and once for the document outside click)

I produced a codesandbox reflecting this issue:
https://codesandbox.io/s/reactstrap-dropdown-bug-yfg24k?file=/src/App.tsx:515-2540

_Note:_ I wasn't able to create a regression test that tests for this very issue since enzyme event bubbling seems to behave different from the browser events.

Thank you guys and happy #hacktoberfest to you all.