### PR TITLE
fix: update Fade.d.ts to change onLeave prop to the correct onExit

### DIFF
--- a/types/lib/Fade.d.ts
+++ b/types/lib/Fade.d.ts
@@ -14,7 +14,7 @@ export interface FadeProps extends React.HTMLAttributes<HTMLElement> {
   transitionAppear?: boolean;
   transitionEnter?: boolean;
   transitionLeave?: boolean;
-  onLeave?: () => void;
+  onExit?: () => void;
   onEnter?: () => void;
   innerRef?: React.Ref<HTMLElement>;
 }


### PR DESCRIPTION

- [X] Bug fix <!-- (change which fixes an issue) -->
- [ ] New feature <!-- (change which adds functionality) -->
- [ ] Chore <!-- (change which doesn't affect the usage of the package (such as documentation, build process, or project setup changes)) -->
- [ ] Breaking change <!-- (fix or feature that would cause existing functionality to change) -->
- [ ] There is an open issue which this change addresses
- [X] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [X] My commits follow the [Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [X] My change requires a change to [Typescript typings](./types/lib).
  - [X] I have updated the typings accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

## Motivation

When testing, we realized that our `onLeave` callback wasn't being called at all for the `Fade` component.

Looking at the types in react-transition-group, it looks like the actual correct prop is `onExit`.

## Fix

Update typings to `onExit`