### PR TITLE
fix: prevent setopen to set undefined value for open

### DIFF
--- a/src/UncontrolledAccordion.js
+++ b/src/UncontrolledAccordion.js
@@ -27,7 +27,7 @@ function UncontrolledAccordion({ defaultOpen, stayOpen, ...props }) {
         setOpen([...open, id]);
       }
     } else if (open === id) {
-      setOpen(undefined);
+      setOpen('');
     } else {
       setOpen(id);
     }

--- a/stories/examples/Accordion/AccordionExample.js
+++ b/stories/examples/Accordion/AccordionExample.js
@@ -10,7 +10,7 @@ function Example(props) {
   const [open, setOpen] = useState('1');
   const toggle = (id) => {
     if (open === id) {
-      setOpen();
+      setOpen('');
     } else {
       setOpen(id);
     }

--- a/stories/examples/Accordion/AccordionFlushExample.js
+++ b/stories/examples/Accordion/AccordionFlushExample.js
@@ -10,7 +10,7 @@ function Example(props) {
   const [open, setOpen] = useState('');
   const toggle = (id) => {
     if (open === id) {
-      setOpen();
+      setOpen('');
     } else {
       setOpen(id);
     }


### PR DESCRIPTION
## Issue Description

**Problem:**
A component that uses an accordion component is experiencing a warning while executing the test cases in jest when toggled to a closed state. The `open` prop, defined as required, is being set to `undefined` during this process. This leads to test failures in components utilizing the Accordion due to the required prop violation.

**fix**
There is no issue in the accordion component the only concern is how we are using it, currently, the use defined in the example is violating the tests, fixing the `setOpen` to an empty string instead of undefined fix the issue. 


<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->

- [x] Bug fix <!-- (change which fixes an issue) -->
- [ ] New feature <!-- (change which adds functionality) -->
- [] Chore <!-- (change which doesn't affect the usage of the package (such as documentation, build process, or project setup changes)) -->
- [ ] Breaking change <!-- (fix or feature that would cause existing functionality to change) -->
- [ ] There is an open issue which this change addresses
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [x] My commits follow the [Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [ ] My change requires a change to [Typescript typings](./types/lib).
  - [ ] I have updated the typings accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- Put any other information you believe would be useful to know when reviewing this PR below -->

<!---
If there is an issue this PR addresses, please make sure it is in the commit message per the Git Commit Guidelines above
**AND** put the issue number below, indicating that it closes or fixes the issue.
-->
