### PR TITLE
fix: change default open state to empty string

### DIFF
--- a/src/UncontrolledAccordion.js
+++ b/src/UncontrolledAccordion.js
@@ -18,7 +18,7 @@ const propTypes = {
 };
 
 function UncontrolledAccordion({ defaultOpen, stayOpen, ...props }) {
-  const [open, setOpen] = useState(defaultOpen || (stayOpen ? [] : undefined));
+  const [open, setOpen] = useState(defaultOpen || (stayOpen ? [] : ''));
   const toggle = (id) => {
     if (stayOpen) {
       if (open.includes(id)) {


### PR DESCRIPTION
UncontrolledAccordion inherits the properties of the Accordion component. We are setting the `defaultOpen` prop in UncontrolledAccordion, This defaultOpen will then be used to set the open prop, if we do not put any values to defaultOpen it will initialize the open prop with an undefined value which breaks the test case of the component which uses the `UncontrolledAccordion`. because the open prop is marked as required and we have set it to undefined. 

<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->

- [x] Bug fix <!-- (change which fixes an issue) -->
- [ ] New feature <!-- (change which adds functionality) -->
- [ ] Chore <!-- (change which doesn't affect the usage of the package (such as documentation, build process, or project setup changes)) -->
- [ ] Breaking change <!-- (fix or feature that would cause existing functionality to change) -->
- [ ] There is an open issue which this change addresses
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [x] My commits follow the [Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [ ] My change requires a change to [Typescript typings](./types/lib).
  - [ ] I have updated the typings accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- Put any other information you believe would be useful to know when reviewing this PR below -->
This PR is related to https://github.com/reactstrap/reactstrap/pull/2814, The same issue was resolved in the previous PR but a minor change is required in uncontrolled accordion.
<!---
If there is an issue this PR addresses, please make sure it is in the commit message per the Git Commit Guidelines above
**AND** put the issue number below, indicating that it closes or fixes the issue.
-->
