### PR TITLE
fix: ensure initial overflow status is stored when opening multiple modals

### DIFF
--- a/src/Modal.js
+++ b/src/Modal.js
@@ -116,7 +116,6 @@ class Modal extends React.Component {
 
     this._element = null;
     this._originalBodyPadding = null;
-    this._originalBodyOverflow = null;
     this.getFocusableChildren = this.getFocusableChildren.bind(this);
     this.handleBackdropClick = this.handleBackdropClick.bind(this);
     this.handleBackdropMouseDown = this.handleBackdropMouseDown.bind(this);
@@ -371,9 +370,11 @@ class Modal extends React.Component {
     }
 
     this._originalBodyPadding = getOriginalBodyPadding();
-    this._originalBodyOverflow = window.getComputedStyle(
-      document.body,
-    ).overflow;
+    if (Modal.openCount < 1) {
+      Modal.originalBodyOverflow = window.getComputedStyle(
+        document.body,
+        ).overflow;
+    };
     conditionallyUpdateScrollbar();
 
     if (Modal.openCount === 0) {
@@ -419,7 +420,7 @@ class Modal extends React.Component {
       document.body.className = document.body.className
         .replace(modalOpenClassNameRegex, ' ')
         .trim();
-      document.body.style.overflow = this._originalBodyOverflow;
+      document.body.style.overflow = Modal.originalBodyOverflow;
     }
     this.manageFocusAfterClose();
     Modal.openCount = Math.max(0, Modal.openCount - 1);
@@ -571,5 +572,6 @@ class Modal extends React.Component {
 Modal.propTypes = propTypes;
 Modal.defaultProps = defaultProps;
 Modal.openCount = 0;
+Modal.originalBodyOverflow = null;
 
 export default Modal;


### PR DESCRIPTION
### Correct bug that prevents scrolling after closing modal

When modals are opened, scrolling is disabled on the main page's body by setting its overflow property to 'hidden'. In certain situations when multiple modals are active, scrolling is not restored after they are closed. This fix corrects the behavior and restores the overflow status that exists on the main page's body at the time before the first modal's opening.

<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->

- [x] Bug fix <!-- (change which fixes an issue) -->
- [x] New feature <!-- (change which adds functionality) -->
- [ ] Chore <!-- (change which doesn't affect the usage of the package (such as documentation, build process, or project setup changes)) -->
- [ ] Breaking change <!-- (fix or feature that would cause existing functionality to change) -->
- [ ] There is an open issue which this change addresses
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [x] My commits follow the [Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] My change requires a change to [Typescript typings](./types/lib).
  - [ ] I have updated the typings accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- Put any other information you believe would be useful to know when reviewing this PR below -->

<!---
If there is an issue this PR addresses, please make sure it is in the commit message per the Git Commit Guidelines above
**AND** put the issue number below, indicating that it closes or fixes the issue.
-->
