### PR TITLE
Issue 1070 Fix popper positioning when using persist in dropdown menus

### DIFF
--- a/src/DropdownMenu.js
+++ b/src/DropdownMenu.js
@@ -89,6 +89,12 @@ class DropdownMenu extends React.Component {
         },
       ];
 
+      const persistStyles = {};
+      if (persist) {
+        persistStyles.display = 'block';
+        persistStyles.visibility = this.context.isOpen ? 'visible' : 'hidden';
+      }
+
       const popper = (
         <Popper
           placement={poperPlacement}
@@ -96,7 +102,7 @@ class DropdownMenu extends React.Component {
           strategy={strategy}
         >
           {({ ref, style, placement, update }) => {
-            let combinedStyle = { ...this.props.style, ...style };
+            let combinedStyle = { ...this.props.style, ...persistStyles, ...style };
 
             const handleRef = (tagRef) => {
               // Send the ref to `react-popper`


### PR DESCRIPTION
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->

- [x] Bug fix <!-- (change which fixes an issue) -->
- [ ] New feature <!-- (change which adds functionality) -->
- [ ] Chore <!-- (change which doesn't affect the usage of the package (such as documentation, build process, or project setup changes)) -->
- [ ] Breaking change <!-- (fix or feature that would cause existing functionality to change) -->
- [x] There is an open issue which this change addresses
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [x] My commits follow the [Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] My change requires a change to [Typescript typings](./types/lib).
  - [ ] I have updated the typings accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- Put any other information you believe would be useful to know when reviewing this PR below -->

As described in my comment in the issue, this simply overrides bootstrap's `display: none` style on persisted dropdowns. Popper.js does not play well with display none due to it not being able to determine positioning details for an unmounted DOM element. Simply changing the style to use `visibility` instead fixes this. The trade off is that the HTML is mounted, it just is not visible which is effectively what persist does for the dropdown menu in react.

<!---
If there is an issue this PR addresses, please make sure it is in the commit message per the Git Commit Guidelines above
**AND** put the issue number below, indicating that it closes or fixes the issue.
-->

fixes #1070 