### PR TITLE
fix: add missing prop in Accordion types

### DIFF
--- a/types/lib/Accordion.d.ts
+++ b/types/lib/Accordion.d.ts
@@ -7,6 +7,7 @@ export interface AccordionProps extends React.HTMLAttributes<HTMLElement> {
   flush?: boolean;
   innerRef?: React.Ref<HTMLElement>;
   open: string | string[];
+  toggle: (id: string) => void;
 }
 
 export interface UncontrolledAccordionProps extends Omit<AccordionProps, 'open'> {


### PR DESCRIPTION
Added the `toggle` function type to Accordion.d.ts. This prop already exists in the `propTypes` definition in Accordion.js
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->

- [ ] Bug fix <!-- (change which fixes an issue) -->
- [ ] New feature <!-- (change which adds functionality) -->
- [x] Chore <!-- (change which doesn't affect the usage of the package (such as documentation, build process, or project setup changes)) -->
- [ ] Breaking change <!-- (fix or feature that would cause existing functionality to change) -->
- [ ] There is an open issue which this change addresses
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [x] My commits follow the [Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] My change requires a change to [Typescript typings](./types/lib).
  - [x] I have updated the typings accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!-- Put any other information you believe would be useful to know when reviewing this PR below -->


<!---
If there is an issue this PR addresses, please make sure it is in the commit message per the Git Commit Guidelines above
**AND** put the issue number below, indicating that it closes or fixes the issue.
-->
