### PR TITLE
refactor(#2801): Remove defaultProps api for function components 

### DIFF
--- a/src/Alert.js
+++ b/src/Alert.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { mapToCssModules, tagPropType } from './utils';
-import Fade from './Fade';
+import Fade, {fadeDefaultProps} from './Fade';
 
 const propTypes = {
   /** Pass children so this component can wrap the child elements */
@@ -46,7 +46,7 @@ function Alert(props) {
     toggle,
     children,
     transition = {
-      ...Fade.defaultProps,
+      ...fadeDefaultProps,
       unmountOnExit: true,
     },
     fade = true,
@@ -67,7 +67,7 @@ function Alert(props) {
   );
 
   const alertTransition = {
-    ...Fade.defaultProps,
+    ...fadeDefaultProps,
     ...transition,
     baseClass: fade ? transition.baseClass : '',
     timeout: fade ? transition.timeout : 0,

--- a/src/Fade.js
+++ b/src/Fade.js
@@ -3,12 +3,13 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { Transition } from 'react-transition-group';
 import {
+  addDefaultProps,
   mapToCssModules,
   omit,
   pick,
+  tagPropType,
   TransitionPropTypeKeys,
   TransitionTimeouts,
-  tagPropType,
 } from './utils';
 
 const propTypes = {
@@ -50,12 +51,13 @@ function Fade(props) {
     children,
     innerRef = ref,
     ...otherProps
-  } = props;
+  } = addDefaultProps(defaultProps, props);
 
   const transitionProps = pick(
     { defaultProps, ...otherProps },
     TransitionPropTypeKeys,
   );
+
   const childProps = omit(otherProps, TransitionPropTypeKeys);
 
   return (
@@ -77,6 +79,5 @@ function Fade(props) {
 }
 
 Fade.propTypes = propTypes;
-Fade.defaultProps = defaultProps;
 
 export default Fade;

--- a/src/Fade.js
+++ b/src/Fade.js
@@ -30,7 +30,7 @@ const propTypes = {
   ]),
 };
 
-const defaultProps = {
+export const fadeDefaultProps = {
   ...Transition.defaultProps,
   timeout: TransitionTimeouts.Fade,
   appear: true,
@@ -51,10 +51,9 @@ function Fade(props) {
     children,
     innerRef = ref,
     ...otherProps
-  } = addDefaultProps(defaultProps, props);
+  } = addDefaultProps(fadeDefaultProps, props);
 
-  const transitionProps = pick(
-    { defaultProps, ...otherProps },
+  const transitionProps = pick(otherProps,
     TransitionPropTypeKeys,
   );
 

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Portal from './Portal';
-import Fade from './Fade';
+import Fade, {fadeDefaultProps} from './Fade';
 import {
   getOriginalBodyPadding,
   conditionallyUpdateScrollbar,
@@ -505,13 +505,13 @@ class Modal extends React.Component {
 
       const hasTransition = this.props.fade;
       const modalTransition = {
-        ...Fade.defaultProps,
+        ...fadeDefaultProps,
         ...this.props.modalTransition,
         baseClass: hasTransition ? this.props.modalTransition.baseClass : '',
         timeout: hasTransition ? this.props.modalTransition.timeout : 0,
       };
       const backdropTransition = {
-        ...Fade.defaultProps,
+        ...fadeDefaultProps,
         ...this.props.backdropTransition,
         baseClass: hasTransition ? this.props.backdropTransition.baseClass : '',
         timeout: hasTransition ? this.props.backdropTransition.timeout : 0,

--- a/src/Offcanvas.js
+++ b/src/Offcanvas.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Portal from './Portal';
-import Fade from './Fade';
+import Fade, {fadeDefaultProps} from './Fade';
 import {
   TransitionTimeouts,
   conditionallyUpdateScrollbar,
@@ -393,7 +393,7 @@ class Offcanvas extends React.Component {
 
       const hasTransition = this.props.fade;
       const offcanvasTransition = {
-        ...Fade.defaultProps,
+        ...fadeDefaultProps,
         ...this.props.offcanvasTransition,
         baseClass: hasTransition
           ? this.props.offcanvasTransition.baseClass
@@ -401,7 +401,7 @@ class Offcanvas extends React.Component {
         timeout: hasTransition ? this.props.offcanvasTransition.timeout : 0,
       };
       const backdropTransition = {
-        ...Fade.defaultProps,
+        ...fadeDefaultProps,
         ...this.props.backdropTransition,
         baseClass: hasTransition ? this.props.backdropTransition.baseClass : '',
         timeout: hasTransition ? this.props.backdropTransition.timeout : 0,

--- a/src/Popover.js
+++ b/src/Popover.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import classNames from 'classnames';
 import TooltipPopoverWrapper, { propTypes } from './TooltipPopoverWrapper';
+import {addDefaultProps} from "./utils";
 
 const defaultProps = {
   placement: 'right',
@@ -16,7 +17,7 @@ function Popover(props) {
 
   return (
     <TooltipPopoverWrapper
-      {...props}
+      {...addDefaultProps(defaultProps, props)}
       arrowClassName={arrowClasses}
       popperClassName={popperClasses}
       innerClassName={classes}
@@ -25,6 +26,5 @@ function Popover(props) {
 }
 
 Popover.propTypes = propTypes;
-Popover.defaultProps = defaultProps;
 
 export default Popover;

--- a/src/PopperContent.js
+++ b/src/PopperContent.js
@@ -10,7 +10,7 @@ import {
   DOMElement,
   tagPropType,
 } from './utils';
-import Fade from './Fade';
+import Fade, {fadeDefaultProps} from './Fade';
 
 function noop() {}
 
@@ -49,7 +49,7 @@ const defaultProps = {
   onClosed: noop,
   fade: true,
   transition: {
-    ...Fade.defaultProps,
+    ...fadeDefaultProps,
   },
 };
 
@@ -164,7 +164,7 @@ class PopperContent extends React.Component {
     const extendedModifiers = [...baseModifiers, ...modifiers];
 
     const popperTransition = {
-      ...Fade.defaultProps,
+      ...fadeDefaultProps,
       ...transition,
       baseClass: fade ? transition.baseClass : '',
       timeout: fade ? transition.timeout : 0,

--- a/src/Toast.js
+++ b/src/Toast.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { mapToCssModules, tagPropType } from './utils';
-import Fade from './Fade';
+import Fade, {fadeDefaultProps} from './Fade';
 
 const propTypes = {
   children: PropTypes.node,
@@ -27,7 +27,7 @@ function Toast(props) {
     isOpen = true,
     children,
     transition = {
-      ...Fade.defaultProps,
+      ...fadeDefaultProps,
       unmountOnExit: true,
     },
     fade = true,
@@ -38,7 +38,7 @@ function Toast(props) {
   const classes = mapToCssModules(classNames(className, 'toast'), cssModule);
 
   const toastTransition = {
-    ...Fade.defaultProps,
+    ...fadeDefaultProps,
     ...transition,
     baseClass: fade ? transition.baseClass : '',
     timeout: fade ? transition.timeout : 0,

--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import classNames from 'classnames';
 import TooltipPopoverWrapper, { propTypes } from './TooltipPopoverWrapper';
+import { addDefaultProps } from './utils';
 
 const defaultProps = {
   placement: 'top',
@@ -14,9 +15,11 @@ function Tooltip(props) {
   const popperClasses = classNames('tooltip', 'show', props.popperClassName);
   const classes = classNames('tooltip-inner', props.innerClassName);
 
+  const _props = addDefaultProps(defaultProps, props);
+
   return (
     <TooltipPopoverWrapper
-      {...props}
+      {..._props}
       arrowClassName={arrowClasses}
       popperClassName={popperClasses}
       innerClassName={classes}
@@ -25,6 +28,5 @@ function Tooltip(props) {
 }
 
 Tooltip.propTypes = propTypes;
-Tooltip.defaultProps = defaultProps;
 
 export default Tooltip;

--- a/src/__tests__/utils.spec.js
+++ b/src/__tests__/utils.spec.js
@@ -234,12 +234,14 @@ describe('Utils', () => {
   describe('isFunction', () => {
     it('should return `true` for functions', () => {
       function test() {}
+
       expect(Utils.isFunction(test)).toBe(true);
       expect(Utils.isFunction(Array.prototype.slice)).toBe(true);
     });
 
     it('should return `true` for async functions', () => {
       async function asyncFunc() {}
+
       expect(Utils.isFunction(asyncFunc)).toEqual(
         typeof asyncFunc === 'function',
       );
@@ -247,6 +249,7 @@ describe('Utils', () => {
 
     it('should return `true` for generator functions', () => {
       function* genFunc() {}
+
       expect(Utils.isFunction(genFunc)).toEqual(typeof genFunc === 'function');
     });
 
@@ -256,6 +259,7 @@ describe('Utils', () => {
           return arguments;
         }.apply(undefined, array);
       }
+
       expect(Utils.isFunction(toArgs([1, 2, 3]))).toBe(false);
       expect(Utils.isFunction([1, 2, 3])).toBe(false);
       expect(Utils.isFunction(true)).toBe(false);
@@ -306,6 +310,52 @@ describe('Utils', () => {
       expect(Utils.toNumber('-1.1')).toEqual(-1.1);
       expect(Utils.toNumber(0 / 0)).toEqual(NaN);
       expect(Utils.toNumber(0)).toEqual(0);
+    });
+  });
+
+  describe('addDefaultProps', () => {
+    it('should return an object', () => {
+      const defaultProps = {
+        a: 1,
+        b: 2,
+        c: 3,
+      };
+      const props = {
+        a: 4,
+        b: 5,
+      };
+      expect(Utils.addDefaultProps(defaultProps, props)).toEqual(
+        expect.any(Object),
+      );
+    });
+
+    it('should return an object with default props', () => {
+      const defaultProps = {
+        a: 1,
+        b: 2,
+        c: 3,
+        d: {
+          e: 4,
+          f: 5,
+        },
+      };
+      const props = {
+        a: 4,
+        b: 5,
+        d: {
+          e: 6,
+          f: 5,
+        },
+      };
+      expect(Utils.addDefaultProps(defaultProps, props)).toEqual({
+        a: 4,
+        b: 5,
+        c: 3,
+        d: {
+          e: 6,
+          f: 5,
+        },
+      });
     });
   });
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -264,8 +264,8 @@ export function toNumber(value) {
   return isBinary || /^0o[0-7]+$/i.test(value)
     ? parseInt(value.slice(2), isBinary ? 2 : 8)
     : /^[-+]0x[0-9a-f]+$/i.test(value)
-    ? NAN
-    : +value;
+      ? NAN
+      : +value;
 }
 
 export function isFunction(value) {
@@ -381,3 +381,23 @@ export const focusableElements = [
   'video[controls]',
   '[contenteditable]:not([contenteditable="false"])',
 ];
+
+export function addDefaultProps(defaultProps, props) {
+  if (!defaultProps || !props) return props;
+
+  let result = { ...props };
+
+  Object.keys(defaultProps).forEach((key) => {
+    if (result[key] === undefined) {
+      result[key] = defaultProps[key];
+    }
+    if (
+      Object.keys(defaultProps[key] || {}).length > 0 &&
+      typeof defaultProps[key] === 'object'
+    ) {
+      addDefaultProps(defaultProps[key], result);
+    }
+  });
+
+  return result;
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -391,12 +391,6 @@ export function addDefaultProps(defaultProps, props) {
     if (result[key] === undefined) {
       result[key] = defaultProps[key];
     }
-    if (
-      Object.keys(defaultProps[key] || {}).length > 0 &&
-      typeof defaultProps[key] === 'object'
-    ) {
-      addDefaultProps(defaultProps[key], result);
-    }
   });
 
   return result;


### PR DESCRIPTION
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->

- [ ] Bug fix <!-- (change which fixes an issue) -->
- [ ] New feature <!-- (change which adds functionality) -->
- [x] Chore <!-- (change which doesn't affect the usage of the package (such as documentation, build process, or project setup changes)) -->
- [ ] Breaking change <!-- (fix or feature that would cause existing functionality to change) -->
- [ ] There is an open issue which this change addresses
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [x] My commits follow the [Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] My change requires a change to [Typescript typings](./types/lib).
  - [ ] I have updated the typings accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- Put any other information you believe would be useful to know when reviewing this PR below -->

Fixes #2801 

This pull request is based on https://github.com/reactstrap/reactstrap/pull/2806 by @islam-kamel.

The defaultProps were removed from the 3 functional components Fade, Tooltip and Popover.

It does require a new method that actively checks the props for `undefined`. Most likely because propTypes adds props that are not passed-in. However, the new method only does a shallow comparison (since functional components only do a shallow compare).

<!---
If there is an issue this PR addresses, please make sure it is in the commit message per the Git Commit Guidelines above
**AND** put the issue number below, indicating that it closes or fixes the issue.
-->
