### PR TITLE
feat!: add forwardRef to all components that contain innerRef

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,9 +2,9 @@ name: Test Coverage
 
 on:
   push:
-    branches: [ master, bootstrap5 ]
+    branches: [ master, bootstrap5, v10 ]
   pull_request:
-    branches: [ master, bootstrap5 ]
+    branches: [ master, bootstrap5, v10 ]
 
 jobs:
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-      - master
+      - v10
 name: Release Bot
 jobs:
   release-pr:
@@ -15,6 +15,8 @@ jobs:
           package-name: "reactstrap"
           changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"chore","section":"Miscellaneous","hidden":true},{"type":"refactor","section":"Miscellaneous","hidden":false}]'
           command: release-pr
+          default-branch: v10
+          prerelease: true
 
   release:
     runs-on: ubuntu-latest
@@ -26,6 +28,8 @@ jobs:
           release-type: node
           package-name: "reactstrap"
           command: github-release
+          default-branch: v10
+          prerelease: true
       - uses: actions/checkout@v2
         if: ${{ steps.release.outputs.release_created }}
       - uses: actions/setup-node@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,9 +5,9 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ master, release-* ]
+    branches: [ master, release-*, v10 ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, v10 ]
 
 jobs:
   build:

--- a/package.json
+++ b/package.json
@@ -319,11 +319,9 @@
     "prettier": "2.7.1",
     "react": "^16.8.0",
     "react-dom": "^16.3.2",
-    "react-helmet": "^5.0.3",
-    "react-prism": "^4.3.2",
     "react-router": "^3.2.1",
     "react-test-renderer": "^16.3.2",
     "typescript": "^4.0.3",
-    "webpack": "^4.43.0"
+    "webpack": "^5.75.0"
   }
 }

--- a/src/Accordion.js
+++ b/src/Accordion.js
@@ -62,4 +62,4 @@ function Accordion(props) {
 Accordion.propTypes = propTypes;
 Accordion.defaultProps = defaultProps;
 
-export default Accordion;
+export default React.forwardRef((props, ref) => <Accordion innerRef={ref} {...props} />);

--- a/src/Accordion.js
+++ b/src/Accordion.js
@@ -29,7 +29,7 @@ const defaultProps = {
   tag: 'div',
 };
 
-function Accordion(props) {
+const Accordion = React.forwardRef((props, ref) => {
   const {
     flush,
     open,
@@ -37,7 +37,7 @@ function Accordion(props) {
     className,
     cssModule,
     tag: Tag,
-    innerRef,
+    innerRef = ref,
     ...attributes
   } = props;
   const classes = mapToCssModules(
@@ -57,9 +57,9 @@ function Accordion(props) {
       <Tag {...attributes} className={classes} ref={innerRef} />
     </AccordionContext.Provider>
   );
-}
+})
 
 Accordion.propTypes = propTypes;
 Accordion.defaultProps = defaultProps;
 
-export default React.forwardRef((props, ref) => <Accordion innerRef={ref} {...props} />);
+export default Accordion;

--- a/src/AccordionBody.js
+++ b/src/AccordionBody.js
@@ -32,7 +32,7 @@ function AccordionBody(props) {
     className,
     cssModule,
     tag: Tag,
-    innerRef,
+    innerRef = ref,
     children,
     accordionId,
     ...attributes
@@ -62,4 +62,4 @@ function AccordionBody(props) {
 AccordionBody.propTypes = propTypes;
 AccordionBody.defaultProps = defaultProps;
 
-export default AccordionBody;
+export default React.forwardRef((props, ref) => <AccordionBody innerRef={ref} {...props} />);

--- a/src/AccordionBody.js
+++ b/src/AccordionBody.js
@@ -27,7 +27,7 @@ const defaultProps = {
   tag: 'div',
 };
 
-function AccordionBody(props) {
+const AccordionBody = React.forwardRef((props, ref) => {
   const {
     className,
     cssModule,
@@ -57,9 +57,9 @@ function AccordionBody(props) {
       <Tag className="accordion-body">{children}</Tag>
     </Collapse>
   );
-}
+})
 
 AccordionBody.propTypes = propTypes;
 AccordionBody.defaultProps = defaultProps;
 
-export default React.forwardRef((props, ref) => <AccordionBody innerRef={ref} {...props} />);
+export default AccordionBody;

--- a/src/AccordionHeader.js
+++ b/src/AccordionHeader.js
@@ -67,4 +67,4 @@ function AccordionHeader(props) {
 AccordionHeader.propTypes = propTypes;
 AccordionHeader.defaultProps = defaultProps;
 
-export default AccordionHeader;
+export default React.forwardRef((props, ref) => <AccordionHeader innerRef={ref} {...props} />);

--- a/src/AccordionHeader.js
+++ b/src/AccordionHeader.js
@@ -25,12 +25,12 @@ const defaultProps = {
   tag: 'h2',
 };
 
-function AccordionHeader(props) {
+const AccordionHeader = React.forwardRef((props, ref) => {
   const {
     className,
     cssModule,
     tag: Tag,
-    innerRef,
+    innerRef = ref,
     children,
     targetId,
     ...attributes
@@ -62,9 +62,9 @@ function AccordionHeader(props) {
       </button>
     </Tag>
   );
-}
+})
 
 AccordionHeader.propTypes = propTypes;
 AccordionHeader.defaultProps = defaultProps;
 
-export default React.forwardRef((props, ref) => <AccordionHeader innerRef={ref} {...props} />);
+export default AccordionHeader;

--- a/src/AccordionItem.js
+++ b/src/AccordionItem.js
@@ -35,4 +35,4 @@ function AccordionItem(props) {
 AccordionItem.propTypes = propTypes;
 AccordionItem.defaultProps = defaultProps;
 
-export default AccordionItem;
+export default React.forwardRef((props, ref) => <AccordionItem innerRef={ref} {...props} />);

--- a/src/AccordionItem.js
+++ b/src/AccordionItem.js
@@ -22,17 +22,17 @@ const defaultProps = {
   tag: 'div',
 };
 
-function AccordionItem(props) {
-  const { className, cssModule, tag: Tag, innerRef, ...attributes } = props;
+const AccordionItem = React.forwardRef((props, ref) => {
+  const { className, cssModule, tag: Tag, innerRef = ref, ...attributes } = props;
   const classes = mapToCssModules(
     classNames(className, 'accordion-item'),
     cssModule,
   );
 
   return <Tag {...attributes} className={classes} ref={innerRef} />;
-}
+})
 
 AccordionItem.propTypes = propTypes;
 AccordionItem.defaultProps = defaultProps;
 
-export default React.forwardRef((props, ref) => <AccordionItem innerRef={ref} {...props} />);
+export default AccordionItem;

--- a/src/Alert.js
+++ b/src/Alert.js
@@ -59,7 +59,7 @@ function Alert(props) {
     children,
     transition,
     fade,
-    innerRef,
+    innerRef = ref,
     ...attributes
   } = props;
 
@@ -108,4 +108,4 @@ function Alert(props) {
 Alert.propTypes = propTypes;
 Alert.defaultProps = defaultProps;
 
-export default Alert;
+export default React.forwardRef((props, ref) => <Alert innerRef={ref} {...props} />);

--- a/src/Alert.js
+++ b/src/Alert.js
@@ -46,7 +46,7 @@ const defaultProps = {
   },
 };
 
-function Alert(props) {
+const Alert = React.forwardRef((props, ref) => {
   const {
     className,
     closeClassName,
@@ -103,9 +103,9 @@ function Alert(props) {
       {children}
     </Fade>
   );
-}
+});
 
 Alert.propTypes = propTypes;
 Alert.defaultProps = defaultProps;
 
-export default React.forwardRef((props, ref) => <Alert innerRef={ref} {...props} />);
+export default Alert;

--- a/src/Badge.js
+++ b/src/Badge.js
@@ -29,12 +29,12 @@ const defaultProps = {
   tag: 'span',
 };
 
-function Badge(props) {
+const Badge = React.forwardRef((props, ref) => {
   let {
     className,
     cssModule,
     color,
-    innerRef,
+    innerRef = ref,
     pill,
     tag: Tag,
     ...attributes
@@ -55,9 +55,9 @@ function Badge(props) {
   }
 
   return <Tag {...attributes} className={classes} ref={innerRef} />;
-}
+});
 
 Badge.propTypes = propTypes;
 Badge.defaultProps = defaultProps;
 
-export default React.forwardRef((props, ref) => <Badge innerRef={ref} {...props} />);
+export default Badge;

--- a/src/Badge.js
+++ b/src/Badge.js
@@ -60,4 +60,4 @@ function Badge(props) {
 Badge.propTypes = propTypes;
 Badge.defaultProps = defaultProps;
 
-export default Badge;
+export default React.forwardRef((props, ref) => <Badge innerRef={ref} {...props} />);

--- a/src/Button.js
+++ b/src/Button.js
@@ -109,4 +109,4 @@ function Button(props) {
 Button.propTypes = propTypes;
 Button.defaultProps = defaultProps;
 
-export default Button;
+export default React.forwardRef((props, ref) => <Button innerRef={ref} {...props} />);

--- a/src/Button.js
+++ b/src/Button.js
@@ -42,7 +42,7 @@ const defaultProps = {
   tag: 'button',
 };
 
-function Button(props) {
+const Button = React.forwardRef((props, ref) => {
   const onClick = useCallback(
     (e) => {
       if (props.disabled) {
@@ -68,7 +68,7 @@ function Button(props) {
     outline,
     size,
     tag: Tag,
-    innerRef,
+    innerRef = ref,
     ...attributes
   } = props;
 
@@ -104,9 +104,9 @@ function Button(props) {
       aria-label={ariaLabel}
     />
   );
-}
+});
 
 Button.propTypes = propTypes;
 Button.defaultProps = defaultProps;
 
-export default React.forwardRef((props, ref) => <Button innerRef={ref} {...props} />);
+export default Button;

--- a/src/Card.js
+++ b/src/Card.js
@@ -58,4 +58,4 @@ function Card(props) {
 Card.propTypes = propTypes;
 Card.defaultProps = defaultProps;
 
-export default Card;
+export default React.forwardRef((props, ref) => <Card innerRef={ref} {...props} />);

--- a/src/CardBody.js
+++ b/src/CardBody.js
@@ -21,17 +21,17 @@ const defaultProps = {
   tag: 'div',
 };
 
-function CardBody(props) {
-  const { className, cssModule, innerRef, tag: Tag, ...attributes } = props;
+const CardBody = React.forwardRef((props, ref) => {
+  const { className, cssModule, innerRef = ref, tag: Tag, ...attributes } = props;
   const classes = mapToCssModules(
     classNames(className, 'card-body'),
     cssModule,
   );
 
   return <Tag {...attributes} className={classes} ref={innerRef} />;
-}
+});
 
 CardBody.propTypes = propTypes;
 CardBody.defaultProps = defaultProps;
 
-export default React.forwardRef((props, ref) => <CardBody innerRef={ref} {...props} />);
+export default CardBody;

--- a/src/CardBody.js
+++ b/src/CardBody.js
@@ -34,4 +34,4 @@ function CardBody(props) {
 CardBody.propTypes = propTypes;
 CardBody.defaultProps = defaultProps;
 
-export default CardBody;
+export default React.forwardRef((props, ref) => <CardBody innerRef={ref} {...props} />);

--- a/src/CardLink.js
+++ b/src/CardLink.js
@@ -18,17 +18,17 @@ const defaultProps = {
   tag: 'a',
 };
 
-function CardLink(props) {
-  const { className, cssModule, tag: Tag, innerRef, ...attributes } = props;
+const CardLink = React.forwardRef((props, ref) => {
+  const { className, cssModule, tag: Tag, innerRef = ref, ...attributes } = props;
   const classes = mapToCssModules(
     classNames(className, 'card-link'),
     cssModule,
   );
 
   return <Tag {...attributes} ref={innerRef} className={classes} />;
-}
+})
 
 CardLink.propTypes = propTypes;
 CardLink.defaultProps = defaultProps;
 
-export default React.forwardRef((props, ref) => <CardLink innerRef={ref} {...props} />);
+export default CardLink;

--- a/src/CardLink.js
+++ b/src/CardLink.js
@@ -31,4 +31,4 @@ function CardLink(props) {
 CardLink.propTypes = propTypes;
 CardLink.defaultProps = defaultProps;
 
-export default CardLink;
+export default React.forwardRef((props, ref) => <CardLink innerRef={ref} {...props} />);

--- a/src/CloseButton.js
+++ b/src/CloseButton.js
@@ -40,4 +40,4 @@ function CloseButton(props) {
 CloseButton.propTypes = propTypes;
 CloseButton.defaultProps = defaultProps;
 
-export default CloseButton;
+export default React.forwardRef((props, ref) => <CloseButton innerRef={ref} {...props} />);

--- a/src/CloseButton.js
+++ b/src/CloseButton.js
@@ -25,8 +25,8 @@ const defaultProps = {
   'aria-label': 'close',
 };
 
-function CloseButton(props) {
-  const { className, cssModule, variant, innerRef, ...attributes } = props;
+const CloseButton = React.forwardRef((props, ref) => {
+  const { className, cssModule, variant, innerRef = ref, ...attributes } = props;
 
   const classes = mapToCssModules(
     classNames(className, 'btn-close', variant && `btn-close-${variant}`),
@@ -35,9 +35,9 @@ function CloseButton(props) {
   return (
     <button ref={innerRef} type="button" className={classes} {...attributes} />
   );
-}
+});
 
 CloseButton.propTypes = propTypes;
 CloseButton.defaultProps = defaultProps;
 
-export default React.forwardRef((props, ref) => <CloseButton innerRef={ref} {...props} />);
+export default CloseButton;

--- a/src/Collapse.js
+++ b/src/Collapse.js
@@ -172,4 +172,4 @@ class Collapse extends Component {
 
 Collapse.propTypes = propTypes;
 Collapse.defaultProps = defaultProps;
-export default Collapse;
+export default React.forwardRef((props, ref) => <Collapse innerRef={ref} {...props} />);

--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -371,4 +371,4 @@ Dropdown.propTypes = propTypes;
 Dropdown.defaultProps = defaultProps;
 Dropdown.contextType = InputGroupContext;
 
-export default Dropdown;
+export default React.forwardRef((props, ref) => <Dropdown innerRef={ref} {...props} />);

--- a/src/DropdownToggle.js
+++ b/src/DropdownToggle.js
@@ -143,4 +143,4 @@ DropdownToggle.propTypes = propTypes;
 DropdownToggle.defaultProps = defaultProps;
 DropdownToggle.contextType = DropdownContext;
 
-export default DropdownToggle;
+export default React.forwardRef((props, ref) => <DropdownToggle innerRef={ref} {...props} />);

--- a/src/Fade.js
+++ b/src/Fade.js
@@ -77,4 +77,4 @@ function Fade(props) {
 Fade.propTypes = propTypes;
 Fade.defaultProps = defaultProps;
 
-export default Fade;
+export default React.forwardRef((props, ref) => <Fade innerRef={ref} {...props} />);

--- a/src/Fade.js
+++ b/src/Fade.js
@@ -41,7 +41,7 @@ const defaultProps = {
   in: true,
 };
 
-function Fade(props) {
+const Fade = React.forwardRef((props, ref) => {
   const {
     tag: Tag,
     baseClass,
@@ -49,7 +49,7 @@ function Fade(props) {
     className,
     cssModule,
     children,
-    innerRef,
+    innerRef = ref,
     ...otherProps
   } = props;
 
@@ -72,9 +72,9 @@ function Fade(props) {
       }}
     </Transition>
   );
-}
+});
 
 Fade.propTypes = propTypes;
 Fade.defaultProps = defaultProps;
 
-export default React.forwardRef((props, ref) => <Fade innerRef={ref} {...props} />);
+export default Fade;

--- a/src/Form.js
+++ b/src/Form.js
@@ -54,4 +54,4 @@ class Form extends Component {
 Form.propTypes = propTypes;
 Form.defaultProps = defaultProps;
 
-export default Form;
+export default React.forwardRef((props, ref) => <Form innerRef={ref} {...props} />);

--- a/src/Form.js
+++ b/src/Form.js
@@ -17,6 +17,8 @@ const propTypes = {
 const defaultProps = {
   tag: 'form',
 };
+
+// TODO: Simple conversion of functional component "good-first-task"
 class Form extends Component {
   constructor(props) {
     super(props);

--- a/src/Input.js
+++ b/src/Input.js
@@ -144,4 +144,4 @@ class Input extends React.Component {
 Input.propTypes = propTypes;
 Input.defaultProps = defaultProps;
 
-export default Input;
+export default React.forwardRef((props, ref) => <Input innerRef={ref} {...props} />);

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -574,4 +574,4 @@ Modal.defaultProps = defaultProps;
 Modal.openCount = 0;
 Modal.originalBodyOverflow = null;
 
-export default Modal;
+export default React.forwardRef((props, ref) => <Modal innerRef={ref} {...props} />);

--- a/src/NavLink.js
+++ b/src/NavLink.js
@@ -82,4 +82,4 @@ class NavLink extends React.Component {
 NavLink.propTypes = propTypes;
 NavLink.defaultProps = defaultProps;
 
-export default NavLink;
+export default React.forwardRef((props, ref) => <NavLink innerRef={ref} {...props} />);

--- a/src/Offcanvas.js
+++ b/src/Offcanvas.js
@@ -468,4 +468,4 @@ Offcanvas.propTypes = propTypes;
 Offcanvas.defaultProps = defaultProps;
 Offcanvas.openCount = 0;
 
-export default Offcanvas;
+export default React.forwardRef((props, ref) => <Offcanvas innerRef={ref} {...props} />);

--- a/src/Placeholder.js
+++ b/src/Placeholder.js
@@ -25,12 +25,12 @@ const defaultProps = {
   tag: 'span',
 };
 
-function Placeholder(props) {
+const Placeholder = React.forwardRef((props, ref) => {
   let {
     className,
     cssModule,
     color,
-    innerRef,
+    innerRef = ref,
     tag: Tag,
     animation,
     size,
@@ -56,9 +56,9 @@ function Placeholder(props) {
   );
 
   return <Tag {...modifiedAttributes} className={classes} ref={innerRef} />;
-}
+})
 
 Placeholder.propTypes = propTypes;
 Placeholder.defaultProps = defaultProps;
 
-export default React.forwardRef((props, ref) => <Placeholder innerRef={ref} {...props} />);
+export default Placeholder;

--- a/src/Placeholder.js
+++ b/src/Placeholder.js
@@ -61,4 +61,4 @@ function Placeholder(props) {
 Placeholder.propTypes = propTypes;
 Placeholder.defaultProps = defaultProps;
 
-export default Placeholder;
+export default React.forwardRef((props, ref) => <Placeholder innerRef={ref} {...props} />);

--- a/src/Table.js
+++ b/src/Table.js
@@ -50,7 +50,7 @@ function Table(props) {
     responsive,
     tag: Tag,
     responsiveTag: ResponsiveTag,
-    innerRef,
+    innerRef = ref,
     ...attributes
   } = props;
 
@@ -89,4 +89,4 @@ function Table(props) {
 Table.propTypes = propTypes;
 Table.defaultProps = defaultProps;
 
-export default Table;
+export default React.forwardRef((props, ref) => <Table innerRef={ref} {...props} />);

--- a/src/Table.js
+++ b/src/Table.js
@@ -37,7 +37,7 @@ const defaultProps = {
   responsiveTag: 'div',
 };
 
-function Table(props) {
+const Table = React.forwardRef((props, ref) => {
   const {
     className,
     cssModule,
@@ -84,9 +84,9 @@ function Table(props) {
   }
 
   return table;
-}
+})
 
 Table.propTypes = propTypes;
 Table.defaultProps = defaultProps;
 
-export default React.forwardRef((props, ref) => <Table innerRef={ref} {...props} />);
+export default Table;

--- a/src/Toast.js
+++ b/src/Toast.js
@@ -29,7 +29,7 @@ const defaultProps = {
   },
 };
 
-function Toast(props) {
+const Toast = React.forwardRef((props, ref) => {
   const {
     className,
     cssModule,
@@ -38,7 +38,7 @@ function Toast(props) {
     children,
     transition,
     fade,
-    innerRef,
+    innerRef = ref,
     ...attributes
   } = props;
 
@@ -64,9 +64,9 @@ function Toast(props) {
       {children}
     </Fade>
   );
-}
+})
 
 Toast.propTypes = propTypes;
 Toast.defaultProps = defaultProps;
 
-export default React.forwardRef((props, ref) => <Toast innerRef={ref} {...props} />);
+export default Toast;

--- a/src/Toast.js
+++ b/src/Toast.js
@@ -69,4 +69,4 @@ function Toast(props) {
 Toast.propTypes = propTypes;
 Toast.defaultProps = defaultProps;
 
-export default Toast;
+export default React.forwardRef((props, ref) => <Toast innerRef={ref} {...props} />);

--- a/src/ToastBody.js
+++ b/src/ToastBody.js
@@ -31,4 +31,4 @@ function ToastBody(props) {
 ToastBody.propTypes = propTypes;
 ToastBody.defaultProps = defaultProps;
 
-export default ToastBody;
+export default React.forwardRef((props, ref) => <ToastBody innerRef={ref} {...props} />);

--- a/src/ToastBody.js
+++ b/src/ToastBody.js
@@ -18,17 +18,17 @@ const defaultProps = {
   tag: 'div',
 };
 
-function ToastBody(props) {
-  const { className, cssModule, innerRef, tag: Tag, ...attributes } = props;
+const ToastBody = React.forwardRef((props, ref) => {
+  const { className, cssModule, innerRef = ref, tag: Tag, ...attributes } = props;
   const classes = mapToCssModules(
     classNames(className, 'toast-body'),
     cssModule,
   );
 
   return <Tag {...attributes} className={classes} ref={innerRef} />;
-}
+});
 
 ToastBody.propTypes = propTypes;
 ToastBody.defaultProps = defaultProps;
 
-export default React.forwardRef((props, ref) => <ToastBody innerRef={ref} {...props} />);
+export default ToastBody;

--- a/src/TooltipPopoverWrapper.js
+++ b/src/TooltipPopoverWrapper.js
@@ -400,4 +400,4 @@ class TooltipPopoverWrapper extends React.Component {
 TooltipPopoverWrapper.propTypes = propTypes;
 TooltipPopoverWrapper.defaultProps = defaultProps;
 
-export default TooltipPopoverWrapper;
+export default React.forwardRef((props, ref) => <TooltipPopoverWrapper innerRef={ref} {...props} />);

--- a/src/UncontrolledAccordion.js
+++ b/src/UncontrolledAccordion.js
@@ -43,4 +43,4 @@ function UncontrolledAccordion({ defaultOpen, stayOpen, ...props }) {
 UncontrolledAccordion.propTypes = propTypes;
 UncontrolledAccordion.defaultProps = defaultProps;
 
-export default UncontrolledAccordion;
+export default React.forwardRef((props, ref) => <UncontrolledAccordion innerRef={ref} {...props} />);

--- a/src/UncontrolledAccordion.js
+++ b/src/UncontrolledAccordion.js
@@ -21,7 +21,8 @@ const defaultProps = {
   tag: 'div',
 };
 
-function UncontrolledAccordion({ defaultOpen, stayOpen, ...props }) {
+const UncontrolledAccordion = React.forwardRef((props, ref) => {
+  const { defaultOpen, stayOpen, innerRef = ref, ...restProps } = props;
   const [open, setOpen] = useState(defaultOpen || (stayOpen ? [] : undefined));
   const toggle = (id) => {
     if (stayOpen) {
@@ -37,10 +38,10 @@ function UncontrolledAccordion({ defaultOpen, stayOpen, ...props }) {
     }
   };
 
-  return <Accordion {...props} open={open} toggle={toggle} />;
-}
+  return <Accordion {...restProps} open={open} toggle={toggle} ref={innerRef} />;
+})
 
 UncontrolledAccordion.propTypes = propTypes;
 UncontrolledAccordion.defaultProps = defaultProps;
 
-export default React.forwardRef((props, ref) => <UncontrolledAccordion innerRef={ref} {...props} />);
+export default UncontrolledAccordion;

--- a/src/__tests__/DropdownToggle.spec.js
+++ b/src/__tests__/DropdownToggle.spec.js
@@ -68,7 +68,7 @@ describe('DropdownToggle', () => {
       </DropdownContext.Provider>,
     );
 
-    expect(wrapper.childAt(0).childAt(0).hasClass('dropdown-toggle')).toBe(
+    expect(wrapper.children().childAt(0).childAt(0).hasClass('dropdown-toggle')).toBe(
       true,
     );
   });
@@ -131,7 +131,7 @@ describe('DropdownToggle', () => {
     );
 
     expect(
-      wrapper.childAt(0).childAt(0).hasClass('dropdown-toggle-split'),
+      wrapper.children().childAt(0).childAt(0).hasClass('dropdown-toggle-split'),
     ).toBe(true);
   });
 
@@ -144,7 +144,7 @@ describe('DropdownToggle', () => {
         </DropdownContext.Provider>,
       );
 
-      const instance = wrapper.instance();
+      const instance = wrapper.children().instance();
 
       instance.onClick({});
       expect(onClick).toHaveBeenCalled();
@@ -158,7 +158,7 @@ describe('DropdownToggle', () => {
         </DropdownContext.Provider>,
       );
 
-      const instance = wrapper.instance();
+      const instance = wrapper.children().instance();
 
       instance.onClick({
         preventDefault: () => {},
@@ -175,7 +175,7 @@ describe('DropdownToggle', () => {
           <DropdownToggle disabled>Ello world</DropdownToggle>
         </DropdownContext.Provider>,
       );
-      const instance = wrapper.instance();
+      const instance = wrapper.children().instance();
 
       instance.onClick(e);
       expect(e.preventDefault).toHaveBeenCalled();
@@ -211,7 +211,7 @@ describe('DropdownToggle', () => {
           <DropdownToggle nav>Ello world</DropdownToggle>
         </DropdownContext.Provider>,
       );
-      const instance = wrapper.instance();
+      const instance = wrapper.children().instance();
 
       instance.onClick(e);
       expect(e.preventDefault).toHaveBeenCalled();

--- a/src/__tests__/NavLink.spec.js
+++ b/src/__tests__/NavLink.spec.js
@@ -1,78 +1,83 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { createEvent, fireEvent, render, screen } from '@testing-library/react';
 import { NavLink } from '..';
 
 describe('NavLink', () => {
   it('should render .nav-link markup', () => {
-    const wrapper = shallow(<NavLink />);
+    const { container } = render(<NavLink />);
 
-    expect(wrapper.html()).toBe('<a class="nav-link"></a>');
+    expect(container.innerHTML).toBe('<a class="nav-link"></a>');
   });
 
   it('should render custom tag', () => {
-    const wrapper = shallow(<NavLink tag="div" />);
+    const { container } = render(<NavLink tag="div" />);
 
-    expect(wrapper.html()).toBe('<div class="nav-link"></div>');
+    expect(container.innerHTML).toBe('<div class="nav-link"></div>');
   });
 
   it('should render children', () => {
-    const wrapper = shallow(<NavLink>Children</NavLink>);
+    const { container } = render(<NavLink>Children</NavLink>);
 
-    expect(wrapper.html()).toBe('<a class="nav-link">Children</a>');
+    expect(container.innerHTML).toBe('<a class="nav-link">Children</a>');
   });
 
   it('should pass additional classNames', () => {
-    const wrapper = shallow(<NavLink className="extra" />);
+    render(<NavLink className="extra" />);
 
-    expect(wrapper.hasClass('extra')).toBe(true);
-    expect(wrapper.hasClass('nav-link')).toBe(true);
+    expect(document.querySelector('.extra')).toBeTruthy();
+    expect(document.querySelector('.nav-link')).toBeTruthy();
   });
 
   it('should render active class', () => {
-    const wrapper = shallow(<NavLink active />);
+    render(<NavLink active />);
 
-    expect(wrapper.hasClass('active')).toBe(true);
+    expect(document.querySelector('.active')).toBeTruthy();
   });
 
   it('should render disabled markup', () => {
-    const wrapper = shallow(<NavLink disabled />);
+    render(<NavLink disabled />);
 
-    expect(wrapper.hasClass('disabled')).toBe(true);
+    expect(document.querySelector('.disabled')).toBeTruthy();
   });
 
   it('handles onClick prop', () => {
     const onClick = jest.fn();
-    const e = createSpyObj('e', ['preventDefault']);
-    const wrapper = shallow(<NavLink onClick={onClick} />);
+    render(<NavLink data-testid="link" onClick={onClick} />);
 
-    wrapper.find('a').simulate('click', e);
+    const node = screen.getByTestId('link');
+    const clickEvent = createEvent.click(node)
+    fireEvent(node, clickEvent);
     expect(onClick).toHaveBeenCalled();
-    expect(e.preventDefault).not.toHaveBeenCalled();
+    expect(clickEvent.defaultPrevented).toBe(false);
   });
 
   it('handles onClick events', () => {
-    const e = createSpyObj('e', ['preventDefault']);
-    const wrapper = shallow(<NavLink />);
+    render(<NavLink data-testid="link" />);
 
-    wrapper.find('a').simulate('click', e);
-    expect(e.preventDefault).not.toHaveBeenCalled();
+    const node = screen.getByTestId('link');
+    const clickEvent = createEvent.click(node)
+    fireEvent(node, clickEvent);
+    expect(clickEvent.defaultPrevented).toBe(false);
   });
 
-  it('prevents link clicks via onClick for dropdown nav-items', () => {
-    const e = createSpyObj('e', ['preventDefault']);
-    const wrapper = shallow(<NavLink href="#" />);
+  it('prevents link clicks via onClick for dropdown nav-items', async () => {
+    render(<NavLink href="#" data-testid="link" />);
 
-    wrapper.find('a').simulate('click', e);
-    expect(e.preventDefault).toHaveBeenCalled();
+    const node = screen.getByTestId('link');
+    const clickEvent = createEvent.click(node)
+    fireEvent(node, clickEvent);
+    expect(clickEvent.defaultPrevented).toBe(true);
   });
 
   it('is not called when disabled', () => {
     const onClick = jest.fn();
-    const e = createSpyObj('e', ['preventDefault']);
-    const wrapper = shallow(<NavLink disabled onClick={onClick} />);
+    render(<NavLink disabled onClick={onClick} data-testid="link" />);
 
-    wrapper.find('a').simulate('click', e);
-    expect(e.preventDefault).toHaveBeenCalled();
+    const node = screen.getByTestId('link');
+    const clickEvent = createEvent.click(node);
+    fireEvent(node, clickEvent);
+
+    expect(clickEvent.defaultPrevented).toBe(true);
     expect(onClick).not.toHaveBeenCalled();
   });
 });

--- a/src/__tests__/Placeholder.spec.js
+++ b/src/__tests__/Placeholder.spec.js
@@ -1,58 +1,58 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { render } from '@testing-library/react';
 import { Placeholder } from '..';
 
 describe('Placeholder', () => {
   it('should render with "placeholder" class', () => {
-    const wrapper = shallow(<Placeholder />);
-    expect(wrapper.hasClass('placeholder')).toBe(true);
+    render(<Placeholder />);
+    expect(document.querySelector('.placeholder')).toBeTruthy();
   });
 
   it('should render column size', () => {
-    const wrapper = shallow(<Placeholder xs={7} />);
-    expect(wrapper.hasClass('col-7')).toBe(true);
+    render(<Placeholder xs={7} />);
+    expect(document.querySelector('.col-7')).toBeTruthy();
   });
 
   it('should render animation', () => {
-    const wrapper = shallow(<Placeholder tag="p" animation="glow" />);
-    expect(wrapper.hasClass('placeholder-glow')).toBe(true);
+    render(<Placeholder tag="p" animation="glow" />);
+    expect(document.querySelector('.placeholder-glow')).toBeTruthy();
   });
 
   it('should render color', () => {
-    const wrapper = shallow(<Placeholder xs={12} color="primary" />);
-    expect(wrapper.hasClass('bg-primary')).toBe(true);
+    render(<Placeholder xs={12} color="primary" />);
+    expect(document.querySelector('.bg-primary')).toBeTruthy();
   });
 
   it('should render size', () => {
-    const wrapper = shallow(<Placeholder size="lg" xs={12} />);
-    expect(wrapper.hasClass('placeholder-lg')).toBe(true);
+    render(<Placeholder size="lg" xs={12} />);
+    expect(document.querySelector('.placeholder-lg')).toBeTruthy();
   });
 
   it('should render different widths for different breakpoints', () => {
-    const wrapper = shallow(<Placeholder size="lg" xs={12} lg={8} />);
-    expect(wrapper.hasClass('col-lg-8')).toBe(true);
-    expect(wrapper.hasClass('col-12')).toBe(true);
+    render(<Placeholder size="lg" xs={12} lg={8} />);
+    expect(document.querySelector('.col-lg-8')).toBeTruthy();
+    expect(document.querySelector('.col-12')).toBeTruthy();
   });
 
   it('should allow custom columns to be defined', () => {
-    const wrapper = shallow(
+    render(
       <Placeholder widths={['base', 'jumbo']} base="4" jumbo="6" />,
     );
-    expect(wrapper.hasClass('col-4')).toBe(true);
-    expect(wrapper.hasClass('col-jumbo-6')).toBe(true);
+    expect(document.querySelector('.col-4')).toBeTruthy();
+    expect(document.querySelector('.col-jumbo-6')).toBeTruthy();
   });
 
   it('should allow custom columns to be defined with objects', () => {
-    const wrapper = shallow(
+    render(
       <Placeholder
         widths={['base', 'jumbo', 'custom']}
         custom={{ size: 1, order: 2, offset: 4 }}
       />,
     );
 
-    expect(wrapper.hasClass('col-custom-1')).toBe(true);
-    expect(wrapper.hasClass('order-custom-2')).toBe(true);
-    expect(wrapper.hasClass('offset-custom-4')).toBe(true);
-    expect(wrapper.hasClass('col')).toBe(false);
+    expect(document.querySelector('.col-custom-1')).toBeTruthy();
+    expect(document.querySelector('.order-custom-2')).toBeTruthy();
+    expect(document.querySelector('.offset-custom-4')).toBeTruthy();
+    expect(document.querySelector('.col')).toBeFalsy();
   });
 });

--- a/src/__tests__/Table.spec.js
+++ b/src/__tests__/Table.spec.js
@@ -1,68 +1,68 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { render, screen } from '@testing-library/react';
 import { Table } from '..';
 
 describe('Table', () => {
   it('should render with "table" class', () => {
-    const wrapper = shallow(<Table>Yo!</Table>);
+    render(<Table>Yo!</Table>);
 
-    expect(wrapper.text()).toBe('Yo!');
-    expect(wrapper.hasClass('table')).toBe(true);
+    screen.getByText('Yo!');
+    expect(document.querySelector('.table')).toBeTruthy();
   });
 
   it('should render additional classes', () => {
-    const wrapper = shallow(<Table className="other">Yo!</Table>);
+    render(<Table className="other">Yo!</Table>);
 
-    expect(wrapper.hasClass('other')).toBe(true);
-    expect(wrapper.hasClass('table')).toBe(true);
+    expect(document.querySelector('.other')).toBeTruthy();
+    expect(document.querySelector('.table')).toBeTruthy();
   });
 
   it('should render custom tag', () => {
-    const wrapper = shallow(<Table tag="div">Yo!</Table>);
-
-    expect(wrapper.text()).toBe('Yo!');
-    expect(wrapper.hasClass('table')).toBe(true);
-    expect(wrapper.find('div').length).toBe(1);
+    // RTL adds a div ot the body, so we should query from the container for this test
+    const { container } = render(<Table tag="div">Yo!</Table>);
+    screen.getByText('Yo!');
+    expect(document.querySelector('.table')).toBeTruthy();
+    expect(container.querySelectorAll('div').length).toBe(1);
   });
 
   it('should render modifier classes', () => {
-    const wrapper = shallow(
+    render(
       <Table size="sm" bordered striped dark hover>
         Yo!
       </Table>,
     );
 
-    expect(wrapper.text()).toBe('Yo!');
-    expect(wrapper.hasClass('table')).toBe(true);
-    expect(wrapper.hasClass('table-sm')).toBe(true);
-    expect(wrapper.hasClass('table-bordered')).toBe(true);
-    expect(wrapper.hasClass('table-striped')).toBe(true);
-    expect(wrapper.hasClass('table-hover')).toBe(true);
-    expect(wrapper.hasClass('table-dark')).toBe(true);
+    screen.getByText('Yo!');
+    expect(document.querySelector('.table')).toBeTruthy();
+    expect(document.querySelector('.table-sm')).toBeTruthy();
+    expect(document.querySelector('.table-bordered')).toBeTruthy();
+    expect(document.querySelector('.table-striped')).toBeTruthy();
+    expect(document.querySelector('.table-hover')).toBeTruthy();
+    expect(document.querySelector('.table-dark')).toBeTruthy();
   });
 
   it('should render a borderless table', () => {
-    const wrapper = shallow(<Table borderless>Yo!</Table>);
+    render(<Table borderless>Yo!</Table>);
 
-    expect(wrapper.text()).toBe('Yo!');
-    expect(wrapper.hasClass('table')).toBe(true);
-    expect(wrapper.hasClass('table-borderless')).toBe(true);
+    screen.getByText('Yo!');
+    expect(document.querySelector('.table')).toBeTruthy();
+    expect(document.querySelector('.table-borderless')).toBeTruthy();
   });
 
   it('should render responsive wrapper class', () => {
-    const wrapper = shallow(<Table responsive>Yo!</Table>);
+    render(<Table responsive>Yo!</Table>);
 
-    expect(wrapper.text()).toBe('Yo!');
-    expect(wrapper.hasClass('table-responsive')).toBe(true);
-    expect(wrapper.find('.table').length).toBe(1);
+    screen.getByText('Yo!');
+    expect(document.querySelector('.table-responsive')).toBeTruthy();
+    expect(document.querySelectorAll('.table').length).toBe(1);
   });
 
   it('should render responsive wrapper class for md', () => {
-    const wrapper = shallow(<Table responsive="md">Yo!</Table>);
+    render(<Table responsive="md">Yo!</Table>);
 
-    expect(wrapper.text()).toBe('Yo!');
-    expect(wrapper.hasClass('table-responsive-md')).toBe(true);
-    expect(wrapper.find('.table').length).toBe(1);
+    screen.getByText('Yo!');
+    expect(document.querySelector('.table-responsive-md')).toBeTruthy();
+    expect(document.querySelectorAll('.table').length).toBe(1);
   });
 
   it('should render responsive wrapper cssModule', () => {
@@ -70,14 +70,14 @@ describe('Table', () => {
       table: 'scopedTable',
       'table-responsive': 'scopedResponsive',
     };
-    const wrapper = shallow(
+    render(
       <Table responsive cssModule={cssModule}>
         Yo!
       </Table>,
     );
 
-    expect(wrapper.text()).toBe('Yo!');
-    expect(wrapper.hasClass('scopedResponsive')).toBe(true);
-    expect(wrapper.find('.scopedTable').length).toBe(1);
+    screen.getByText('Yo!');
+    expect(document.querySelector('.scopedResponsive')).toBeTruthy();
+    expect(document.querySelectorAll('.scopedTable').length).toBe(1);
   });
 });

--- a/src/__tests__/ToastBody.spec.js
+++ b/src/__tests__/ToastBody.spec.js
@@ -1,27 +1,27 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { render, screen } from '@testing-library/react';
 import { ToastBody } from '..';
 
 describe('ToastBody', () => {
   it('should render with "toast-body" class', () => {
-    const wrapper = shallow(<ToastBody>Yo!</ToastBody>);
+    render(<ToastBody>Yo!</ToastBody>);
 
-    expect(wrapper.text()).toBe('Yo!');
-    expect(wrapper.hasClass('toast-body')).toBe(true);
+    screen.getByText('Yo!');
+    expect(document.querySelector('.toast-body')).toBeTruthy();
   });
 
   it('should render additional classes', () => {
-    const wrapper = shallow(<ToastBody className="other">Yo!</ToastBody>);
+    render(<ToastBody className="other">Yo!</ToastBody>);
 
-    expect(wrapper.hasClass('other')).toBe(true);
-    expect(wrapper.hasClass('toast-body')).toBe(true);
+    expect(document.querySelector('.other')).toBeTruthy();
+    expect(document.querySelector('.toast-body')).toBeTruthy();
   });
 
   it('should render custom tag', () => {
-    const wrapper = shallow(<ToastBody tag="main">Yo!</ToastBody>);
+    render(<ToastBody tag="main">Yo!</ToastBody>);
 
-    expect(wrapper.text()).toBe('Yo!');
-    expect(wrapper.hasClass('toast-body')).toBe(true);
-    expect(wrapper.type()).toBe('main');
+    screen.getByText('Yo!');
+    expect(document.querySelector('.toast-body')).toBeTruthy();
+    expect(document.querySelector('main')).toBeTruthy();
   });
 });

--- a/src/__tests__/TooltipPopoverWrapper.spec.js
+++ b/src/__tests__/TooltipPopoverWrapper.spec.js
@@ -49,7 +49,7 @@ describe('Tooltip', () => {
       </TooltipPopoverWrapper>,
     );
 
-    expect(wrapper.prop('hideArrow')).toBe(false);
+    expect(wrapper.children().prop('hideArrow')).toBe(false);
   });
 
   it('should render with "hideArrow" true when "hideArrow" prop is truthy', () => {
@@ -62,7 +62,7 @@ describe('Tooltip', () => {
       >
         Tooltip Content
       </TooltipPopoverWrapper>,
-    );
+    ).children();
 
     expect(wrapper.prop('hideArrow')).toBe(true);
   });
@@ -195,7 +195,7 @@ describe('Tooltip', () => {
       </TooltipPopoverWrapper>,
       { attachTo: container },
     );
-    const instance = wrapper.instance();
+    const instance = wrapper.children().instance();
 
     expect(isOpen).toBe(false);
     instance.handleDocumentClick({ target: target });
@@ -215,7 +215,7 @@ describe('Tooltip', () => {
       </TooltipPopoverWrapper>,
       { attachTo: container },
     );
-    const instance = wrapper.instance();
+    const instance = wrapper.children().instance();
 
     expect(isOpen).toBe(false);
     instance.handleDocumentClick({ target: innerTarget });
@@ -231,7 +231,7 @@ describe('Tooltip', () => {
       </TooltipPopoverWrapper>,
       { attachTo: container },
     );
-    const instance = wrapper.instance();
+    const instance = wrapper.children().instance();
 
     expect(isOpen).toBe(false);
     instance.handleDocumentClick({ target: innerTarget });
@@ -249,7 +249,7 @@ describe('Tooltip', () => {
       </TooltipPopoverWrapper>,
       { attachTo: container },
     );
-    const instance = wrapper.instance();
+    const instance = wrapper.children().instance();
 
     expect(isOpen).toBe(false);
     instance.handleDocumentClick({ target: container });
@@ -270,7 +270,7 @@ describe('Tooltip', () => {
       </TooltipPopoverWrapper>,
       { attachTo: container },
     );
-    const instance = wrapper.instance();
+    const instance = wrapper.children().instance();
 
     instance.hideWithDelay();
     expect(isOpen).toBe(false);
@@ -420,7 +420,7 @@ describe('Tooltip', () => {
       </TooltipPopoverWrapper>,
       { attachTo: container },
     );
-    const instance = wrapper.instance();
+    const instance = wrapper.children().instance();
 
     instance.toggle(event);
 
@@ -439,7 +439,7 @@ describe('Tooltip', () => {
       </TooltipPopoverWrapper>,
       { attachTo: container },
     );
-    const instance = wrapper.instance();
+    const instance = wrapper.children().instance();
 
     instance.toggle(event);
 
@@ -458,7 +458,7 @@ describe('Tooltip', () => {
       { attachTo: container },
     );
 
-    const instance = wrapper.instance();
+    const instance = wrapper.children().instance();
     instance.toggle(event);
 
     wrapper.detach();
@@ -555,7 +555,7 @@ describe('Tooltip', () => {
         </TooltipPopoverWrapper>,
         { attachTo: container },
       );
-      const instance = wrapper.instance();
+      const instance = wrapper.children().instance();
 
       instance.hideWithDelay();
       expect(isOpen).toBe(true);
@@ -576,7 +576,7 @@ describe('Tooltip', () => {
         </TooltipPopoverWrapper>,
         { attachTo: container },
       );
-      const instance = wrapper.instance();
+      const instance = wrapper.children().instance();
 
       instance.hideWithDelay();
       expect(isOpen).toBe(true);
@@ -597,7 +597,7 @@ describe('Tooltip', () => {
         </TooltipPopoverWrapper>,
         { attachTo: container },
       );
-      const instance = wrapper.instance();
+      const instance = wrapper.children().instance();
 
       instance.hideWithDelay();
       expect(isOpen).toBe(true);
@@ -616,7 +616,7 @@ describe('Tooltip', () => {
         </TooltipPopoverWrapper>,
         { attachTo: container },
       );
-      const instance = wrapper.instance();
+      const instance = wrapper.children().instance();
 
       expect(spy).not.toHaveBeenCalled();
 
@@ -635,7 +635,7 @@ describe('Tooltip', () => {
         </TooltipPopoverWrapper>,
         { attachTo: container },
       );
-      const instance = wrapper.instance();
+      const instance = wrapper.children().instance();
 
       expect(spy).not.toHaveBeenCalled();
 
@@ -656,7 +656,7 @@ describe('Tooltip', () => {
         </TooltipPopoverWrapper>,
         { attachTo: container },
       );
-      const instance = wrapper.instance();
+      const instance = wrapper.children().instance();
 
       expect(spy).not.toHaveBeenCalled();
 
@@ -676,7 +676,7 @@ describe('Tooltip', () => {
         </TooltipPopoverWrapper>,
         { attachTo: container },
       );
-      const instance = wrapper.instance();
+      const instance = wrapper.children().instance();
 
       expect(spy).not.toHaveBeenCalled();
 
@@ -703,7 +703,7 @@ describe('Tooltip', () => {
         </TooltipPopoverWrapper>,
         { attachTo: container },
       );
-      const instance = wrapper.instance();
+      const instance = wrapper.children().instance();
 
       instance.hideWithDelay();
 
@@ -732,7 +732,7 @@ describe('Tooltip', () => {
         </TooltipPopoverWrapper>,
         { attachTo: container },
       );
-      const instance = wrapper.instance();
+      const instance = wrapper.children().instance();
 
       instance.showWithDelay();
       jest.advanceTimersByTime(0); // delay: 0 toggle is still async
@@ -759,7 +759,7 @@ describe('Tooltip', () => {
         </TooltipPopoverWrapper>,
         { attachTo: container },
       );
-      const instance = wrapper.instance();
+      const instance = wrapper.children().instance();
 
       instance.showWithDelay();
 
@@ -788,7 +788,7 @@ describe('Tooltip', () => {
         </TooltipPopoverWrapper>,
         { attachTo: container },
       );
-      const instance = wrapper.instance();
+      const instance = wrapper.children().instance();
 
       instance.hideWithDelay();
       jest.advanceTimersByTime(0); // delay: 0 toggle is still async
@@ -817,7 +817,7 @@ describe('Tooltip', () => {
         </TooltipPopoverWrapper>,
         { attachTo: container },
       );
-      const instance = wrapper.instance();
+      const instance = wrapper.children().instance();
 
       expect(isOpen).toBe(true);
       expect(spy).not.toHaveBeenCalled();
@@ -847,7 +847,7 @@ describe('Tooltip', () => {
         </TooltipPopoverWrapper>,
         { attachTo: container },
       );
-      const instance = wrapper.instance();
+      const instance = wrapper.children().instance();
 
       instance.showWithDelay();
       expect(instance._showTimeout).toBeTruthy();
@@ -873,7 +873,7 @@ describe('Tooltip', () => {
         </TooltipPopoverWrapper>,
         { attachTo: container },
       );
-      const instance = wrapper.instance();
+      const instance = wrapper.children().instance();
 
       expect(isOpen).toBe(true);
       expect(spy).not.toHaveBeenCalled();
@@ -902,7 +902,7 @@ describe('Tooltip', () => {
         </TooltipPopoverWrapper>,
         { attachTo: container },
       );
-      const instance = wrapper.instance();
+      const instance = wrapper.children().instance();
       expect(isOpen).toBe(true);
       expect(spy).not.toHaveBeenCalled();
       instance.hideWithDelay();

--- a/src/__tests__/Uncontrolled.spec.js
+++ b/src/__tests__/Uncontrolled.spec.js
@@ -219,6 +219,7 @@ describe('UncontrolledDropdown', () => {
 
       wrapper
         .find(Dropdown)
+        .children()
         .instance()
         .handleDocumentClick({ type: 'keyup', which: keyCodes.tab });
 
@@ -249,6 +250,7 @@ describe('UncontrolledDropdown', () => {
 
       wrapper
         .find(Dropdown)
+        .children()
         .instance()
         .handleDocumentClick('keydown', { which: keyCodes.down });
 

--- a/types/lib/Accordion.d.ts
+++ b/types/lib/Accordion.d.ts
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import { CSSModule } from './utils';
-
 export interface AccordionProps extends React.HTMLAttributes<HTMLElement> {
   tag?: React.ElementType;
   cssModule?: CSSModule;
   flush?: boolean;
+  ref?: React.Ref<HTMLElement>;
   innerRef?: React.Ref<HTMLElement>;
   open: string | string[];
 }

--- a/types/lib/AccordionBody.d.ts
+++ b/types/lib/AccordionBody.d.ts
@@ -4,6 +4,7 @@ import { CSSModule } from './utils';
 export interface AccordionBodyProps extends React.HTMLAttributes<HTMLElement> {
   tag?: React.ElementType;
   cssModule?: CSSModule;
+  ref?: React.Ref<HTMLElement>;
   innerRef?: React.Ref<HTMLElement>;
   accordionId: string;
 }

--- a/types/lib/AccordionHeader.d.ts
+++ b/types/lib/AccordionHeader.d.ts
@@ -4,6 +4,7 @@ import { CSSModule } from './utils';
 export interface AccordionHeaderProps extends React.HTMLAttributes<HTMLElement> {
   tag?: React.ElementType;
   cssModule?: CSSModule;
+  ref?: React.Ref<HTMLElement>;
   innerRef?: React.Ref<HTMLElement>;
   targetId: string;
 }

--- a/types/lib/AccordionItem.d.ts
+++ b/types/lib/AccordionItem.d.ts
@@ -4,6 +4,7 @@ import { CSSModule } from './utils';
 export interface AccordionItemProps extends React.HTMLAttributes<HTMLElement> {
   tag?: React.ElementType;
   cssModule?: CSSModule;
+  ref?: React.Ref<HTMLElement>;
   innerRef?: React.Ref<HTMLElement>;
 }
 

--- a/types/lib/Alert.d.ts
+++ b/types/lib/Alert.d.ts
@@ -12,6 +12,7 @@ export interface UncontrolledAlertProps
   fade?: boolean;
   tag?: React.ElementType;
   transition?: FadeProps;
+  ref?: React.Ref<HTMLElement>;
   innerRef?: React.Ref<HTMLElement>;
 }
 export interface AlertProps extends UncontrolledAlertProps {

--- a/types/lib/Badge.d.ts
+++ b/types/lib/Badge.d.ts
@@ -6,6 +6,7 @@ export interface BadgeProps extends React.HTMLAttributes<HTMLElement> {
   color?: string;
   pill?: boolean;
   tag?: React.ElementType;
+  ref?: React.Ref<HTMLElement>;
   innerRef?: React.Ref<HTMLElement>;
   cssModule?: CSSModule;
 }

--- a/types/lib/Button.d.ts
+++ b/types/lib/Button.d.ts
@@ -9,6 +9,7 @@ export interface ButtonProps
   block?: boolean;
   color?: string;
   tag?: React.ElementType;
+  ref?: React.Ref<HTMLElement>;
   innerRef?: React.Ref<HTMLButtonElement>;
   size?: string;
   cssModule?: CSSModule;

--- a/types/lib/Card.d.ts
+++ b/types/lib/Card.d.ts
@@ -9,6 +9,7 @@ export interface CardProps extends React.HTMLAttributes<HTMLElement> {
   body?: boolean;
   outline?: boolean;
   cssModule?: CSSModule;
+  ref?: React.Ref<HTMLElement>;
   innerRef?: React.Ref<HTMLElement>;
 }
 

--- a/types/lib/CardBody.d.ts
+++ b/types/lib/CardBody.d.ts
@@ -5,6 +5,7 @@ export interface CardBodyProps extends React.HTMLAttributes<HTMLElement> {
   [key: string]: any;
   tag?: React.ElementType;
   cssModule?: CSSModule;
+  ref?: React.Ref<HTMLElement>;
   innerRef?: React.Ref<HTMLElement>;
 }
 

--- a/types/lib/CardLink.d.ts
+++ b/types/lib/CardLink.d.ts
@@ -5,6 +5,7 @@ export interface CardLinkProps
   extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
   [key: string]: any;
   tag?: React.ElementType;
+  ref?: React.Ref<HTMLElement>;
   innerRef?: React.Ref<HTMLAnchorElement>;
   cssModule?: CSSModule;
 }

--- a/types/lib/Collapse.d.ts
+++ b/types/lib/Collapse.d.ts
@@ -19,6 +19,7 @@ export interface CollapseProps extends React.HTMLAttributes<HTMLElement> {
   onExit?: () => void;
   onExiting?: () => void;
   onExited?: () => void;
+  ref?: React.Ref<HTMLElement>;
   innerRef?: React.Ref<HTMLElement>;
 }
 

--- a/types/lib/Fade.d.ts
+++ b/types/lib/Fade.d.ts
@@ -16,6 +16,7 @@ export interface FadeProps extends React.HTMLAttributes<HTMLElement> {
   transitionLeave?: boolean;
   onLeave?: () => void;
   onEnter?: () => void;
+  ref?: React.Ref<HTMLElement>;
   innerRef?: React.Ref<HTMLElement>;
 }
 

--- a/types/lib/Form.d.ts
+++ b/types/lib/Form.d.ts
@@ -4,6 +4,7 @@ import { CSSModule } from './utils';
 export interface FormProps extends React.FormHTMLAttributes<HTMLFormElement> {
   [key: string]: any;
   tag?: React.ElementType;
+  ref?: React.Ref<HTMLElement>;
   innerRef?: React.Ref<HTMLFormElement>;
   cssModule?: CSSModule;
 }

--- a/types/lib/Input.d.ts
+++ b/types/lib/Input.d.ts
@@ -37,6 +37,7 @@ export interface InputProps
   valid?: boolean;
   invalid?: boolean;
   tag?: React.ElementType;
+  ref?: React.Ref<HTMLElement>;
   innerRef?: React.Ref<HTMLInputElement | HTMLTextAreaElement>;
   plaintext?: boolean;
   addon?: boolean;

--- a/types/lib/Modal.d.ts
+++ b/types/lib/Modal.d.ts
@@ -31,6 +31,7 @@ export interface ModalProps extends React.HTMLAttributes<HTMLElement> {
   unmountOnClose?: boolean;
   returnFocusAfterClose?: boolean;
   container?: string | HTMLElement | React.RefObject<HTMLElement>;
+  ref?: React.Ref<HTMLElement>;
   innerRef?: React.Ref<HTMLElement>;
   trapFocus?: boolean;
 }

--- a/types/lib/NavLink.d.ts
+++ b/types/lib/NavLink.d.ts
@@ -5,6 +5,7 @@ export interface NavLinkProps
   extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
   [key: string]: any;
   tag?: React.ElementType;
+  ref?: React.Ref<HTMLElement>;
   innerRef?: React.Ref<HTMLAnchorElement>;
   disabled?: boolean;
   active?: boolean;

--- a/types/lib/Offcanvas.d.ts
+++ b/types/lib/Offcanvas.d.ts
@@ -14,6 +14,7 @@ export interface OffcanvasProps extends React.HTMLAttributes<HTMLElement> {
   contentClassName?: string;
   cssModule?: CSSModule;
   fade?: boolean;
+  ref?: React.Ref<HTMLElement>;
   innerRef?: React.Ref<HTMLElement>;
   isOpen?: boolean;
   keyboard?: boolean;

--- a/types/lib/Placeholder.d.ts
+++ b/types/lib/Placeholder.d.ts
@@ -10,6 +10,7 @@ export interface PlaceholderProps extends React.HTMLAttributes<HTMLElement> {
   cssModule?: CSSModule;
   size?: string;
   widths?: string[];
+  ref?: React.Ref<HTMLElement>;
   innerRef?: React.Ref<HTMLElement>;
 }
 

--- a/types/lib/Table.d.ts
+++ b/types/lib/Table.d.ts
@@ -15,6 +15,7 @@ export interface TableProps
   responsive?: boolean | string;
   tag?: React.ElementType;
   responsiveTag?: React.ElementType;
+  ref?: React.Ref<HTMLElement>;
   innerRef?: React.Ref<HTMLTableElement>;
 }
 

--- a/types/lib/Toast.d.ts
+++ b/types/lib/Toast.d.ts
@@ -6,6 +6,7 @@ export interface ToastProps extends React.HTMLAttributes<HTMLElement> {
   [key: string]: any;
   tag?: React.ElementType;
   cssModule?: CSSModule;
+  ref?: React.Ref<HTMLElement>;
   innerRef?: React.Ref<HTMLElement>;
   isOpen?: boolean;
   fade?: boolean;

--- a/types/lib/ToastBody.d.ts
+++ b/types/lib/ToastBody.d.ts
@@ -5,6 +5,7 @@ export interface ToastBodyProps extends React.HTMLAttributes<HTMLElement> {
   [key: string]: any;
   tag?: React.ElementType;
   cssModule?: CSSModule;
+  ref?: React.Ref<HTMLElement>;
   innerRef?: React.Ref<HTMLElement>;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3380,6 +3380,14 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.1.2.tgz#7c6cf998d6d20b914c0a55a91ae928ff25965e72"
   integrity sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==
 
+"@jridgewell/source-map@^0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@jridgewell/source-map/-/source-map-0.3.2.tgz#f45351aaed4527a298512ec72f81040c998580fb"
+  integrity sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==
+  dependencies:
+    "@jridgewell/gen-mapping" "^0.3.0"
+    "@jridgewell/trace-mapping" "^0.3.9"
+
 "@jridgewell/sourcemap-codec@1.4.14":
   version "1.4.14"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24"
@@ -3390,7 +3398,7 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz#b6461fb0c2964356c469e115f504c95ad97ab88c"
   integrity sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==
 
-"@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.13":
+"@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.13", "@jridgewell/trace-mapping@^0.3.14":
   version "0.3.17"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz#793041277af9073b0951a7fe0f0d8c4c98c36985"
   integrity sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==
@@ -4462,6 +4470,22 @@
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
+"@types/eslint-scope@^3.7.3":
+  version "3.7.4"
+  resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.4.tgz#37fc1223f0786c39627068a12e94d6e6fc61de16"
+  integrity sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==
+  dependencies:
+    "@types/eslint" "*"
+    "@types/estree" "*"
+
+"@types/eslint@*":
+  version "8.4.10"
+  resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-8.4.10.tgz#19731b9685c19ed1552da7052b6f668ed7eb64bb"
+  integrity sha512-Sl/HOqN8NKPmhWo2VBEPm0nvHnu2LL3v9vKo8MEq0EtbJ4eVzGPl41VNPvn5E1i5poMk4/XD8UriLHpJvEP/Nw==
+  dependencies:
+    "@types/estree" "*"
+    "@types/json-schema" "*"
+
 "@types/estree@*":
   version "0.0.45"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.45.tgz#e9387572998e5ecdac221950dab3e8c3b16af884"
@@ -4471,6 +4495,11 @@
   version "0.0.39"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
   integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
+
+"@types/estree@^0.0.51":
+  version "0.0.51"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.51.tgz#cfd70924a25a3fd32b218e5e420e6897e1ac4f40"
+  integrity sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==
 
 "@types/glob-base@^0.3.0":
   version "0.3.0"
@@ -4553,6 +4582,11 @@
     "@types/parse5" "^6.0.3"
     "@types/tough-cookie" "*"
 
+"@types/json-schema@*", "@types/json-schema@^7.0.8", "@types/json-schema@^7.0.9":
+  version "7.0.11"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
+  integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
+
 "@types/json-schema@^7.0.4":
   version "7.0.5"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.5.tgz#dcce4430e64b443ba8945f0290fb564ad5bac6dd"
@@ -4567,11 +4601,6 @@
   version "7.0.7"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad"
   integrity sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==
-
-"@types/json-schema@^7.0.9":
-  version "7.0.11"
-  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
-  integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
 
 "@types/json5@^0.0.29":
   version "0.0.29"
@@ -4883,6 +4912,14 @@
     "@typescript-eslint/types" "5.30.6"
     eslint-visitor-keys "^3.3.0"
 
+"@webassemblyjs/ast@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.11.1.tgz#2bfd767eae1a6996f432ff7e8d7fc75679c0b6a7"
+  integrity sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==
+  dependencies:
+    "@webassemblyjs/helper-numbers" "1.11.1"
+    "@webassemblyjs/helper-wasm-bytecode" "1.11.1"
+
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.9.0.tgz#bd850604b4042459a5a41cd7d338cbed695ed964"
@@ -4892,15 +4929,30 @@
     "@webassemblyjs/helper-wasm-bytecode" "1.9.0"
     "@webassemblyjs/wast-parser" "1.9.0"
 
+"@webassemblyjs/floating-point-hex-parser@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz#f6c61a705f0fd7a6aecaa4e8198f23d9dc179e4f"
+  integrity sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==
+
 "@webassemblyjs/floating-point-hex-parser@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.9.0.tgz#3c3d3b271bddfc84deb00f71344438311d52ffb4"
   integrity sha512-TG5qcFsS8QB4g4MhrxK5TqfdNe7Ey/7YL/xN+36rRjl/BlGE/NcBvJcqsRgCP6Z92mRE+7N50pRIi8SmKUbcQA==
 
+"@webassemblyjs/helper-api-error@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz#1a63192d8788e5c012800ba6a7a46c705288fd16"
+  integrity sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==
+
 "@webassemblyjs/helper-api-error@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-api-error/-/helper-api-error-1.9.0.tgz#203f676e333b96c9da2eeab3ccef33c45928b6a2"
   integrity sha512-NcMLjoFMXpsASZFxJ5h2HZRcEhDkvnNFOAKneP5RbKRzaWJN36NC4jqQHKwStIhGXu5mUWlUUk7ygdtrO8lbmw==
+
+"@webassemblyjs/helper-buffer@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz#832a900eb444884cde9a7cad467f81500f5e5ab5"
+  integrity sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==
 
 "@webassemblyjs/helper-buffer@1.9.0":
   version "1.9.0"
@@ -4926,10 +4978,34 @@
   dependencies:
     "@webassemblyjs/ast" "1.9.0"
 
+"@webassemblyjs/helper-numbers@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz#64d81da219fbbba1e3bd1bfc74f6e8c4e10a62ae"
+  integrity sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==
+  dependencies:
+    "@webassemblyjs/floating-point-hex-parser" "1.11.1"
+    "@webassemblyjs/helper-api-error" "1.11.1"
+    "@xtuc/long" "4.2.2"
+
+"@webassemblyjs/helper-wasm-bytecode@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz#f328241e41e7b199d0b20c18e88429c4433295e1"
+  integrity sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==
+
 "@webassemblyjs/helper-wasm-bytecode@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.9.0.tgz#4fed8beac9b8c14f8c58b70d124d549dd1fe5790"
   integrity sha512-R7FStIzyNcd7xKxCZH5lE0Bqy+hGTwS3LJjuv1ZVxd9O7eHCedSdrId/hMOd20I+v8wDXEn+bjfKDLzTepoaUw==
+
+"@webassemblyjs/helper-wasm-section@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz#21ee065a7b635f319e738f0dd73bfbda281c097a"
+  integrity sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.1"
+    "@webassemblyjs/helper-buffer" "1.11.1"
+    "@webassemblyjs/helper-wasm-bytecode" "1.11.1"
+    "@webassemblyjs/wasm-gen" "1.11.1"
 
 "@webassemblyjs/helper-wasm-section@1.9.0":
   version "1.9.0"
@@ -4941,12 +5017,26 @@
     "@webassemblyjs/helper-wasm-bytecode" "1.9.0"
     "@webassemblyjs/wasm-gen" "1.9.0"
 
+"@webassemblyjs/ieee754@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz#963929e9bbd05709e7e12243a099180812992614"
+  integrity sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==
+  dependencies:
+    "@xtuc/ieee754" "^1.2.0"
+
 "@webassemblyjs/ieee754@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ieee754/-/ieee754-1.9.0.tgz#15c7a0fbaae83fb26143bbacf6d6df1702ad39e4"
   integrity sha512-dcX8JuYU/gvymzIHc9DgxTzUUTLexWwt8uCTWP3otys596io0L5aW02Gb1RjYpx2+0Jus1h4ZFqjla7umFniTg==
   dependencies:
     "@xtuc/ieee754" "^1.2.0"
+
+"@webassemblyjs/leb128@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/leb128/-/leb128-1.11.1.tgz#ce814b45574e93d76bae1fb2644ab9cdd9527aa5"
+  integrity sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==
+  dependencies:
+    "@xtuc/long" "4.2.2"
 
 "@webassemblyjs/leb128@1.9.0":
   version "1.9.0"
@@ -4955,10 +5045,29 @@
   dependencies:
     "@xtuc/long" "4.2.2"
 
+"@webassemblyjs/utf8@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/utf8/-/utf8-1.11.1.tgz#d1f8b764369e7c6e6bae350e854dec9a59f0a3ff"
+  integrity sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==
+
 "@webassemblyjs/utf8@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/utf8/-/utf8-1.9.0.tgz#04d33b636f78e6a6813227e82402f7637b6229ab"
   integrity sha512-GZbQlWtopBTP0u7cHrEx+73yZKrQoBMpwkGEIqlacljhXCkVM1kMQge/Mf+csMJAjEdSwhOyLAS0AoR3AG5P8w==
+
+"@webassemblyjs/wasm-edit@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz#ad206ebf4bf95a058ce9880a8c092c5dec8193d6"
+  integrity sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.1"
+    "@webassemblyjs/helper-buffer" "1.11.1"
+    "@webassemblyjs/helper-wasm-bytecode" "1.11.1"
+    "@webassemblyjs/helper-wasm-section" "1.11.1"
+    "@webassemblyjs/wasm-gen" "1.11.1"
+    "@webassemblyjs/wasm-opt" "1.11.1"
+    "@webassemblyjs/wasm-parser" "1.11.1"
+    "@webassemblyjs/wast-printer" "1.11.1"
 
 "@webassemblyjs/wasm-edit@1.9.0":
   version "1.9.0"
@@ -4974,6 +5083,17 @@
     "@webassemblyjs/wasm-parser" "1.9.0"
     "@webassemblyjs/wast-printer" "1.9.0"
 
+"@webassemblyjs/wasm-gen@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz#86c5ea304849759b7d88c47a32f4f039ae3c8f76"
+  integrity sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.1"
+    "@webassemblyjs/helper-wasm-bytecode" "1.11.1"
+    "@webassemblyjs/ieee754" "1.11.1"
+    "@webassemblyjs/leb128" "1.11.1"
+    "@webassemblyjs/utf8" "1.11.1"
+
 "@webassemblyjs/wasm-gen@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-gen/-/wasm-gen-1.9.0.tgz#50bc70ec68ded8e2763b01a1418bf43491a7a49c"
@@ -4985,6 +5105,16 @@
     "@webassemblyjs/leb128" "1.9.0"
     "@webassemblyjs/utf8" "1.9.0"
 
+"@webassemblyjs/wasm-opt@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz#657b4c2202f4cf3b345f8a4c6461c8c2418985f2"
+  integrity sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.1"
+    "@webassemblyjs/helper-buffer" "1.11.1"
+    "@webassemblyjs/wasm-gen" "1.11.1"
+    "@webassemblyjs/wasm-parser" "1.11.1"
+
 "@webassemblyjs/wasm-opt@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-opt/-/wasm-opt-1.9.0.tgz#2211181e5b31326443cc8112eb9f0b9028721a61"
@@ -4994,6 +5124,18 @@
     "@webassemblyjs/helper-buffer" "1.9.0"
     "@webassemblyjs/wasm-gen" "1.9.0"
     "@webassemblyjs/wasm-parser" "1.9.0"
+
+"@webassemblyjs/wasm-parser@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz#86ca734534f417e9bd3c67c7a1c75d8be41fb199"
+  integrity sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.1"
+    "@webassemblyjs/helper-api-error" "1.11.1"
+    "@webassemblyjs/helper-wasm-bytecode" "1.11.1"
+    "@webassemblyjs/ieee754" "1.11.1"
+    "@webassemblyjs/leb128" "1.11.1"
+    "@webassemblyjs/utf8" "1.11.1"
 
 "@webassemblyjs/wasm-parser@1.9.0":
   version "1.9.0"
@@ -5017,6 +5159,14 @@
     "@webassemblyjs/helper-api-error" "1.9.0"
     "@webassemblyjs/helper-code-frame" "1.9.0"
     "@webassemblyjs/helper-fsm" "1.9.0"
+    "@xtuc/long" "4.2.2"
+
+"@webassemblyjs/wast-printer@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz#d0c73beda8eec5426f10ae8ef55cee5e7084c2f0"
+  integrity sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.1"
     "@xtuc/long" "4.2.2"
 
 "@webassemblyjs/wast-printer@1.9.0":
@@ -5067,13 +5217,10 @@ acorn-globals@^6.0.0:
     acorn "^7.1.1"
     acorn-walk "^7.1.1"
 
-acorn-globals@^7.0.0:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-7.0.1.tgz#0dbf05c44fa7c94332914c02066d5beff62c40c3"
-  integrity sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==
-  dependencies:
-    acorn "^8.1.0"
-    acorn-walk "^8.0.2"
+acorn-import-assertions@^1.7.6:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz#ba2b5939ce62c238db6d93d81c9b111b29b855e9"
+  integrity sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==
 
 acorn-jsx@^5.3.1, acorn-jsx@^5.3.2:
   version "5.3.2"
@@ -5085,11 +5232,6 @@ acorn-walk@^7.1.1, acorn-walk@^7.2.0:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
   integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
 
-acorn-walk@^8.0.2:
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
-  integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
-
 acorn@^6.4.1:
   version "6.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.1.tgz#531e58ba3f51b9dacb9a6646ca4debf5b14ca474"
@@ -5100,7 +5242,7 @@ acorn@^7.1.1, acorn@^7.4.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
-acorn@^8.1.0, acorn@^8.5.0, acorn@^8.8.0:
+acorn@^8.5.0:
   version "8.8.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.1.tgz#0a3f9cbecc4ec3bea6f0a80b66ae8dd2da250b73"
   integrity sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==
@@ -6195,6 +6337,16 @@ browserslist@^4.0.0, browserslist@^4.12.0, browserslist@^4.16.6, browserslist@^4
     escalade "^3.1.1"
     node-releases "^1.1.75"
 
+browserslist@^4.14.5, browserslist@^4.21.3, browserslist@^4.21.4:
+  version "4.21.4"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.21.4.tgz#e7496bbc67b9e39dd0f98565feccdcb0d4ff6987"
+  integrity sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==
+  dependencies:
+    caniuse-lite "^1.0.30001400"
+    electron-to-chromium "^1.4.251"
+    node-releases "^2.0.6"
+    update-browserslist-db "^1.0.9"
+
 browserslist@^4.16.0, browserslist@^4.17.3, browserslist@^4.17.5:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.17.5.tgz#c827bbe172a4c22b123f5e337533ceebadfdd559"
@@ -6216,16 +6368,6 @@ browserslist@^4.20.2, browserslist@^4.20.3:
     escalade "^3.1.1"
     node-releases "^2.0.5"
     picocolors "^1.0.0"
-
-browserslist@^4.21.3, browserslist@^4.21.4:
-  version "4.21.4"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.21.4.tgz#e7496bbc67b9e39dd0f98565feccdcb0d4ff6987"
-  integrity sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==
-  dependencies:
-    caniuse-lite "^1.0.30001400"
-    electron-to-chromium "^1.4.251"
-    node-releases "^2.0.6"
-    update-browserslist-db "^1.0.9"
 
 bser@2.1.1:
   version "2.1.1"
@@ -6636,9 +6778,9 @@ ci-info@^2.0.0:
   integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
 
 ci-info@^3.2.0:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.6.1.tgz#7594f1c95cb7fdfddee7af95a13af7dbc67afdcf"
-  integrity sha512-up5ggbaDqOqJ4UqLKZ2naVkyqSJQgJi5lwD6b6mM748ysrghDBX0bx/qJTUHzw7zu6Mq4gycviSF5hJnwceD8w==
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.5.0.tgz#bfac2a29263de4c829d806b1ab478e35091e171f"
+  integrity sha512-yH4RezKOGlOhxkmhbeNuC4eYZKAUsEaGtBuBzDDP1eFUKiccDWzBABxBfOx31IDwDIXMTxWuwAxUGModvkbuVw==
 
 cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   version "1.0.4"
@@ -7586,7 +7728,7 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-data-urls@^3.0.1, data-urls@^3.0.2:
+data-urls@^3.0.1:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-3.0.2.tgz#9cf24a477ae22bcef5cd5f6f0bfbc1d2d3be9143"
   integrity sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==
@@ -7641,7 +7783,7 @@ decamelize@^1.1.0, decamelize@^1.2.0:
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
 
-decimal.js@^10.3.1, decimal.js@^10.4.1:
+decimal.js@^10.3.1:
   version "10.4.2"
   resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.4.2.tgz#0341651d1d997d86065a2ce3a441fbd0d8e8b98e"
   integrity sha512-ic1yEvwT6GuvaYwBLLY6/aFFgjZdySKTE8en/fkU3QICTmRtgtSlFn0u0BXN06InZwtfCelR7j8LRiDI/02iGA==
@@ -8164,6 +8306,14 @@ enhanced-resolve@^4.5.0:
     memory-fs "^0.5.0"
     tapable "^1.0.0"
 
+enhanced-resolve@^5.10.0:
+  version "5.10.0"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.10.0.tgz#0dc579c3bb2a1032e357ac45b8f3a6f3ad4fb1e6"
+  integrity sha512-T0yTFjdpldGY8PmuXXR0PyQ1ufZpEGiHVrp7zHKB7jdR4qlmZHhONVM5AQOAWXuF/w3dnHbEQVrNptJgt7F+cQ==
+  dependencies:
+    graceful-fs "^4.2.4"
+    tapable "^2.2.0"
+
 entities@^1.1.1, entities@~1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.2.tgz#bdfa735299664dfafd34529ed4f8522a275fea56"
@@ -8173,11 +8323,6 @@ entities@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/entities/-/entities-2.0.3.tgz#5c487e5742ab93c15abb5da22759b8590ec03b7f"
   integrity sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==
-
-entities@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/entities/-/entities-4.4.0.tgz#97bdaba170339446495e653cfd2db78962900174"
-  integrity sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==
 
 enzyme-adapter-react-16@^1.15.6:
   version "1.15.6"
@@ -8406,6 +8551,11 @@ es-get-iterator@^1.0.2:
     is-string "^1.0.5"
     isarray "^2.0.5"
 
+es-module-lexer@^0.9.0:
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-0.9.3.tgz#6f13db00cc38417137daf74366f535c8eb438f19"
+  integrity sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==
+
 es-shim-unscopables@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/es-shim-unscopables/-/es-shim-unscopables-1.0.0.tgz#702e632193201e3edf8713635d083d378e510241"
@@ -8591,20 +8741,20 @@ eslint-scope@3.7.1:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
+eslint-scope@5.1.1, eslint-scope@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
+  integrity sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
+  dependencies:
+    esrecurse "^4.3.0"
+    estraverse "^4.1.1"
+
 eslint-scope@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.3.tgz#ca03833310f6889a3264781aa82e63eb9cfe7848"
   integrity sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==
   dependencies:
     esrecurse "^4.1.0"
-    estraverse "^4.1.1"
-
-eslint-scope@^5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
-  integrity sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
-  dependencies:
-    esrecurse "^4.3.0"
     estraverse "^4.1.1"
 
 eslint-scope@^7.1.1:
@@ -8771,6 +8921,11 @@ events@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.1.0.tgz#84279af1b34cb75aa88bf5ff291f6d0bd9b31a59"
   integrity sha512-Rv+u8MLHNOdMjTAFeT3nCjHn2aGlx435FP/sDHNaRhDEMwyI/aB22Kj2qIN8R0cw3z28psEQLYwxVKLsKrMgWg==
+
+events@^3.2.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
+  integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
 
 evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
   version "1.0.3"
@@ -9633,6 +9788,11 @@ glob-to-regexp@^0.3.0:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
   integrity sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=
 
+glob-to-regexp@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
+  integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
+
 glob@^7.1.1, glob@^7.1.3, glob@^7.1.4:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
@@ -10210,7 +10370,7 @@ https-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
 
-https-proxy-agent@^5.0.0, https-proxy-agent@^5.0.1:
+https-proxy-agent@^5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz#c59ef224a04fe8b754f3db0063a25ea30d0005d6"
   integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
@@ -11430,6 +11590,15 @@ jest-worker@^26.2.1, jest-worker@^26.5.0, jest-worker@^26.6.2:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
+jest-worker@^27.4.5:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-27.5.1.tgz#8d146f0900e8973b106b6f73cc1e9a8cb86f8db0"
+  integrity sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==
+  dependencies:
+    "@types/node" "*"
+    merge-stream "^2.0.0"
+    supports-color "^8.0.0"
+
 jest-worker@^28.1.3:
   version "28.1.3"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-28.1.3.tgz#7e3c4ce3fa23d1bb6accb169e7f396f98ed4bb98"
@@ -11517,38 +11686,6 @@ jsdom@^19.0.0:
     ws "^8.2.3"
     xml-name-validator "^4.0.0"
 
-jsdom@^20.0.2:
-  version "20.0.2"
-  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-20.0.2.tgz#65ccbed81d5e877c433f353c58bb91ff374127db"
-  integrity sha512-AHWa+QO/cgRg4N+DsmHg1Y7xnz+8KU3EflM0LVDTdmrYOc1WWTSkOjtpUveQH+1Bqd5rtcVnb/DuxV/UjDO4rA==
-  dependencies:
-    abab "^2.0.6"
-    acorn "^8.8.0"
-    acorn-globals "^7.0.0"
-    cssom "^0.5.0"
-    cssstyle "^2.3.0"
-    data-urls "^3.0.2"
-    decimal.js "^10.4.1"
-    domexception "^4.0.0"
-    escodegen "^2.0.0"
-    form-data "^4.0.0"
-    html-encoding-sniffer "^3.0.0"
-    http-proxy-agent "^5.0.0"
-    https-proxy-agent "^5.0.1"
-    is-potential-custom-element-name "^1.0.1"
-    nwsapi "^2.2.2"
-    parse5 "^7.1.1"
-    saxes "^6.0.0"
-    symbol-tree "^3.2.4"
-    tough-cookie "^4.1.2"
-    w3c-xmlserializer "^3.0.0"
-    webidl-conversions "^7.0.0"
-    whatwg-encoding "^2.0.0"
-    whatwg-mimetype "^3.0.0"
-    whatwg-url "^11.0.0"
-    ws "^8.9.0"
-    xml-name-validator "^4.0.0"
-
 jsesc@^2.5.1:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
@@ -11569,7 +11706,7 @@ json-parse-better-errors@^1.0.1, json-parse-better-errors@^1.0.2:
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
   integrity sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
 
-json-parse-even-better-errors@^2.3.0:
+json-parse-even-better-errors@^2.3.0, json-parse-even-better-errors@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz#7c47805a94319928e05777405dc12e1f7a4ee02d"
   integrity sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==
@@ -11805,6 +11942,11 @@ loader-runner@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
   integrity sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==
+
+loader-runner@^4.2.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-4.3.0.tgz#c1b4a163b99f614830353b16755e7149ac2314e1"
+  integrity sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==
 
 loader-utils@2.0.0, loader-utils@^2.0.0:
   version "2.0.0"
@@ -12596,7 +12738,7 @@ negotiator@0.6.2:
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
   integrity sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==
 
-neo-async@^2.5.0, neo-async@^2.6.0, neo-async@^2.6.1:
+neo-async@^2.5.0, neo-async@^2.6.0, neo-async@^2.6.1, neo-async@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
@@ -12824,7 +12966,7 @@ number-is-nan@^1.0.0:
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
   integrity sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=
 
-nwsapi@^2.2.0, nwsapi@^2.2.2:
+nwsapi@^2.2.0:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.2.tgz#e5418863e7905df67d51ec95938d67bf801f0bb0"
   integrity sha512-90yv+6538zuvUMnN+zCr8LuV6bPFdq50304114vJYJ8RDyK8D5O9Phpbd6SZWgI7PwzmmfN1upeOJlvybDSgCw==
@@ -13305,13 +13447,6 @@ parse5@^3.0.1:
   integrity sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==
   dependencies:
     "@types/node" "*"
-
-parse5@^7.1.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/parse5/-/parse5-7.1.1.tgz#4649f940ccfb95d8754f37f73078ea20afe0c746"
-  integrity sha512-kwpuwzB+px5WUg9pyK0IcK/shltJN5/OVhQagxhCQNtT9Y9QRZqNY2e1cmbu/paRh5LMnz/oVTVLBpjFmMZhSg==
-  dependencies:
-    entities "^4.4.0"
 
 parseurl@~1.3.2, parseurl@~1.3.3:
   version "1.3.3"
@@ -14018,7 +14153,7 @@ prop-types-exact@^1.2.0:
     object.assign "^4.1.0"
     reflect.ownkeys "^0.2.0"
 
-prop-types@^15.0.0, prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.0.0, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -14334,11 +14469,6 @@ react-error-overlay@^6.0.9:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.9.tgz#3c743010c9359608c375ecd6bc76f35d93995b0a"
   integrity sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==
 
-react-fast-compare@^2.0.2:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
-  integrity sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==
-
 react-fast-compare@^3.0.1, react-fast-compare@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
@@ -14354,16 +14484,6 @@ react-helmet-async@^1.0.7:
     prop-types "^15.7.2"
     react-fast-compare "^3.2.0"
     shallowequal "^1.1.0"
-
-react-helmet@^5.0.3:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/react-helmet/-/react-helmet-5.2.1.tgz#16a7192fdd09951f8e0fe22ffccbf9bb3e591ffa"
-  integrity sha512-CnwD822LU8NDBnjCpZ4ySh8L6HYyngViTZLfBBb3NjtrpN8m49clH8hidHouq20I51Y6TpCTISCBbqiY5GamwA==
-  dependencies:
-    object-assign "^4.1.1"
-    prop-types "^15.5.4"
-    react-fast-compare "^2.0.2"
-    react-side-effect "^1.1.0"
 
 react-inspector@^5.1.0:
   version "5.1.1"
@@ -14411,11 +14531,6 @@ react-popper@^2.2.4:
     react-fast-compare "^3.0.1"
     warning "^4.0.2"
 
-react-prism@^4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/react-prism/-/react-prism-4.3.2.tgz#5c07609539b3ba6f45eb33e7d6a3588df3270c21"
-  integrity sha512-Z8BzDfWxzhngDtnZFjYj4RgHo7uqiWB4cOCpp//GFEpWbtINbCqHLIpL+q/f8ah5Aokw/uXkBkoLgvYIGgtm4A==
-
 react-refresh@^0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.8.3.tgz#721d4657672d400c5e3c75d063c4a85fb2d5d68f"
@@ -14434,13 +14549,6 @@ react-router@^3.2.1:
     prop-types "^15.7.2"
     react-is "^16.13.0"
     warning "^3.0.0"
-
-react-side-effect@^1.1.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/react-side-effect/-/react-side-effect-1.2.0.tgz#0e940c78faba0c73b9b0eba9cd3dda8dfb7e7dae"
-  integrity sha512-v1ht1aHg5k/thv56DRcjw+WtojuuDHFUgGfc+bFHOWsF4ZK6C2V57DO0Or0GPsg6+LSTE0M6Ry/gfzhzSwbc5w==
-  dependencies:
-    shallowequal "^1.0.1"
 
 react-sizeme@^3.0.1:
   version "3.0.2"
@@ -15166,13 +15274,6 @@ saxes@^5.0.1:
   dependencies:
     xmlchars "^2.2.0"
 
-saxes@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/saxes/-/saxes-6.0.0.tgz#fe5b4a4768df4f14a201b1ba6a65c1f3d9988cc5"
-  integrity sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==
-  dependencies:
-    xmlchars "^2.2.0"
-
 scheduler@^0.19.1:
   version "0.19.1"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.19.1.tgz#4f3e2ed2c1a7d65681f4c854fa8c5a1ccb40f196"
@@ -15214,6 +15315,15 @@ schema-utils@^3.0.0:
   integrity sha512-6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==
   dependencies:
     "@types/json-schema" "^7.0.6"
+    ajv "^6.12.5"
+    ajv-keywords "^3.5.2"
+
+schema-utils@^3.1.0, schema-utils@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-3.1.1.tgz#bc74c4b6b6995c1d88f76a8b77bea7219e0c8281"
+  integrity sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==
+  dependencies:
+    "@types/json-schema" "^7.0.8"
     ajv "^6.12.5"
     ajv-keywords "^3.5.2"
 
@@ -15293,6 +15403,13 @@ serialize-javascript@^5.0.1:
   dependencies:
     randombytes "^2.1.0"
 
+serialize-javascript@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.0.tgz#efae5d88f45d7924141da8b5c3a7a7e663fefeb8"
+  integrity sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==
+  dependencies:
+    randombytes "^2.1.0"
+
 serve-favicon@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/serve-favicon/-/serve-favicon-2.5.0.tgz#935d240cdfe0f5805307fdfe967d88942a2cbcf0"
@@ -15354,7 +15471,7 @@ shallow-clone@^3.0.0:
   dependencies:
     kind-of "^6.0.2"
 
-shallowequal@^1.0.1, shallowequal@^1.1.0:
+shallowequal@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
   integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==
@@ -16088,6 +16205,11 @@ tapable@^1.0.0, tapable@^1.1.3:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
   integrity sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
 
+tapable@^2.1.1, tapable@^2.2.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0"
+  integrity sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==
+
 tar-stream@1.6.2:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-1.6.2.tgz#8ea55dab37972253d9a9af90fdcd559ae435c555"
@@ -16192,6 +16314,17 @@ terser-webpack-plugin@^4.2.3:
     terser "^5.3.4"
     webpack-sources "^1.4.3"
 
+terser-webpack-plugin@^5.1.3:
+  version "5.3.6"
+  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.3.6.tgz#5590aec31aa3c6f771ce1b1acca60639eab3195c"
+  integrity sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==
+  dependencies:
+    "@jridgewell/trace-mapping" "^0.3.14"
+    jest-worker "^27.4.5"
+    schema-utils "^3.1.1"
+    serialize-javascript "^6.0.0"
+    terser "^5.14.1"
+
 terser@^4.1.2, terser@^4.6.3:
   version "4.8.0"
   resolved "https://registry.yarnpkg.com/terser/-/terser-4.8.0.tgz#63056343d7c70bb29f3af665865a46fe03a0df17"
@@ -16208,6 +16341,16 @@ terser@^5.0.0, terser@^5.3.4, terser@^5.7.0:
   dependencies:
     commander "^2.20.0"
     source-map "~0.7.2"
+    source-map-support "~0.5.20"
+
+terser@^5.14.1:
+  version "5.15.1"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.15.1.tgz#8561af6e0fd6d839669c73b92bdd5777d870ed6c"
+  integrity sha512-K1faMUvpm/FBxjBXud0LWVAGxmvoPbZbfTCYbSgaaYQaIXI3/TdI7a7ZGA73Zrou6Q8Zmz3oeUTsp/dj+ag2Xw==
+  dependencies:
+    "@jridgewell/source-map" "^0.3.2"
+    acorn "^8.5.0"
+    commander "^2.20.0"
     source-map-support "~0.5.20"
 
 test-exclude@^6.0.0:
@@ -16343,7 +16486,7 @@ toidentifier@1.0.0:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
   integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
 
-tough-cookie@^4.0.0, tough-cookie@^4.1.2:
+tough-cookie@^4.0.0:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.1.2.tgz#e53e84b85f24e0b65dd526f46628db6c85f6b874"
   integrity sha512-G9fqXWoYFZgTc2z8Q5zaHy/vJMjm+WV0AkAeHxVCQiEB1b+dGvWzFW6QV07cY5jQ5gRkeid2qIkzkxUnmoQZUQ==
@@ -17064,6 +17207,14 @@ watchpack@^1.7.4:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"
 
+watchpack@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-2.4.0.tgz#fa33032374962c78113f93c7f2fb4c54c9862a5d"
+  integrity sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==
+  dependencies:
+    glob-to-regexp "^0.4.1"
+    graceful-fs "^4.1.2"
+
 web-namespaces@^1.0.0:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/web-namespaces/-/web-namespaces-1.1.4.tgz#bc98a3de60dadd7faefc403d1076d529f5e030ec"
@@ -17121,6 +17272,11 @@ webpack-sources@^1.4.0, webpack-sources@^1.4.1, webpack-sources@^1.4.3:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
+webpack-sources@^3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.3.tgz#2d4daab8451fd4b240cc27055ff6a0c2ccea0cde"
+  integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==
+
 webpack-virtual-modules@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/webpack-virtual-modules/-/webpack-virtual-modules-0.2.2.tgz#20863dc3cb6bb2104729fff951fbe14b18bd0299"
@@ -17128,7 +17284,7 @@ webpack-virtual-modules@^0.2.2:
   dependencies:
     debug "^3.0.0"
 
-webpack@4, webpack@^4.43.0:
+webpack@4:
   version "4.46.0"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.46.0.tgz#bf9b4404ea20a073605e0a011d188d77cb6ad542"
   integrity sha512-6jJuJjg8znb/xRItk7bkT0+Q7AHCYjjFnvKIWQPkNIOyRqoCGvkOs0ipeQzrqz4l5FtN5ZI/ukEHroeX/o1/5Q==
@@ -17156,6 +17312,36 @@ webpack@4, webpack@^4.43.0:
     terser-webpack-plugin "^1.4.3"
     watchpack "^1.7.4"
     webpack-sources "^1.4.1"
+
+webpack@^5.75.0:
+  version "5.75.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.75.0.tgz#1e440468647b2505860e94c9ff3e44d5b582c152"
+  integrity sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==
+  dependencies:
+    "@types/eslint-scope" "^3.7.3"
+    "@types/estree" "^0.0.51"
+    "@webassemblyjs/ast" "1.11.1"
+    "@webassemblyjs/wasm-edit" "1.11.1"
+    "@webassemblyjs/wasm-parser" "1.11.1"
+    acorn "^8.7.1"
+    acorn-import-assertions "^1.7.6"
+    browserslist "^4.14.5"
+    chrome-trace-event "^1.0.2"
+    enhanced-resolve "^5.10.0"
+    es-module-lexer "^0.9.0"
+    eslint-scope "5.1.1"
+    events "^3.2.0"
+    glob-to-regexp "^0.4.1"
+    graceful-fs "^4.2.9"
+    json-parse-even-better-errors "^2.3.1"
+    loader-runner "^4.2.0"
+    mime-types "^2.1.27"
+    neo-async "^2.6.2"
+    schema-utils "^3.1.0"
+    tapable "^2.1.1"
+    terser-webpack-plugin "^5.1.3"
+    watchpack "^2.4.0"
+    webpack-sources "^3.2.3"
 
 whatwg-encoding@^2.0.0:
   version "2.0.0"
@@ -17307,7 +17493,7 @@ write-file-atomic@^4.0.1:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.7"
 
-ws@^8.2.3, ws@^8.9.0:
+ws@^8.2.3:
   version "8.11.0"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.11.0.tgz#6a0d36b8edfd9f96d8b25683db2f8d7de6e8e143"
   integrity sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==


### PR DESCRIPTION
This will make us follow React best practices and depend on libraries that are expecting ref to exist

<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->

- [ ] Bug fix <!-- (change which fixes an issue) -->
- [x] New feature <!-- (change which adds functionality) -->
- [ ] Chore <!-- (change which doesn't affect the usage of the package (such as documentation, build process, or project setup changes)) -->
- [x] Breaking change <!-- (fix or feature that would cause existing functionality to change) -->
- [ ] There is an open issue which this change addresses
- [ ] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [x] My commits follow the [Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] My change requires a change to [Typescript typings](./types/lib).
  - [ ] I have updated the typings accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Supporting `forwardRef` to allow usage of reactstrap with other libraries like `react-hook-form`. I left `innerRef` so current usage can be backwards compatible, but this will still be a breaking change as that's [common practice with React](https://reactjs.org/docs/forwarding-refs.html#note-for-component-library-maintainers). This will also break any usage where someone might use the implementation of a component.