### PR TITLE
fix(#2744): Toast fade fix with display block

### DIFF
--- a/src/Toast.js
+++ b/src/Toast.js
@@ -35,7 +35,10 @@ function Toast(props) {
     ...attributes
   } = props;
 
-  const classes = mapToCssModules(classNames(className, 'toast'), cssModule);
+  const classes = mapToCssModules(
+    classNames(className, 'toast d-block'),
+    cssModule,
+  );
 
   const toastTransition = {
     ...Fade.defaultProps,


### PR DESCRIPTION
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->

- [x] Bug fix <!-- (change which fixes an issue) -->
- [ ] New feature <!-- (change which adds functionality) -->
- [ ] Chore <!-- (change which doesn't affect the usage of the package (such as documentation, build process, or project setup changes)) -->
- [ ] Breaking change <!-- (fix or feature that would cause existing functionality to change) -->
- [x] There is an open issue which this change addresses
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [x] My commits follow the [Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] My change requires a change to [Typescript typings](./types/lib).
  - [ ] I have updated the typings accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- Put any other information you believe would be useful to know when reviewing this PR below -->

Boostrap has a [.toast style](https://github.com/twbs/bootstrap/blob/main/scss/_toasts.scss#L35) that breaks Reactstrap's Toast fade transition.  
This PR overrides the Toast's display: none with the `d-block` utility class to fix the fade transition.

<!---
If there is an issue this PR addresses, please make sure it is in the commit message per the Git Commit Guidelines above
**AND** put the issue number below, indicating that it closes or fixes the issue.
-->

Fix for #2744 
