### PR TITLE
Modal.js should consider shadowRoot

### DIFF
--- a/src/Modal.js
+++ b/src/Modal.js
@@ -306,12 +306,26 @@ class Modal extends React.Component {
     return this._element.querySelectorAll(focusableElements.join(', '));
   }
 
+  getActiveElement(elem) {
+    const activeEl = elem.activeElement;
+
+    if (!activeEl) {
+      return null;
+    }
+
+    if (activeEl.shadowRoot) {
+      return this.getActiveElement(activeEl.shadowRoot);
+    } else {
+      return activeEl;
+    }
+  }
+
   getFocusedChild() {
     let currentFocus;
     const focusableChildren = this.getFocusableChildren();
 
     try {
-      currentFocus = document.activeElement;
+      currentFocus = this.getActiveElement(document);
     } catch (err) {
       currentFocus = focusableChildren[0];
     }


### PR DESCRIPTION
consider the possibility that document.activeElement could be a shadowRoot. In this case recursively look inside shadowRoots until the actual focused child is found.

<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->

- [ x] Bug fix <!-- (change which fixes an issue) -->
- [ ] New feature <!-- (change which adds functionality) -->
- [ ] Chore <!-- (change which doesn't affect the usage of the package (such as documentation, build process, or project setup changes)) -->
- [ ] Breaking change <!-- (fix or feature that would cause existing functionality to change) -->
- [ x] There is an open issue which this change addresses
- [x ] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [ x] My commits follow the [Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] My change requires a change to [Typescript typings](./types/lib).
  - [ ] I have updated the typings accordingly.
- [ ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.

<!-- Put any other information you believe would be useful to know when reviewing this PR below -->

<!---
If there is an issue this PR addresses, please make sure it is in the commit message per the Git Commit Guidelines above
**AND** put the issue number below, indicating that it closes or fixes the issue.
-->

Fixes #2777
